### PR TITLE
Linux package: bundled terminal in AppImage and minor adjustment

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -31,7 +31,7 @@ apt install gcc g++ make gdb gdbserver
 ### 2. Install Qt 5 and Other Dependencies
 
 ```bash
-apt install qtbase5-dev qttools5-dev-tools libicu-dev libqt5svg5-dev git qterminal
+apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
 ```
 
 ### 3. Fetch Source Code

--- a/BUILD.md
+++ b/BUILD.md
@@ -65,30 +65,34 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
 
 ## AppImage
 
-1. Install dependency: cURL, Docker.
+1. Install dependency: Docker or Podman.
 
    Extra requirements for Windows host:
    - Docker uses WSL 2 based engine, or enable file sharing on the project folder (Settings > Resources > File sharing);
-   - PowerShell (previously “PowerShell Core”, not “Windows PowerShell”).
+   - PowerShell (Core) or Windows PowerShell.
 2. Prepare build environment. Linux host:
    ```bash
-   arch=x86_64 # or aarch64
-   curl -L -o packages/appimage/dockerfile-$arch/appimagetool-$arch.AppImage https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-$arch.AppImage
-   docker build -t redpanda-builder-$arch packages/appimage/dockerfile-$arch
+   ARCH=x86_64 # or aarch64
+   DOCKER=docker # or podman
+   $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
    Windows host:
    ```ps1
-   $arch = "x86_64" # or "aarch64" someday Docker is available on WoA
-   Invoke-WebRequest -OutFile packages/appimage/dockerfile-$arch/appimagetool-$arch.AppImage -Uri https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-$arch.AppImage
-   docker build -t redpanda-builder-$arch packages/appimage/dockerfile-$arch
+   $ARCH = "x86_64" # or "aarch64" someday Docker or Podman is available on WoA
+   $DOCKER = "docker" # or "podman"
+   & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
 3. Build AppImage. Linux host:
    ```bash
-   ./packages/appimage/build-x86_64.sh # or *-aarch64.sh
+   ARCH=x86_64
+   DOCKER=docker
+   $DOCKER run --rm -v $PWD:/build/RedPanda-CPP -e CARCH=$ARCH redpanda-builder-$ARCH /build/RedPanda-CPP/packages/appimage/01-in-docker.sh
    ```
    Windows host:
    ```ps1
-   ./packages/appimage/build-x86_64.ps1 # or *-aarch64.ps1 someday Docker is available on WoA
+   $ARCH = "x86_64"
+   $DOCKER = "docker"
+   & $DOCKER run --rm -v "$(Get-Location):/build/RedPanda-CPP" -e CARCH=$ARCH redpanda-builder-$ARCH /build/RedPanda-CPP/packages/appimage/01-in-docker.sh
    ```
 4. Run Red Panda C++.
    ```bash

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -34,7 +34,7 @@ apt install gcc g++ make gdb gdbserver
 ### 2.安装QT5和依赖包
 
 ```bash
-apt install qtbase5-dev qttools5-dev-tools libicu-dev libqt5svg5-dev git qterminal
+apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
 ```
 
 ### 3.下载源码

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -68,30 +68,34 @@ RedPandaIDE
 
 ## AppImage
 
-1. 安装依赖包：cURL、Docker。
+1. 安装依赖包：Docker 或 Podman。
 
    Windows 宿主的额外要求：
    - Docker 使用基于 WSL 2 的引擎，或者对此项目文件夹启用文件共享（Settings > Resources > File sharing）；
-   - PowerShell（曾用名 “PowerShell Core”，不是 “Windows PowerShell”）。
+   - PowerShell (Core) 或 Windows PowerShell。
 2. 准备构建环境。Linux 宿主：
    ```bash
