### PR TITLE
Linux package: fix AppImage emulated native build and add RISC-V support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,18 @@
-##########################
-# AppImage on Windows host
-##########################
+##################################
+# Linux packageing on Windows host
+##################################
 
 # script run in docker
 /packages/appimage/01-in-docker.sh eol=lf
+/packages/debian/01-in-docker.sh eol=lf
+/packages/debian/rules eol=lf
 
 # text files to be packed
 /packages/appimage/AppRun.sh eol=lf
+/packages/debian/changelog eol=lf
+/packages/debian/compat eol=lf
+/packages/debian/control eol=lf
+/packages/debian/copyright eol=lf
 /platform/linux/install.sh eol=lf
 /platform/linux/redpandaide.desktop.in eol=lf
 /platform/linux/redpandaide.svg eol=lf

--- a/BUILD.md
+++ b/BUILD.md
@@ -22,40 +22,83 @@ qmake variables:
 - `XDG_ADAPTIVE_ICON=ON`: install the icon file following [freedesktop.org Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) for adaptiveness to themes and sizes. Required by AppImage; recommended for Linux packaging if `PREFIX` set to `/usr`.
 - `LINUX_STATIC_IME_PLUGIN=ON` (make phase): link to static ime plugin. Recommended for building with static version of Qt; **DO NOT** set for dynamic version of Qt.
 
-## Ubuntu
+## Debian and Its Derivatives
 
-### 1. Install Compiler
+### “deb” Package for Current OS
 
-```bash
-apt install gcc g++ make gdb gdbserver
-```
+1. Install dependency:
+   ```bash
+   sudo apt install \
+     build-essential debhelper \
+     libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
+   ```
+2. Build the package:
+   ```bash
+   ./packages/debian/builddeb.sh
+   ```
+3. Install the package:
+   ```bash
+   sudo apt install /tmp/redpanda-cpp_*.deb
+   ```
+4. Run Red Panda C++:
+   ```bash
+   RedPandaIDE
+   ```
 
-### 2. Install Qt 5 and Other Dependencies
+### Build Packages for Multiple Architectures and Versions in Containers
 
-```bash
-apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
-```
+Extra requirements for Windows host:
+- Docker uses WSL 2 based engine, or enable file sharing on the project folder (Settings > Resources > File sharing);
+- PowerShell (Core) or Windows PowerShell.
 
-### 3. Fetch Source Code
+* Linux host:
+  ```bash
+  DOCKER=docker # or podman
+  SOURCE_DIR=/build/RedPanda-CPP # source directory *in container*
 
-```bash
-git clone https://github.com/royqh1979/RedPanda-CPP.git
-```
+  MIRROR=mirrors.kernel.org # leave empty for default mirror
+  PLATFORM=linux/amd64 # or linux/386, linux/arm64/v8, linux/arm/v7, linux/riscv64
+  IMAGE=debian:12 # or Ubuntu (e.g. ubuntu:22.04)
 
-### 4. Build
+  $DOCKER run --rm -e MIRROR=$MIRROR -e SOURCE_DIR=$SOURCE_DIR -v $PWD:$SOURCE_DIR --platform $PLATFORM $IMAGE $SOURCE_DIR/packages/debian/01-in-docker.sh
+  ```
+* Windows host:
+  ```ps1
+  $DOCKER = "docker" # or "podman"
+  $SOURCE_DIR = "/build/RedPanda-CPP" # source directory *in container*
 
-```bash
-cd RedPanda-CPP/
-qmake Red_Panda_CPP.pro
-make -j$(nproc)
-sudo make install
-```
+  $MIRROR = "mirrors.kernel.org" # leave empty for default mirror
+  $PLATFORM = "linux/amd64" # or "linux/386", "linux/arm64/v8", "linux/arm/v7", "linux/riscv64"
+  $IMAGE = "debian:12" # or Ubuntu (e.g. "ubuntu:22.04")
 
-### 5. Run
+  & $DOCKER run --rm -e MIRROR=$MIRROR -e SOURCE_DIR=$SOURCE_DIR -v "$(Get-Location):$SOURCE_DIR" --platform $PLATFORM $IMAGE $SOURCE_DIR/packages/debian/01-in-docker.sh
+  ```
 
-```bash
-RedPandaIDE
-```
+### Manual Install
+
+1. Install compiler
+   ```bash
+   apt install gcc g++ make gdb gdbserver
+   ```
+2. Install Qt 5 and other dependencies
+   ```bash
+   apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
+   ```
+3. Fetch source code
+   ```bash
+   git clone https://github.com/royqh1979/RedPanda-CPP.git
+   ```
+4. Build
+   ```bash
+   cd RedPanda-CPP/
+   qmake Red_Panda_CPP.pro
+   make -j$(nproc)
+   sudo make install
+   ```
+5. Run
+   ```bash
+   RedPandaIDE
+   ```
 
 ## Arch Linux
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -80,7 +80,7 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
    ```
    Windows host:
    ```ps1
