### PR TITLE
make behavior consistent in adding compiler bindirs to Path

### DIFF
--- a/RedPandaIDE/compiler/executablerunner.cpp
+++ b/RedPandaIDE/compiler/executablerunner.cpp
@@ -108,7 +108,7 @@ void ExecutableRunner::run()
     }
     pathAdded.append(pSettings->dirs().appDir());
     if (!path.isEmpty()) {
-        path+= PATH_SEPARATOR + pathAdded.join(PATH_SEPARATOR);
+        path= pathAdded.join(PATH_SEPARATOR) + PATH_SEPARATOR + path;
     } else {
         path = pathAdded.join(PATH_SEPARATOR);
     }

--- a/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
+++ b/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
@@ -73,7 +73,7 @@ void OJProblemCasesRunner::runCase(int index,POJProblemCase problemCase)
     }
     pathAdded.append(pSettings->dirs().appDir());
     if (!path.isEmpty()) {
-        path+= PATH_SEPARATOR + pathAdded.join(PATH_SEPARATOR);
+        path= pathAdded.join(PATH_SEPARATOR) + PATH_SEPARATOR + path;
     } else {
         path = pathAdded.join(PATH_SEPARATOR);
     }


### PR DESCRIPTION
When running the compiled user program, current compiler's binary directories should be added to the beginning of the Path environment variable instead of the end, in order to avoid loading other user-installed versions of MinGW libraries (such as libstdc++). Otherwise, weird behaviors occur when the user has installed a lower version of libstdc++ and add it to system Path. And this only affects a subset of user programs that use library routines with their ABI changed. Moreover, RedPanda uses brand new GCC compiler, which increases the chance that the user has a incompatible version elsewhere (maybe in hidden locations such as an Anaconda installation). 

The above problem was discovered on a setup of my friend's environment  @coldbubbletea

Previously, in openShell of mainwindow.cpp the behavior has already been updated (selected compiler comes first), but in executablerunner.cpp and ojproblemcasesrunner.cpp, the behavior is different. I think they should be unified to the one in mainwindow.cpp, so I proposed this code change.