-   arch=x86_64 # 或 aarch64
-   curl -L -o packages/appimage/dockerfile-$arch/appimagetool-$arch.AppImage https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-$arch.AppImage
-   docker build -t redpanda-builder-$arch packages/appimage/dockerfile-$arch
+   ARCH=x86_64 # 或 aarch64
+   DOCKER=docker # 或 podman
+   $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
    Windows 宿主：
    ```ps1
-   $arch = "x86_64" # 或 "aarch64"（如果将来 Docker 支持 WoA）
-   Invoke-WebRequest -OutFile packages/appimage/dockerfile-$arch/appimagetool-$arch.AppImage -Uri https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-$arch.AppImage
-   docker build -t redpanda-builder-$arch packages/appimage/dockerfile-$arch
+   $ARCH = "x86_64" # 或 "aarch64"（如果将来 Docker 或 Podman 支持 WoA）
+   $DOCKER = "docker" # 或 "podman"
+   & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
 3. 构建 AppImage。Linux 宿主：
    ```bash
-   ./packages/appimage/build-x86_64.sh # 或 *-aarch64.sh
+   ARCH=x86_64
+   DOCKER=docker
+   $DOCKER run --rm -v $PWD:/build/RedPanda-CPP -e CARCH=$ARCH redpanda-builder-$ARCH /build/RedPanda-CPP/packages/appimage/01-in-docker.sh
    ```
    Windows 宿主：
    ```ps1
-   ./packages/appimage/build-x86_64.ps1 # 或 *-aarch64.ps1（如果将来 Docker 支持 WoA）
+   $ARCH = "x86_64"
+   $DOCKER = "docker"
+   & $DOCKER run --rm -v "$(Get-Location):/build/RedPanda-CPP" -e CARCH=$ARCH redpanda-builder-$ARCH /build/RedPanda-CPP/packages/appimage/01-in-docker.sh
    ```
 4. 运行小熊猫 C++.
    ```bash

--- a/RedPandaIDE/compiler/compilermanager.cpp
+++ b/RedPandaIDE/compiler/compilermanager.cpp
@@ -288,7 +288,7 @@ void CompilerManager::run(
             newArguments = QString(" -e \"%1\" %2")
                 .arg(localizePath(escapeSpacesInString(filename))).arg(arguments);
         }
-        execRunner = new ExecutableRunner(pSettings->environment().terminalPath(),newArguments,workDir);
+        execRunner = new ExecutableRunner(pSettings->environment().terminalPathForExec(),newArguments,workDir);
         execRunner->setShareMemoryId(sharedMemoryId);
 #endif
         execRunner->setStartConsole(true);

--- a/RedPandaIDE/debugger.cpp
+++ b/RedPandaIDE/debugger.cpp
@@ -2788,7 +2788,7 @@ void DebugTarget::run()
     cmd= mGDBServer;
     arguments = QString(" localhost:%1 \"%2\" %3").arg(mPort).arg(mInferior,mArguments);
 #else
-    cmd= pSettings->environment().terminalPath();
+    cmd= pSettings->environment().terminalPathForExec();
     arguments = QString(" -e \"%1\" localhost:%2 \"%3\"").arg(mGDBServer).arg(mPort).arg(mInferior);
 #endif
     QString workingDir = QFileInfo(mInferior).path();

--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4490,7 +4490,7 @@ void MainWindow::onFilesViewOpenInTerminal()
 #ifdef Q_OS_WIN
         openShell(fileInfo.path(),"cmd.exe",getDefaultCompilerSetBinDirs());
 #else
-        openShell(fileInfo.path(),pSettings->environment().terminalPath(),getDefaultCompilerSetBinDirs());
+        openShell(fileInfo.path(),pSettings->environment().terminalPathForExec(),getDefaultCompilerSetBinDirs());
 #endif
     }
 }
@@ -6617,7 +6617,7 @@ void MainWindow::on_actionOpen_Terminal_triggered()
 #ifdef Q_OS_WIN
             openShell(info.path(),"cmd.exe",getBinDirsForCurrentEditor());
 #else
-            openShell(info.path(),pSettings->environment().terminalPath(),getBinDirsForCurrentEditor());
+            openShell(info.path(),pSettings->environment().terminalPathForExec(),getBinDirsForCurrentEditor());
 #endif
         }
     }