-   $ARCH = "x86_64" # or "aarch64" someday Docker or Podman is available on WoA
+   $ARCH = "x86_64" # or "aarch64"
    $DOCKER = "docker" # or "podman"
    & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
@@ -101,4 +101,20 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
    ./dist/RedPandaIDE-x86_64.AppImage # or *-aarch64.AppImage
    ```
 
-Note: AppImage, in which format AppImageKit is shipped, is incompatable with QEMU user space emulator, so you cannot build AArch64 AppImage on x86-64, and vice versa.
+## Emulated Native Build for Foreign Architectures
+
+It is possible to build Red Panda C++ for foreign architectures using targets’ native toolchains with QEMU user space emulation.
+
+Note: Always run emulated native build **in containers**. Mixing architectures may kill your system.
+
+For Linux host, install statically linked QEMU user space emulator (package name is likely `qemu-user-static`) and make sure that binfmt support is enabled.
+
+For Windows host, Docker and Podman should have QEMU user space emulation enabled. If not,
+* For Docker:
+  ```ps1
+  docker run --rm --privileged multiarch/qemu-user-static:register
+  ```
+* For Podman, whose virtual machine is based on Fedora WSL, simply enable binfmt support:
+  ```ps1
+  wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
+  ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -74,13 +74,13 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
    - PowerShell (Core) or Windows PowerShell.
 2. Prepare build environment. Linux host:
    ```bash
-   ARCH=x86_64 # or aarch64
+   ARCH=x86_64 # or aarch64, riscv64
    DOCKER=docker # or podman
    $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
    Windows host:
    ```ps1
-   $ARCH = "x86_64" # or "aarch64"
+   $ARCH = "x86_64" # or "aarch64", "riscv64"
    $DOCKER = "docker" # or "podman"
    & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
@@ -98,7 +98,7 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
    ```
 4. Run Red Panda C++.
    ```bash
-   ./dist/RedPandaIDE-x86_64.AppImage # or *-aarch64.AppImage
+   ./dist/RedPandaIDE-x86_64.AppImage # or *-aarch64.AppImage, *-riscv64.AppImage
    ```
 
 ## Emulated Native Build for Foreign Architectures
@@ -117,4 +117,5 @@ For Windows host, Docker and Podman should have QEMU user space emulation enable
 * For Podman, whose virtual machine is based on Fedora WSL, simply enable binfmt support:
   ```ps1
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
+  wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-riscv64-static.conf /proc/sys/fs/binfmt_misc/register
   ```

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -83,7 +83,7 @@ RedPandaIDE
    ```
    Windows 宿主：
    ```ps1
-   $ARCH = "x86_64" # 或 "aarch64"（如果将来 Docker 或 Podman 支持 WoA）
+   $ARCH = "x86_64" # 或 "aarch64"
    $DOCKER = "docker" # 或 "podman"
    & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
@@ -104,4 +104,20 @@ RedPandaIDE
    ./dist/RedPandaIDE-x86_64.AppImage # 或 *-aarch64.AppImage
    ```
 
-注意：AppImage 与 QEMU 用户态模拟不兼容，使用此格式的 AppImageKit 工具自然不能用 QEMU 用户态模拟来运行。因此不能在 x86-64 系统上构建 AArch64 AppImage，反之亦然。
+## 异架构的模拟本机构建（emulated native build）
+
+可以借助 QEMU 用户空间模拟，运行目标架构的本机工具链，来构建小熊猫 C++。
+
+注意：始终**在容器中**运行模拟本机构建，因为混用不同架构的程序和库可能会损坏系统。
+
+对于 Linux 宿主，需要安装静态链接的 QEMU 用户空间模拟器（包名通常为 `qemu-user-static`）并确认已经启用 binfmt 支持。
+
+对于 Windows 宿主，Docker 和 Podman 应该已经启用了 QEMU 用户空间模拟。如果没有启用，
+* Docker：
+  ```ps1
+  docker run --rm --privileged multiarch/qemu-user-static:register
+  ```
+* Podman（其虚拟机基于 Fedora WSL）只需要启用 binfmt 支持：
+  ```ps1
+  wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
+  ```

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -25,40 +25,83 @@ qmake 变量:
 - `XDG_ADAPTIVE_ICON=ON`：遵循 [freedesktop.org 图标主题规范](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html)安装图标，以适应不同的主题和尺寸。AppImage 需要启用此项；Linux 打包 `PREFIX=/usr` 时推荐启用此项。
 - `LINUX_STATIC_IME_PLUGIN=ON`（make 阶段）：静态链接输入法插件。推荐在使用静态版本的 Qt 编译时启用；**不要**在使用动态版本的 Qt 编译时启用。
 
