### PR TITLE
Update systemconsts.h for MacOS

### DIFF
--- a/RedPandaIDE/systemconsts.h
+++ b/RedPandaIDE/systemconsts.h
@@ -56,6 +56,7 @@
 #define LLDB_MI_PROGRAM   "lldb-mi"
 #define LLDB_SERVER_PROGRAM   "lldb-server"
 #elif defined(Q_OS_MACOS)
+#define CONSOLE_PAUSER  "consolepauser"
 #define ASSEMBLER   "nasm"
 #define GCC_PROGRAM     "gcc"
 #define GPP_PROGRAM     "g++"


### PR DESCRIPTION
by RigoLigo, 不过他似乎一直没时间提交, 我就代为提交一下吧...mac的定义中缺少一个consolepauser的常量定义