### PR TITLE
Disable Address Sanitizer on non-x86 64-bit Linux

### DIFF
--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -2735,23 +2735,13 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
         platformName = "32-bit";
     }
 
-    /* Clang’s document says ASan is supported on Windows.
-     * (https://clang.llvm.org/docs/AddressSanitizer.html)
-     * That’s true for 'compiler-rt' builds, but not true for 'libgcc' builds.
-     *
-     * Add "debug with Asan" for Windows Clang, anyway.
-     *
-     * TODO: Test on BSD family.
-     */
-#ifdef Q_OS_WIN
-    if (baseSet->compilerType() == CompilerType::Clang)
+    // Enable ASan compiler set if it is supported and gdb works with ASan.
+#ifdef Q_OS_LINUX
+    PCompilerSet debugAsanSet = addSet(baseSet);
+    debugAsanSet->setName(baseName + " " + platformName + " Debug with ASan");
+    debugAsanSet->setCompilerSetType(CompilerSetType::DEBUG);
+    setDebugOptions(debugAsanSet, true);
 #endif
-    {
-        PCompilerSet debugAsanSet = addSet(baseSet);
-        debugAsanSet->setName(baseName + " " + platformName + " Debug with ASan");
-        debugAsanSet->setCompilerSetType(CompilerSetType::DEBUG);
-        setDebugOptions(debugAsanSet, true);
-    }
 
     PCompilerSet debugSet = addSet(baseSet);
     debugSet->setName(baseName + " " + platformName + " Debug");

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -2735,6 +2735,12 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
         platformName = "32-bit";
     }
 
+
+    PCompilerSet debugSet = addSet(baseSet);
+    debugSet->setName(baseName + " " + platformName + " Debug");
+    debugSet->setCompilerSetType(CompilerSetType::DEBUG);
+    setDebugOptions(debugSet);
+
     // Enable ASan compiler set if it is supported and gdb works with ASan.
 #ifdef Q_OS_LINUX
     PCompilerSet debugAsanSet = addSet(baseSet);
@@ -2742,11 +2748,6 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
     debugAsanSet->setCompilerSetType(CompilerSetType::DEBUG);
     setDebugOptions(debugAsanSet, true);
 #endif
-
-    PCompilerSet debugSet = addSet(baseSet);
-    debugSet->setName(baseName + " " + platformName + " Debug");
-    debugSet->setCompilerSetType(CompilerSetType::DEBUG);
-    setDebugOptions(debugSet);
 
     baseSet->setName(baseName + " " + platformName + " Release");
     baseSet->setCompilerSetType(CompilerSetType::RELEASE);
@@ -2757,7 +2758,16 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
 //    baseSet->setCompilerSetType(CompilerSetType::CST_PROFILING);
 //    setProfileOptions(baseSet);
 
+#ifdef Q_OS_LINUX
+# if defined(__x86_64__) || __SIZEOF_POINTER__ == 4
+    mDefaultIndex = (int)mList.size() - 1; // x86-64 Linux or 32-bit Unix, default to "debug with ASan"
+# else
+    mDefaultIndex = (int)mList.size() - 2; // other Unix, where ASan can be very slow, default to "debug"
+# endif
+#else
     mDefaultIndex = (int)mList.size() - 1;
+#endif
+
     return true;
 
 }

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -2735,12 +2735,6 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
         platformName = "32-bit";
     }
 
-
-    PCompilerSet debugSet = addSet(baseSet);
-    debugSet->setName(baseName + " " + platformName + " Debug");
-    debugSet->setCompilerSetType(CompilerSetType::DEBUG);
-    setDebugOptions(debugSet);
-
     /* Clang’s document says ASan is supported on Windows.
      * (https://clang.llvm.org/docs/AddressSanitizer.html)
      * That’s true for 'compiler-rt' builds, but not true for 'libgcc' builds.
@@ -2758,6 +2752,11 @@ bool Settings::CompilerSets::addSets(const QString &folder, const QString& c_pro
         debugAsanSet->setCompilerSetType(CompilerSetType::DEBUG);
         setDebugOptions(debugAsanSet, true);
     }
+
+    PCompilerSet debugSet = addSet(baseSet);
+    debugSet->setName(baseName + " " + platformName + " Debug");
+    debugSet->setCompilerSetType(CompilerSetType::DEBUG);
+    setDebugOptions(debugSet);
 
     baseSet->setName(baseName + " " + platformName + " Release");
     baseSet->setCompilerSetType(CompilerSetType::RELEASE);

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -1253,7 +1253,6 @@ public:
         bool setCompileOption(const QString& key, const QString& value);
         void unsetCompileOption(const QString& key);
         void setCompileOptions(const QMap<QString, QString> options);
-        void setAddressSanitizerOptions();
 
         QString getCompileOptionValue(const QString& key);
 

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -1253,6 +1253,7 @@ public:
         bool setCompileOption(const QString& key, const QString& value);
         void unsetCompileOption(const QString& key);
         void setCompileOptions(const QMap<QString, QString> options);
+        void setAddressSanitizerOptions();
 
         QString getCompileOptionValue(const QString& key);
 


### PR DESCRIPTION
Programs enabling Address Sanitizer (ASan) would cost several seconds after `main` on non-x86 64-bit architectures. My test shows that a hello world program took ~3s on Ampere Altra (Cloud VM) and ~6s on AllWinner H6 (development board).

[File structure of LLVM’s implementation of ASan](https://github.com/llvm/llvm-project/tree/main/compiler-rt/lib/asan), which is also [GCC’s implementation](https://github.com/gcc-mirror/gcc/tree/master/libsanitizer/asan), shows that the runtime library `asan_rtl` optimization only applies to x86-64, and other arches share the general, unoptimized one. Since address space of 64-bit apps is extremely large, the sanitizing check may cost long time.

In this patch, some extra checks are added to determine whether enable ASan or not:
- always enable on x86-64 Linux (which has optimized runtime) or 32-bit Linux (address space of which is small),
- enable on ARM64 Linux if the compiler’s target is ARM32,
- disable on other arches.