-## Ubuntu
+## Debian 及其衍生版本
 
-### 1.安装编译器
+### 适用于当前系统的 deb 包
 
-```bash
-apt install gcc g++ make gdb gdbserver
-```
+1. 安装依赖包：
+   ```bash
+   sudo apt install \
+     build-essential debhelper \
+     libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
+   ```
+2. 构建 deb 包：
+   ```bash
+   ./packages/debian/builddeb.sh
+   ```
+3. 安装 deb 包：
+   ```bash
+   sudo apt install /tmp/redpanda-cpp_*.deb
+   ```
+4. 运行小熊猫 C++：
+   ```bash
+   RedPandaIDE
+   ```
 
-### 2.安装QT5和依赖包
+### 在容器中构建适用于多架构/版本的包
 
-```bash
-apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
-```
+Windows 宿主的额外要求：
+- Docker 使用基于 WSL 2 的引擎，或者对此项目文件夹启用文件共享（Settings > Resources > File sharing）；
+- PowerShell (Core) 或 Windows PowerShell。
 
-### 3.下载源码
+* Linux 宿主：
+  ```bash
+  DOCKER=docker # 或 podman
+  SOURCE_DIR=/build/RedPanda-CPP # *容器内*的源代码路径
 
-```bash
-git clone https://gitee.com/royqh1979/RedPanda-CPP.git
-```
+  MIRROR=mirrors.ustc.edu.cn # 留空以使用默认的镜像站
+  PLATFORM=linux/amd64 # 或 linux/386、linux/arm64/v8、linux/arm/v7、linux/riscv64
+  IMAGE=debian:12 # 或 Ubuntu（如 ubuntu:22.04）
 
-### 4.编译
+  $DOCKER run --rm -e MIRROR=$MIRROR -e SOURCE_DIR=$SOURCE_DIR -v $PWD:$SOURCE_DIR --platform $PLATFORM $IMAGE $SOURCE_DIR/packages/debian/01-in-docker.sh
+  ```
+* Windows 宿主：
+  ```ps1
+  $DOCKER = "docker" # 或 "podman"
+  $SOURCE_DIR = "/build/RedPanda-CPP" # *容器内*的源代码路径
 
-```bash
-cd RedPanda-CPP/
-qmake Red_Panda_CPP.pro
-make -j$(nproc)
-sudo make install
-```
+  $MIRROR = "mirrors.ustc.edu.cn" # 留空以使用默认的镜像站
+  $PLATFORM = "linux/amd64" # 或 "linux/386"、"linux/arm64/v8"、"linux/arm/v7"、"linux/riscv64"
+  $IMAGE = "debian:12" # 或 Ubuntu（如 "ubuntu:22.04"）
 
-### 5.运行
+  & $DOCKER run --rm -e MIRROR=$MIRROR -e SOURCE_DIR=$SOURCE_DIR -v "$(Get-Location):$SOURCE_DIR" --platform $PLATFORM $IMAGE $SOURCE_DIR/packages/debian/01-in-docker.sh
+  ```
 
-```bash
-RedPandaIDE
-```
+### 手动安装
+
+1. 安装编译器
+   ```bash
+   apt install gcc g++ make gdb gdbserver
+   ```
+2. 安装 Qt 5 和依赖包
+   ```bash
+   apt install qtbase5-dev qttools5-dev-tools libqt5svg5-dev git qterminal
+   ```
+3. 下载源码
+   ```bash
+   git clone https://gitee.com/royqh1979/RedPanda-CPP.git
+   ```
+4. 编译
+   ```bash
+   cd RedPanda-CPP/
+   qmake Red_Panda_CPP.pro
+   make -j$(nproc)
+   sudo make install
+   ```
+5. 运行
+   ```bash
+   RedPandaIDE
+   ```
 
 ## Arch Linux 及衍生版本
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -77,13 +77,13 @@ RedPandaIDE
    - PowerShell (Core) 或 Windows PowerShell。
 2. 准备构建环境。Linux 宿主：
    ```bash
-   ARCH=x86_64 # 或 aarch64
+   ARCH=x86_64 # 或 aarch64、riscv64
    DOCKER=docker # 或 podman
    $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
    Windows 宿主：
    ```ps1
-   $ARCH = "x86_64" # 或 "aarch64"
+   $ARCH = "x86_64" # 或 "aarch64"、"riscv64"
    $DOCKER = "docker" # 或 "podman"
    & $DOCKER build -t redpanda-builder-$ARCH packages/appimage/dockerfile-$ARCH
    ```
@@ -101,7 +101,7 @@ RedPandaIDE
    ```
 4. 运行小熊猫 C++.
    ```bash
-   ./dist/RedPandaIDE-x86_64.AppImage # 或 *-aarch64.AppImage
+   ./dist/RedPandaIDE-x86_64.AppImage # 或 *-aarch64.AppImage、*-riscv64.AppImage
    ```
 
 ## 异架构的模拟本机构建（emulated native build）
