### PR TITLE
fix: macos icon size overgrown

### DIFF
--- a/RedPandaIDE/main.cpp
+++ b/RedPandaIDE/main.cpp
@@ -252,6 +252,10 @@ int main(int argc, char *argv[])
 //    qputenv("QT_AUTO_SCREEN_SCALE_FACTOR","false");
 //#endif
     QApplication app(argc, argv);
+#ifdef Q_OS_MACOS
+    // Fix macOS overgrown icon size issue
+    app.setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     QFile tempFile(QDir::tempPath()+QDir::separator()+"RedPandaDevCppStartUp.lock");
     {
         bool firstRun;


### PR DESCRIPTION
MacOS uses high DPI pixmaps with devicePixelRatio equals 2. Setting a flag in QApplication can enforce this in pixmaps fetched from QIcons and thus make the icons look high DPI.

Before: 
<img width="851" alt="图片" src="https://user-images.githubusercontent.com/49363666/224388998-63ff10dd-e7ca-4a95-a1fd-2c4303a043ee.png">

After: 
<img width="851" alt="图片" src="https://user-images.githubusercontent.com/49363666/224388893-f170d25d-d066-4178-9719-b2bf10383fb5.png">