@@ -6960,7 +6960,7 @@ void MainWindow::on_actionProject_Open_In_Terminal_triggered()
 #ifdef Q_OS_WIN
     openShell(mProject->directory(),"cmd.exe",mProject->binDirs());
 #else
-    openShell(mProject->directory(),pSettings->environment().terminalPath(),mProject->binDirs());
+    openShell(mProject->directory(),pSettings->environment().terminalPathForExec(),mProject->binDirs());
 #endif
 }
 

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -569,6 +569,7 @@ public:
         void setIconSet(const QString &newIconSet);
 
         QString terminalPath() const;
+        QString terminalPathForExec() const;
         void setTerminalPath(const QString &terminalPath);
 
         QString AStylePath() const;

--- a/RedPandaIDE/utils.h
+++ b/RedPandaIDE/utils.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <QThread>
 #include <QProcessEnvironment>
+#define SI_NO_CONVERSION
 #include "SimpleIni.h"
 #include "qt_utils/utils.h"
 

--- a/packages/appimage/01-in-docker.sh
+++ b/packages/appimage/01-in-docker.sh
@@ -5,7 +5,7 @@ set -xe
 # build RedPanda C++
 mkdir -p /build/redpanda-build
 cd /build/redpanda-build
-qmake PREFIX='/usr' XDG_ADAPTIVE_ICON=ON QMAKE_RPATHDIR='/_PlaceHolder' /build/RedPanda-CPP/Red_Panda_CPP.pro
+qmake PREFIX='/usr' XDG_ADAPTIVE_ICON=ON /build/RedPanda-CPP/Red_Panda_CPP.pro
 make -j$(nproc)
 
 # install RedPanda C++ to AppDir
@@ -20,11 +20,6 @@ cp /build/RedPanda-CPP/platform/linux/redpandaide.png .DirIcon
 
 # copy dependency
 cp /usr/local/bin/alacritty usr/bin