@@ -120,4 +120,5 @@ RedPandaIDE
 * Podman（其虚拟机基于 Fedora WSL）只需要启用 binfmt 支持：
   ```ps1
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
+  wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-riscv64-static.conf /proc/sys/fs/binfmt_misc/register
   ```

--- a/packages/appimage/01-in-docker.sh
+++ b/packages/appimage/01-in-docker.sh
@@ -4,6 +4,8 @@ set -xe
 
 VERSION=$(sed -nr -e '/APP_VERSION\s*=/ s/APP_VERSION\s*=\s*(([0-9]+\.)*[0-9]+)\s*/\1/p' /build/RedPanda-CPP/Red_Panda_CPP.pro)
 APPIMAGE_FILE=RedPandaIDE-$VERSION-$CARCH.AppImage
+RUNTIME_FILE=/opt/appimage-runtime
+RUNTIME_SIZE=$(wc -c <$RUNTIME_FILE)
 
 # build RedPanda C++
 mkdir -p /build/redpanda-build
@@ -27,7 +29,9 @@ cp /usr/local/bin/alacritty usr/bin
 
 # create AppImage
 cd /build
-appimagetool --appimage-extract-and-run RedPandaIDE.AppDir $APPIMAGE_FILE
+mksquashfs RedPandaIDE.AppDir $APPIMAGE_FILE -offset $RUNTIME_SIZE -comp zstd -root-owned -noappend -b 1M -mkfs-time 0
+dd if=$RUNTIME_FILE of=$APPIMAGE_FILE conv=notrunc
+chmod +x $APPIMAGE_FILE
 
 # copy back to host
 mkdir -p /build/RedPanda-CPP/dist

--- a/packages/appimage/dockerfile-aarch64/Dockerfile
+++ b/packages/appimage/dockerfile-aarch64/Dockerfile
@@ -1,27 +1,58 @@
-# RHEL would be the best choice, if EL 8 were released on time.
-# AppImageKit AArch64 requires Ubuntu 18.04 or later.
-FROM docker.io/arm64v8/ubuntu:18.04
+# RHEL devtoolset, which provides new version of GCC targetting old libgcc_s and libstdc++, is the key to compatibility.
+# EL 7 is modern enough for apps and libs.
+# CentOS 7 aarch64 container image is a mess. Use Oracle instead.
+FROM docker.io/arm64v8/oraclelinux:7
 
 # System
-RUN sed -i 's|ports.ubuntu.com|mirrors.ustc.edu.cn|g' /etc/apt/sources.list && \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt update && \
-    apt upgrade -y && \
-    apt install --no-install-recommends -y ca-certificates cargo curl cmake extra-cmake-modules file gcc g++ make \
-        libatspi2.0-dev libdbus-1-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libxkbcommon-x11-dev
+RUN yum-config-manager --enable ol7_optional_latest && \
+    yum install -y oracle-softwarecollection-release-el7 oracle-epel-release-el7 && \
+    yum upgrade -y && \
+    yum install -y \
+        # general devtools
+        devtoolset-7-gcc devtoolset-7-gcc-c++ make \
+        # squashfs-tools libs
+        libzstd-devel \
+        # Qt build tools
+        file which \
+        # Qt libs
+        at-spi2-core-devel dbus-devel fontconfig-devel freetype-devel glib2-devel libXrender-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel mesa-libGL-devel xcb-util-devel \
+        # fcitx5-qt build tools
+        cmake3 extra-cmake-modules && \
+    yum clean all
 
-# AppImageKit
-RUN curl -L -o /usr/local/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-aarch64.AppImage' && \
-    chmod +x /usr/local/bin/appimagetool
+ARG DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-7/root
+ENV PATH=${DEVTOOLSET_ROOTPATH}/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=${DEVTOOLSET_ROOTPATH}/usr/lib64
+
+ARG SQUASHFS_TOOLS_VERSION=4.4
+ARG QT_MAJOR_MINOR=5.12
+ARG QT_PATCH=12
+ARG QT_VERSION=${QT_MAJOR_MINOR}.${QT_PATCH}
+ARG FCITX5_QT_VERSION=5.0.17
+ARG ALACRITTY_VERSION=0.12.2
+
+# AppImage runtime
+RUN curl -L -o /opt/appimage-runtime 'https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-aarch64'
+
+# squashfs-tools
+RUN mkdir -p /build/squashfs-tools && \
+    cd /build/squashfs-tools && \
+    curl -L -o squashfs-tools-${SQUASHFS_TOOLS_VERSION}.tar.gz "https://github.com/plougher/squashfs-tools/archive/refs/tags/${SQUASHFS_TOOLS_VERSION}.tar.gz" && \
+    tar xf squashfs-tools-${SQUASHFS_TOOLS_VERSION}.tar.gz && \
+    cd squashfs-tools-${SQUASHFS_TOOLS_VERSION}/squashfs-tools && \
+    make ZSTD_SUPPORT=1 -j$(nproc) && \
+    make install && \
+    # cleanup
+    cd / && \
+    rm -r /build/squashfs-tools
 
 # Qt 5
 RUN mkdir -p /build/qt5 && \
     cd /build/qt5 && \
-    curl -O 'https://download.qt.io/archive/qt/5.12/5.12.12/submodules/qt{base,svg,tools}-everywhere-src-5.12.12.tar.xz' && \
-    # fcitx5-qt 5.0.6 is the last version compatible with ubuntu 18.04’s cmake 3.10
-    curl -L -o fcitx5-qt-5.0.6.tar.gz 'https://github.com/fcitx/fcitx5-qt/archive/refs/tags/5.0.6.tar.gz' && \
-    tar xf qtbase-everywhere-src-5.12.12.tar.xz && \
-    cd qtbase-everywhere-src-5.12.12 && \
+    curl -O "https://download.qt.io/archive/qt/${QT_MAJOR_MINOR}/${QT_VERSION}/submodules/qt{base,svg,tools}-everywhere-src-${QT_VERSION}.tar.xz" && \
+    curl -L -o fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz "https://github.com/fcitx/fcitx5-qt/archive/refs/tags/${FCITX5_QT_VERSION}.tar.gz" && \
+    tar xf qtbase-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtbase-everywhere-src-${QT_VERSION} && \
     ./configure \
         -prefix /usr/local \
         -opensource -confirm-license \
@@ -32,40 +63,42 @@ RUN mkdir -p /build/qt5 && \
     make install && \
     # svg package
     cd /build/qt5 && \
-    tar xf qtsvg-everywhere-src-5.12.12.tar.xz && \
-    cd qtsvg-everywhere-src-5.12.12 && \
+    tar xf qtsvg-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtsvg-everywhere-src-${QT_VERSION} && \
     qmake . && \
     make -j$(nproc) && \
     make install && \
     # tools package
     cd /build/qt5 && \
-    tar xf qttools-everywhere-src-5.12.12.tar.xz && \
-    cd qttools-everywhere-src-5.12.12 && \
+    tar xf qttools-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qttools-everywhere-src-${QT_VERSION} && \
     qmake . && \
     make -j$(nproc) && \
     make install && \
     # fcitx5 package
     cd /build/qt5 && \
-    tar xf fcitx5-qt-5.0.6.tar.gz && \
-    cd fcitx5-qt-5.0.6 && \
-    cmake . -Bbuild -DCMAKE_MODULE_PATH=/usr/local/lib/cmake -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_BUILD_TYPE=Release -DENABLE_QT4=Off -DENABLE_QT5=On -DENABLE_QT6=Off -DBUILD_ONLY_PLUGIN=On -DBUILD_STATIC_PLUGIN=On && \
-    # cmake 3.10 is too old to build with `--parallel` option
-    cmake --build build -- -j$(nproc) && \
-    cmake --install build && \
+    tar xf fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz && \
+    cd fcitx5-qt-${FCITX5_QT_VERSION} && \
+    cmake3 . -Bbuild -DCMAKE_MODULE_PATH=/usr/local/lib/cmake -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_BUILD_TYPE=Release -DENABLE_QT4=Off -DENABLE_QT5=On -DENABLE_QT6=Off -DBUILD_ONLY_PLUGIN=On -DBUILD_STATIC_PLUGIN=On && \
+    cmake3 --build build --parallel && \
+    # cmake 3.14 is too old to `--install`
+    cmake3 --build build -- install && \
     # cleanup
     cd / && \
     rm -r /build/qt5
 
 # Alacritty
-RUN mkdir -p /build/alacritty && \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.71.1 && \
+    . ~/.cargo/env && \
+    mkdir -p /build/alacritty && \
     cd /build/alacritty && \
-    curl -L -o alacritty-0.11.0.tar.gz 'https://github.com/alacritty/alacritty/archive/refs/tags/v0.11.0.tar.gz' && \
-    tar xf alacritty-0.11.0.tar.gz && \
-    cd alacritty-0.11.0 && \
-    /bin/echo -e '[profile.relminsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
-    cargo build --profile relminsize && \
-    cp target/relminsize/alacritty /usr/local/bin && \
+    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
+    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
+    cd alacritty-${ALACRITTY_VERSION} && \
+    echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
+    cargo build --profile minsize && \
+    cp target/minsize/alacritty /usr/local/bin && \
     # cleanup
     cd / && \
     rm -r /build/alacritty && \
-    rm -r ~/.cargo/registry
+    rustup self uninstall -y