-mkdir -p usr/lib
-cp /usr/lib64/libicu{data,i18n,uc}.so.?? usr/lib || cp /usr/lib/aarch64-linux-gnu/libicu{data,i18n,uc}.so.?? usr/lib
-patchelf --set-rpath '$ORIGIN' usr/lib/*.so*
-patchelf --set-rpath '$ORIGIN/../lib' usr/bin/RedPandaIDE
-patchelf --set-rpath '$ORIGIN/../../lib' usr/libexec/RedPandaCPP/*
 
 # create AppImage
 cd /build

--- a/packages/appimage/01-in-docker.sh
+++ b/packages/appimage/01-in-docker.sh
@@ -5,7 +5,7 @@ set -xe
 # build RedPanda C++
 mkdir -p /build/redpanda-build
 cd /build/redpanda-build
-/opt/qt5/bin/qmake PREFIX='/usr' XDG_ADAPTIVE_ICON=ON QMAKE_RPATHDIR='/_PlaceHolder' /build/RedPanda-CPP/Red_Panda_CPP.pro
+qmake PREFIX='/usr' XDG_ADAPTIVE_ICON=ON QMAKE_RPATHDIR='/_PlaceHolder' /build/RedPanda-CPP/Red_Panda_CPP.pro
 make -j$(nproc)
 
 # install RedPanda C++ to AppDir
@@ -19,8 +19,9 @@ ln -s usr/share/icons/hicolor/scalable/apps/redpandaide.svg redpandaide.svg
 cp /build/RedPanda-CPP/platform/linux/redpandaide.png .DirIcon
 
 # copy dependency
+cp /usr/local/bin/alacritty usr/bin
 mkdir -p usr/lib
-cp /usr/lib64/libicu{data,i18n,uc}.so.?? usr/lib
+cp /usr/lib64/libicu{data,i18n,uc}.so.?? usr/lib || cp /usr/lib/aarch64-linux-gnu/libicu{data,i18n,uc}.so.?? usr/lib
 patchelf --set-rpath '$ORIGIN' usr/lib/*.so*
 patchelf --set-rpath '$ORIGIN/../lib' usr/bin/RedPandaIDE
 patchelf --set-rpath '$ORIGIN/../../lib' usr/libexec/RedPandaCPP/*

--- a/packages/appimage/build-aarch64.ps1
+++ b/packages/appimage/build-aarch64.ps1
@@ -1,7 +1,0 @@
-#!/usr/bin/env pwsh
-
-Set-PSDebug -Trace 1
-
-$arch = "aarch64"
-
-docker run --rm -v "$(Get-Location):/build/RedPanda-CPP" -e CARCH=$arch redpanda-builder-$arch /build/RedPanda-CPP/packages/appimage/01-in-docker.sh

--- a/packages/appimage/build-aarch64.sh
+++ b/packages/appimage/build-aarch64.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -xe
-
-arch=aarch64
-
-docker run --rm -v $PWD:/build/RedPanda-CPP -e CARCH=$arch redpanda-builder-$arch /build/RedPanda-CPP/packages/appimage/01-in-docker.sh

--- a/packages/appimage/build-x86_64.ps1
+++ b/packages/appimage/build-x86_64.ps1
@@ -1,7 +1,0 @@
-#!/usr/bin/env pwsh
-
-Set-PSDebug -Trace 1
-
-$arch = "x86_64"
-
-docker run --rm -v "$(Get-Location):/build/RedPanda-CPP" -e CARCH=$arch redpanda-builder-$arch /build/RedPanda-CPP/packages/appimage/01-in-docker.sh

--- a/packages/appimage/build-x86_64.sh
+++ b/packages/appimage/build-x86_64.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -xe
-
-arch=x86_64
-
-docker run --rm -v $PWD:/build/RedPanda-CPP -e CARCH=$arch redpanda-builder-$arch /build/RedPanda-CPP/packages/appimage/01-in-docker.sh

--- a/packages/appimage/dockerfile-aarch64/Dockerfile
+++ b/packages/appimage/dockerfile-aarch64/Dockerfile
@@ -1,35 +1,61 @@
-FROM quay.io/pypa/manylinux_2_28_aarch64
+# RHEL would be the best choice, if EL 8 were released on time.
+# AppImageKit AArch64 requires Ubuntu 18.04 or later.
+FROM docker.io/arm64v8/ubuntu:18.04
 
-COPY appimagetool-aarch64.AppImage /usr/local/bin/appimagetool
-RUN chmod +x /usr/local/bin/appimagetool && \
-    sed -i 's|^mirrorlist=|#mirrorlist=|g ; s|^# baseurl=https://repo.almalinux.org/almalinux|baseurl=https://mirror.sjtu.edu.cn/almalinux|g' /etc/yum.repos.d/almalinux*.repo && \
-    dnf install -y epel-release && \
-    sed -i 's|^metalink=|#metalink=|g ; s|^#baseurl=https\?://download.fedoraproject.org/pub/epel/|baseurl=https://mirrors.ustc.edu.cn/epel/|g' /etc/yum.repos.d/epel*.repo && \
-    dnf install -y fontconfig-devel freetype-devel libXrender-devel libicu-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel patchelf xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel
+# System
+RUN sed -i 's|ports.ubuntu.com|mirrors.ustc.edu.cn|g' /etc/apt/sources.list && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt update && \
+    apt upgrade -y && \
+    apt install --no-install-recommends -y ca-certificates cargo curl cmake file gcc g++ make patchelf \
+        libatspi2.0-dev libdbus-1-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libicu-dev libxkbcommon-x11-dev
+
+# AppImageKit
+RUN curl -L -o /usr/local/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-aarch64.AppImage' && \
+    chmod +x /usr/local/bin/appimagetool
+
+# Qt 5
 RUN mkdir -p /build/qt5 && \
     cd /build/qt5 && \
-    curl -O 'https://mirrors.ustc.edu.cn/qtproject/official_releases/qt/5.15/5.15.7/submodules/qt{base,svg,tools}-everywhere-opensource-src-5.15.7.tar.xz' && \
-    tar xf qtbase-everywhere-opensource-src-5.15.7.tar.xz && \
-    cd qtbase-everywhere-src-5.15.7 && \
+    curl -O 'https://mirrors.ustc.edu.cn/qtproject/archive/qt/5.12/5.12.12/submodules/qt{base,svg,tools}-everywhere-src-5.12.12.tar.xz' && \
+    tar xf qtbase-everywhere-src-5.12.12.tar.xz && \
+    cd qtbase-everywhere-src-5.12.12 && \
     ./configure \
-        -prefix /opt/qt5 \
+        -prefix /usr/local \
         -opensource -confirm-license \
         -optimize-size -no-shared -static -platform linux-g++ -no-use-gold-linker \
-        -qt-zlib -qt-doubleconversion -qt-pcre -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -xcb -qt-sqlite \
+        -qt-zlib -qt-doubleconversion -no-iconv -icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
         -nomake examples -nomake tests -nomake tools && \
     make -j$(nproc) && \
     make install && \
+    # svg package
     cd /build/qt5 && \
-    tar xf qtsvg-everywhere-opensource-src-5.15.7.tar.xz && \
-    cd qtsvg-everywhere-src-5.15.7 && \
-    /opt/qt5/bin/qmake . && \
+    tar xf qtsvg-everywhere-src-5.12.12.tar.xz && \
+    cd qtsvg-everywhere-src-5.12.12 && \
+    qmake . && \
     make -j$(nproc) && \
     make install && \
+    # tools package
     cd /build/qt5 && \
-    tar xf qttools-everywhere-opensource-src-5.15.7.tar.xz && \
-    cd qttools-everywhere-src-5.15.7 && \
-    /opt/qt5/bin/qmake . && \
+    tar xf qttools-everywhere-src-5.12.12.tar.xz && \
+    cd qttools-everywhere-src-5.12.12 && \
+    qmake . && \
     make -j$(nproc) && \
     make install && \
+    # cleanup
     cd / && \
     rm -r /build/qt5
+
+# Alacritty
+RUN mkdir -p /build/alacritty && \
+    cd /build/alacritty && \
+    curl -L -o alacritty-0.11.0.tar.gz 'https://github.com/alacritty/alacritty/archive/refs/tags/v0.11.0.tar.gz' && \
+    tar xf alacritty-0.11.0.tar.gz && \
+    cd alacritty-0.11.0 && \
+    /bin/echo -e '[profile.relminsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
+    cargo build --profile relminsize && \
+    cp target/relminsize/alacritty /usr/local/bin && \
+    # cleanup
+    cd / && \
+    rm -r /build/alacritty && \
+    rm -r ~/.cargo/registry

--- a/packages/appimage/dockerfile-aarch64/Dockerfile
+++ b/packages/appimage/dockerfile-aarch64/Dockerfile
@@ -7,8 +7,8 @@ RUN sed -i 's|ports.ubuntu.com|mirrors.ustc.edu.cn|g' /etc/apt/sources.list && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt upgrade -y && \
-    apt install --no-install-recommends -y ca-certificates cargo curl cmake file gcc g++ make patchelf \
-        libatspi2.0-dev libdbus-1-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libicu-dev libxkbcommon-x11-dev
+    apt install --no-install-recommends -y ca-certificates cargo curl cmake file gcc g++ make \
+        libatspi2.0-dev libdbus-1-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libxkbcommon-x11-dev
 
 # AppImageKit
 RUN curl -L -o /usr/local/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-aarch64.AppImage' && \
@@ -24,7 +24,7 @@ RUN mkdir -p /build/qt5 && \
         -prefix /usr/local \
         -opensource -confirm-license \
         -optimize-size -no-shared -static -platform linux-g++ -no-use-gold-linker \
-        -qt-zlib -qt-doubleconversion -no-iconv -icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
+        -qt-zlib -qt-doubleconversion -iconv -no-icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
         -nomake examples -nomake tests -nomake tools && \
     make -j$(nproc) && \
     make install && \

--- a/packages/appimage/dockerfile-x86_64/Dockerfile
+++ b/packages/appimage/dockerfile-x86_64/Dockerfile
@@ -8,8 +8,8 @@ RUN sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/
     sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
     sed -i 's|^metalink=|#metalink=|g; s|^#baseurl=https\?://download.fedoraproject.org/pub/epel/|baseurl=https://mirrors.ustc.edu.cn/epel/|g' /etc/yum.repos.d/epel.repo && \
     yum upgrade -y && \
-    yum install -y cargo cmake3 file make patchelf which \
-        at-spi2-core-devel dbus-devel fontconfig-devel freetype-devel glib2-devel libXrender-devel libicu-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel mesa-libGL-devel xcb-util-devel \
+    yum install -y cargo cmake3 file make which \
+        at-spi2-core-devel dbus-devel fontconfig-devel freetype-devel glib2-devel libXrender-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel mesa-libGL-devel xcb-util-devel \
         devtoolset-7-gcc devtoolset-7-gcc-c++
 
 ARG DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-7/root
@@ -30,7 +30,7 @@ RUN mkdir -p /build/qt5 && \
         -prefix /usr/local \
         -opensource -confirm-license \
         -optimize-size -no-shared -static -platform linux-g++ -no-use-gold-linker \
-        -qt-zlib -qt-doubleconversion -no-iconv -icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
+        -qt-zlib -qt-doubleconversion -iconv -no-icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
         -nomake examples -nomake tests -nomake tools && \
     make -j$(nproc) && \
     make install && \

--- a/packages/appimage/dockerfile-x86_64/Dockerfile
+++ b/packages/appimage/dockerfile-x86_64/Dockerfile
@@ -1,34 +1,67 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+# RHEL devtoolset, which provides new version of GCC targetting old libgcc_s and libstdc++, is the key to compatibility.
+# AppImageKit x86-64 requires EL 7 or later.
+FROM docker.io/amd64/centos:7
 
-COPY appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
-RUN chmod +x /usr/local/bin/appimagetool && \
-    sed -i 's|^mirrorlist=|#mirrorlist=|g ; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-*.repo && \
-    sed -i 's|^metalink=|#metalink=|g ; s|^#baseurl=https\?://download.example/pub/epel/|baseurl=https://mirrors.ustc.edu.cn/epel/|g' /etc/yum.repos.d/epel.repo && \
-    yum install -y fontconfig-devel freetype-devel libXrender-devel libicu-devel libxcb-devel libxkbcommon-devel patchelf
+# System
+RUN sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-Base.repo && \
+    yum install -y centos-release-scl-rh epel-release && \
+    sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
+    sed -i 's|^metalink=|#metalink=|g; s|^#baseurl=https\?://download.fedoraproject.org/pub/epel/|baseurl=https://mirrors.ustc.edu.cn/epel/|g' /etc/yum.repos.d/epel.repo && \
+    yum upgrade -y && \
+    yum install -y cargo cmake3 file make patchelf which \
+        at-spi2-core-devel dbus-devel fontconfig-devel freetype-devel glib2-devel libXrender-devel libicu-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel mesa-libGL-devel xcb-util-devel \
+        devtoolset-7-gcc devtoolset-7-gcc-c++
+
+ARG DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-7/root
+ENV PATH=${DEVTOOLSET_ROOTPATH}/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=${DEVTOOLSET_ROOTPATH}/usr/lib64
+
+# AppImageKit
+RUN curl -L -o /usr/local/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage' && \
+    chmod +x /usr/local/bin/appimagetool
+
+# Qt 5
 RUN mkdir -p /build/qt5 && \
     cd /build/qt5 && \
     curl -O 'https://mirrors.ustc.edu.cn/qtproject/archive/qt/5.12/5.12.12/submodules/qt{base,svg,tools}-everywhere-src-5.12.12.tar.xz' && \
     tar xf qtbase-everywhere-src-5.12.12.tar.xz && \
     cd qtbase-everywhere-src-5.12.12 && \
     ./configure \
-        -prefix /opt/qt5 \
+        -prefix /usr/local \
         -opensource -confirm-license \
         -optimize-size -no-shared -static -platform linux-g++ -no-use-gold-linker \
-        -qt-zlib -qt-doubleconversion -qt-pcre -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
+        -qt-zlib -qt-doubleconversion -no-iconv -icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
         -nomake examples -nomake tests -nomake tools && \
     make -j$(nproc) && \
     make install && \
+    # svg package
     cd /build/qt5 && \
     tar xf qtsvg-everywhere-src-5.12.12.tar.xz && \
     cd qtsvg-everywhere-src-5.12.12 && \
-    /opt/qt5/bin/qmake . && \
+    qmake . && \
     make -j$(nproc) && \
     make install && \
+    # tools package
     cd /build/qt5 && \
     tar xf qttools-everywhere-src-5.12.12.tar.xz && \
     cd qttools-everywhere-src-5.12.12 && \
-    /opt/qt5/bin/qmake . && \
+    qmake . && \
     make -j$(nproc) && \
     make install && \
+    # cleanup
     cd / && \
     rm -r /build/qt5
+
+# Alacritty
+RUN mkdir -p /build/alacritty && \
+    cd /build/alacritty && \
+    curl -L -o alacritty-0.11.0.tar.gz 'https://github.com/alacritty/alacritty/archive/refs/tags/v0.11.0.tar.gz' && \
+    tar xf alacritty-0.11.0.tar.gz && \
+    cd alacritty-0.11.0 && \
+    echo -e '[profile.relminsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
+    cargo build --profile relminsize && \
+    cp target/relminsize/alacritty /usr/local/bin && \
+    # cleanup
+    cd / && \
+    rm -r /build/alacritty && \
+    rm -r ~/.cargo/registry

--- a/packages/archlinux/PKGBUILD
+++ b/packages/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 _pkgname=RedPanda-CPP
 pkgname=${_pkgname,,}-git
-pkgver=2.7.r10.g0caaad84
+pkgver=2.12.r1.g57c4c5bc
 pkgrel=1
 pkgdesc='A fast, lightweight, open source, and cross platform C++ IDE (development version)'
 arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
@@ -9,10 +9,16 @@ license=('GPL3')
 depends=(qt5-base qt5-svg gcc gdb)
 makedepends=(git qt5-tools)
 optdepends=(
-    'clang: alternate C/C++ compiler'
-    'qterminal: run in terminal'
-    'konsole: run in terminal (alternate)'
+    'clang: C/C++ compiler (alternative)'
     'git: git integration'
+    'alacritty: run in terminal'
+    'kitty: run in terminal'
+    'tilix: run in terminal'
+    'cool-retro-term: run in terminal'
+    'konsole: run in terminal'
+    'deepin-terminal: run in terminal'
+    'qterminal: run in terminal'
+    'lxterminal: run in terminal'
 )
 conflicts=("${_pkgname,,}")
 provides=("${_pkgname,,}")

--- a/packages/debian/control
+++ b/packages/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper (>= 12~),
 	       qtbase5-dev,
                qtbase5-dev-tools,
 	       qttools5-dev-tools,
-               libicu-dev,
                libqt5svg5-dev
 Standards-Version: 4.3.0
 Homepage: https://github.com/royqh1979/RedPanda-CPP


### PR DESCRIPTION
* Migrate AppImage build environment from Python’s “manylinux” to upstream distro.
  * AArch64 build has less external dependencies by using Qt 5.12 (which is incompatible with manylinux_2_28) instead of Qt 5.15.
* Bundle [Alacritty terminal](https://github.com/alacritty/alacritty) in AppImage package.
* Fix terminal determination logic, and adapt it to AppImage change.
  * Breaking change: customized terminal path like `qterminal` (search in PATH) or `./qterminal` (relative to cwd) was directly passed to `exec`, while now treated as relative path to `RedPandaIDE`.
  * Add more compatible terminals to the lookup list. Almost all terminals listed in [Arch Wiki](https://wiki.archlinux.org/title/List_of_applications/Utilities#Terminal_emulators) was tested.
* Remove build dependency of libicu.
  * It is a dependency of SimpleIni’s wide character API, which is not actually used in Red Panda C++.