--- a/packages/appimage/dockerfile-riscv64/Dockerfile
+++ b/packages/appimage/dockerfile-riscv64/Dockerfile
@@ -1,0 +1,86 @@
+FROM docker.io/riscv64/ubuntu:20.04
+
+# System
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt update && \
+    apt upgrade -y && \
+    apt install --no-install-recommends -y \
+        # general utils
+        ca-certificates curl xz-utils \
+        # general devtools
+        gcc g++ make \
+        # Qt build tools
+        file \
+        # Qt libs
+        libatspi2.0-dev libdbus-1-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libxkbcommon-x11-dev \
+        # fcitx-qt5 build tools
+        cmake extra-cmake-modules \
+        # appimage tools
+        squashfs-tools && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG QT_MAJOR_MINOR=5.12
+ARG QT_PATCH=12
+ARG QT_VERSION=${QT_MAJOR_MINOR}.${QT_PATCH}
+ARG FCITX5_QT_VERSION=5.0.17
+ARG ALACRITTY_VERSION=0.12.2
+
+# AppImage runtime
+RUN curl -L -o /opt/appimage-runtime 'https://github.com/cyano-linux/appimage-riscv64/releases/download/20230808.0/runtime-riscv64'
+
+# Qt 5
+RUN mkdir -p /build/qt5 && \
+    cd /build/qt5 && \
+    curl -O "https://download.qt.io/archive/qt/${QT_MAJOR_MINOR}/${QT_VERSION}/submodules/qt{base,svg,tools}-everywhere-src-${QT_VERSION}.tar.xz" && \
+    curl -L -o fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz "https://github.com/fcitx/fcitx5-qt/archive/refs/tags/${FCITX5_QT_VERSION}.tar.gz" && \
+    tar xf qtbase-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtbase-everywhere-src-${QT_VERSION} && \
+    ./configure \
+        -prefix /usr/local \
+        -opensource -confirm-license \
+        -optimize-size -no-shared -static -platform linux-g++ -no-use-gold-linker \
+        -qt-zlib -qt-doubleconversion -iconv -no-icu -qt-pcre -no-openssl -system-freetype -fontconfig -qt-harfbuzz -qt-libjpeg -qt-libpng -qt-xcb -qt-sqlite \
+        -nomake examples -nomake tests -nomake tools && \
+    make -j$(nproc) && \
+    make install && \
+    # svg package
+    cd /build/qt5 && \
+    tar xf qtsvg-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtsvg-everywhere-src-${QT_VERSION} && \
+    qmake . && \
+    make -j$(nproc) && \
+    make install && \
+    # tools package
+    cd /build/qt5 && \
+    tar xf qttools-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qttools-everywhere-src-${QT_VERSION} && \
+    qmake . && \
+    make -j$(nproc) && \
+    make install && \
+    # fcitx5 package
+    cd /build/qt5 && \
+    tar xf fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz && \
+    cd fcitx5-qt-${FCITX5_QT_VERSION} && \
+    cmake . -Bbuild -DCMAKE_MODULE_PATH=/usr/local/lib/cmake -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_BUILD_TYPE=Release -DENABLE_QT4=Off -DENABLE_QT5=On -DENABLE_QT6=Off -DBUILD_ONLY_PLUGIN=On -DBUILD_STATIC_PLUGIN=On && \
+    cmake --build build --parallel && \
+    cmake --install build && \
+    # cleanup
+    cd / && \
+    rm -r /build/qt5
+
+# Alacritty
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.71.1 && \
+    . ~/.cargo/env && \
+    mkdir -p /build/alacritty && \
+    cd /build/alacritty && \
+    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
+    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
+    cd alacritty-${ALACRITTY_VERSION} && \
+    /bin/echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
+    cargo build --profile minsize && \
+    cp target/minsize/alacritty /usr/local/bin && \
+    # cleanup
+    cd / && \
+    rm -r /build/alacritty && \
+    rustup self uninstall -y

--- a/packages/appimage/dockerfile-x86_64/Dockerfile
+++ b/packages/appimage/dockerfile-x86_64/Dockerfile
@@ -1,32 +1,56 @@
 # RHEL devtoolset, which provides new version of GCC targetting old libgcc_s and libstdc++, is the key to compatibility.
-# AppImageKit x86-64 requires EL 7 or later.
+# EL 7 is modern enough for apps and libs.
 FROM docker.io/amd64/centos:7
 
 # System
-RUN sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-Base.repo && \
-    yum install -y centos-release-scl-rh epel-release && \
-    sed -i 's|^mirrorlist=|#mirrorlist=|g; s|^#baseurl=http://mirror.centos.org/centos|baseurl=https://mirrors.ustc.edu.cn/centos|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
-    sed -i 's|^metalink=|#metalink=|g; s|^#baseurl=https\?://download.fedoraproject.org/pub/epel/|baseurl=https://mirrors.ustc.edu.cn/epel/|g' /etc/yum.repos.d/epel.repo && \
+RUN yum install -y centos-release-scl-rh epel-release && \
     yum upgrade -y && \
-    yum install -y cargo cmake3 extra-cmake-modules file make which \
+    yum install -y \
+        # general devtools
+        devtoolset-7-gcc devtoolset-7-gcc-c++ make \
+        # squashfs-tools libs
+        libzstd-devel \
+        # Qt build tools
+        file which \
+        # Qt libs
         at-spi2-core-devel dbus-devel fontconfig-devel freetype-devel glib2-devel libXrender-devel libxcb-devel libxkbcommon-devel libxkbcommon-x11-devel mesa-libGL-devel xcb-util-devel \
-        devtoolset-7-gcc devtoolset-7-gcc-c++
+        # fcitx5-qt build tools
+        cmake3 extra-cmake-modules && \
+    yum clean all
 
 ARG DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-7/root
 ENV PATH=${DEVTOOLSET_ROOTPATH}/usr/bin:${PATH}
 ENV LD_LIBRARY_PATH=${DEVTOOLSET_ROOTPATH}/usr/lib64
 
-# AppImageKit
-RUN curl -L -o /usr/local/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage' && \
-    chmod +x /usr/local/bin/appimagetool
+ARG SQUASHFS_TOOLS_VERSION=4.4
+ARG QT_MAJOR_MINOR=5.12
+ARG QT_PATCH=12
+ARG QT_VERSION=${QT_MAJOR_MINOR}.${QT_PATCH}
+ARG FCITX5_QT_VERSION=5.0.17
+ARG ALACRITTY_VERSION=0.12.2
+
+# AppImage runtime
+RUN curl -L -o /opt/appimage-runtime 'https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64'
+
+# squashfs-tools
+RUN mkdir -p /build/squashfs-tools && \
+    cd /build/squashfs-tools && \
+    curl -L -o squashfs-tools-${SQUASHFS_TOOLS_VERSION}.tar.gz "https://github.com/plougher/squashfs-tools/archive/refs/tags/${SQUASHFS_TOOLS_VERSION}.tar.gz" && \
+    tar xf squashfs-tools-${SQUASHFS_TOOLS_VERSION}.tar.gz && \
+    cd squashfs-tools-${SQUASHFS_TOOLS_VERSION}/squashfs-tools && \
+    make ZSTD_SUPPORT=1 -j$(nproc) && \
+    make install && \
+    # cleanup
+    cd / && \
+    rm -r /build/squashfs-tools
 
 # Qt 5
 RUN mkdir -p /build/qt5 && \
     cd /build/qt5 && \
-    curl -O 'https://download.qt.io/archive/qt/5.12/5.12.12/submodules/qt{base,svg,tools}-everywhere-src-5.12.12.tar.xz' && \
-    curl -L -o fcitx5-qt-5.0.17.tar.gz 'https://github.com/fcitx/fcitx5-qt/archive/refs/tags/5.0.17.tar.gz' && \
-    tar xf qtbase-everywhere-src-5.12.12.tar.xz && \
-    cd qtbase-everywhere-src-5.12.12 && \
+    curl -O "https://download.qt.io/archive/qt/${QT_MAJOR_MINOR}/${QT_VERSION}/submodules/qt{base,svg,tools}-everywhere-src-${QT_VERSION}.tar.xz" && \
+    curl -L -o fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz "https://github.com/fcitx/fcitx5-qt/archive/refs/tags/${FCITX5_QT_VERSION}.tar.gz" && \
+    tar xf qtbase-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtbase-everywhere-src-${QT_VERSION} && \
     ./configure \
         -prefix /usr/local \
         -opensource -confirm-license \
@@ -37,22 +61,22 @@ RUN mkdir -p /build/qt5 && \
     make install && \
     # svg package
     cd /build/qt5 && \
-    tar xf qtsvg-everywhere-src-5.12.12.tar.xz && \
-    cd qtsvg-everywhere-src-5.12.12 && \
+    tar xf qtsvg-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qtsvg-everywhere-src-${QT_VERSION} && \
     qmake . && \
     make -j$(nproc) && \
     make install && \
     # tools package
     cd /build/qt5 && \
-    tar xf qttools-everywhere-src-5.12.12.tar.xz && \
-    cd qttools-everywhere-src-5.12.12 && \
+    tar xf qttools-everywhere-src-${QT_VERSION}.tar.xz && \
+    cd qttools-everywhere-src-${QT_VERSION} && \
     qmake . && \
     make -j$(nproc) && \
     make install && \
     # fcitx5 package
     cd /build/qt5 && \
-    tar xf fcitx5-qt-5.0.17.tar.gz && \
-    cd fcitx5-qt-5.0.17 && \
+    tar xf fcitx5-qt-${FCITX5_QT_VERSION}.tar.gz && \
+    cd fcitx5-qt-${FCITX5_QT_VERSION} && \
     cmake3 . -Bbuild -DCMAKE_MODULE_PATH=/usr/local/lib/cmake -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_BUILD_TYPE=Release -DENABLE_QT4=Off -DENABLE_QT5=On -DENABLE_QT6=Off -DBUILD_ONLY_PLUGIN=On -DBUILD_STATIC_PLUGIN=On && \
     cmake3 --build build --parallel && \
     cmake3 --install build && \
@@ -61,15 +85,18 @@ RUN mkdir -p /build/qt5 && \
     rm -r /build/qt5
 
 # Alacritty
-RUN mkdir -p /build/alacritty && \
+RUN yum install -y cargo && \
+    mkdir -p /build/alacritty && \
     cd /build/alacritty && \
-    curl -L -o alacritty-0.11.0.tar.gz 'https://github.com/alacritty/alacritty/archive/refs/tags/v0.11.0.tar.gz' && \
-    tar xf alacritty-0.11.0.tar.gz && \
-    cd alacritty-0.11.0 && \
-    echo -e '[profile.relminsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
-    cargo build --profile relminsize && \
-    cp target/relminsize/alacritty /usr/local/bin && \
+    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
+    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
+    cd alacritty-${ALACRITTY_VERSION} && \
+    echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
+    cargo build --profile minsize && \
+    cp target/minsize/alacritty /usr/local/bin && \
     # cleanup
     cd / && \
     rm -r /build/alacritty && \
-    rm -r ~/.cargo/registry
+    yum autoremove -y cargo && \
+    yum clean all && \
+    rm -r ~/.cargo

--- a/packages/archlinux/PKGBUILD
+++ b/packages/archlinux/PKGBUILD
@@ -1,9 +1,9 @@
 _pkgname=RedPanda-CPP
 pkgname=${_pkgname,,}-git
-pkgver=2.12.r1.g57c4c5bc
+pkgver=2.23.r14.gd1214e3d
 pkgrel=1
 pkgdesc='A fast, lightweight, open source, and cross platform C++ IDE (development version)'
-arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
+arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64' 'riscv64')
 url="https://github.com/royqh1979/$_pkgname"
 license=('GPL3')
 depends=(qt5-base qt5-svg gcc gdb)

--- a/packages/debian/01-in-docker.sh
+++ b/packages/debian/01-in-docker.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -xe
+
+TMP_FOLDER=/build/redpanda-build
+DISTRO_ID=$(grep ^ID= /etc/os-release | cut -d= -f2- | tr -d '"')
+VERSION_ID=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2- | tr -d '"')
+
+# install deps
+default_repositories=(
+  deb.debian.org
+  security.debian.org
+  archive.ubuntu.com
+  security.ubuntu.com
+  ports.ubuntu.com
+)
+
+if [[ -n $MIRROR ]]
+then
+  for repo in ${default_repositories[@]}
+  do
+    [[ -f /etc/apt/sources.list ]] && sed -i "s|$repo|$MIRROR|" /etc/apt/sources.list
+    for file in $(ls /etc/apt/sources.list.d/)
+    do
+      # okay for both *.list and *.sources (since Debian 12)
+      sed -i "s|$repo|$MIRROR|" /etc/apt/sources.list.d/$file
+    done
+  done
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt update
+apt install -y --no-install-recommends \
+  build-essential debhelper \
+  libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
+
+# prepare source
+mkdir -p $TMP_FOLDER
+
+cd $SOURCE_DIR
+cp -r packages/debian $TMP_FOLDER
+cp -r tools $TMP_FOLDER
+cp -r libs $TMP_FOLDER
+cp -r RedPandaIDE $TMP_FOLDER
+cp README.md $TMP_FOLDER
+cp LICENSE $TMP_FOLDER
+cp NEWS.md $TMP_FOLDER
+cp -r platform $TMP_FOLDER
+cp Red_Panda_CPP.pro $TMP_FOLDER
+
+# build
+cd $TMP_FOLDER
+dpkg-buildpackage -us -uc
+
+# copy back to host
+cd ..
+file=$(ls redpanda-cpp_*.deb)
+mkdir -p $SOURCE_DIR/dist
+cp $file $SOURCE_DIR/dist/${file/.deb/.$DISTRO_ID$VERSION_ID.deb}


### PR DESCRIPTION
(The purpose of _emulated native build_ is same as cross build, but the approach is slightly different -- emulated native build uses native toolchains with QEMU user space emulation, while cross build uses cross toolchains running natively on host.)

* Fix AppImage emulated native build by replacing `appimagetool.AppImage`, which is incompatible with QEMU user emulation, with `mksquashfs` and `dd`.
* Port AppImage to RISC-V (riscv64).
* Enable RISC-V in Arch Linux package.
* Add a convenient script to build “deb” packages in container for multiple Debian/Ubuntu architectures and versions.