### PR TITLE
Fix build failure for various Windows toolchains and update Windows build doc

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,12 +3,200 @@
  Red Panda C++ need Qt 5 (>=5.12) to build.
 
 # Windows
- I build Red Panda Cpp with the latest gcc and mingw-w64, distributed by msys2 mingw-w64. Visual C++  and other version of gcc may not work.
 
- - Install msys2 (https://www.msys2.org)
- - Use msys2's pacman to install mingw-w64-x86_64-qt5 and mingw-w64-x86_64-gcc
- - Install qtcreator
- - Use qtcreator to open Red_Panda_CPP.pro
+| Library + Toolchain \ Target | x86 | x64 | ARM64 |
+| ---------------------------- | --- | --- | ----- |
+| MSYS2 + GNU-based MinGW | ✔️ | ✔️ | ❌ |
+| MSYS2 + LLVM-based MinGW | ✔️ | ✔️ | ✔️ |
+| Qt.io + MinGW | ✔️ | ✔️ | ❌ |
+| Qt.io + MSVC | ✔️ | ✔️ | ❌ |
+| vcpkg + MSVC | ✔️ | ✔️ | ❌ |
+
+Notes for Windows on ARM:
+- Red Panda C++ can be built for ARM64 ABI only on Windows 11 ARM64, while it is supposed (but not tested) to run on Windows 10 ARM64.
+- The ARM64EC (“emulation compatible”) ABI, which highlights interoperability with x64, is currently not supported.
+  - ARM64EC does not bring significant benefit, since Red Panda C++ can be built to ARM64 classic ABI.
+  - However, ARM64EC will allow users to use their favorite input methods, fancy Qt styles.
+- With the [ARM32 deprecation in Windows 11 Insider Preview Build 25905](https://blogs.windows.com/windows-insider/2023/07/12/announcing-windows-11-insider-preview-build-25905/), ARM32 support will never be added.
+
+## MSYS2 Qt Library with MinGW Toolchain (Recommended)
+
+Red Panda C++ should work with any MinGW toolchain from MSYS2, including GCCs and Clangs in three GNU-based environments (MINGW32, MINGW64 and UCRT64), and Clangs in three LLVM-based environments (CLANG32, CLANG64 and CLANGARM64; see also [MSYS2’s document](https://www.msys2.org/docs/environments/)), while the following toolchains are frequently tested:
+- MINGW32 GCC,
+- MINGW64 GCC,
+- UCRT64 GCC (recommended for x64)
+- CLANGARM64 Clang (the only and recommended toolchain for ARM64).
+
+Official distributions of Red Panda C++ are built with MINGW32 GCC and MINGW64 GCC.
+
+Prerequisites:
+
+0. Windows 8.1 x64 or later, or Windows 11 ARM64.
+1. Install MSYS2.
+2. In selected environment, install toolchain and Qt 5 library:
+   ```bash
+   pacman -S $MINGW_PACKAGE_PREFIX-toolchain $MINGW_PACKAGE_PREFIX-qt5-static
+   ```
+
+For build only:
+
+1. In selected environment, set related variables:
+   ```bash
+   SRC_DIR="/c/src/redpanda-src" # “C:\src\redpanda-src” for example
+   BUILD_DIR="/c/src/redpanda-build" # “C:\src\redpanda-build” for example
+   INSTALL_DIR="/c/src/redpanda-pkg" # “C:\src\redpanda-pkg” for example
+   ```
+2. Navigate to build directory:
+   ```bash
+   rm -rf "$BUILD_DIR" # optional for clean build
+   mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
+   ```
+3. Configure, build and install:
+   ```bash
+   $MSYSTEM_PREFIX/qt5-static/bin/qmake PREFIX="$INSTALL_DIR" "$SRC_DIR/Red_Panda_CPP.pro"
+   mingw32-make -j$(nproc)
+   mingw32-make install
+   ```
+
+For development:
+
+1. Install Qt Creator (either MSYS2 edition from package `$MINGW_PACKAGE_PREFIX-qt-creator` or standalone edition from [Qt.io downloads site](https://download.qt.io/official_releases/qtcreator/)).
+2. Open `Red_Panda_CPP.pro` with Qt Creator.
+
+## Qt.io Qt Library with MinGW Toolchain or MSVC Toolchain
+
+Prerequisites:
+
+0. Windows 7 x64 or later. ARM64 is not supported.
+1. Install Qt with online installer from [Qt.io](https://www.qt.io/download-qt-installer-oss).
+   - Select the library (in _Qt_ group, _Qt 5.15.2_ subgroup, check at lease one of _MinGW 8.1.0 32-bit_, _MinGW 8.1.0 64-bit_, _MSVC 2019 32-bit_ or _MSVC 2019 64-bit_).
+   - For MinGW toolchain, select the toolchain (in _Qt_ group, _Developer and Designer Tools_ subgroup, check _MinGW 8.1.0 32-bit_ or _MinGW 8.1.0 64-bit_, matching the library).
+   - Optionally select Qt Creator (in _Qt_ group, _Developer and Designer Tools_ subgroup; recomended for MSVC toolchain for parallel build support).
+2. For MSVC toolchain, install Visual Studio 2019 or later, or Visual Studio Build Tools 2019 or later, with _Desktop Development with C++_ workload.
+   - In _Installation Details_ panel, under the _Desktop Development with C++_ workload, select at least one _MSVC x86/x64 build tools_ and one _Windows SDK_.
+
+For build only:
+
+1. Launch Qt environment from Start Menu.
+2. In Qt environment, set related variables:
+   ```bat
+   rem no quotes even if path contains spaces
+   set SRC_DIR=C:\src\redpanda-src
+   set BUILD_DIR=C:\src\redpanda-build
+   set INSTALL_DIR=C:\src\redpanda-pkg
+   rem for MSVC toolchain
+   set VS_INSTALL_PATH=C:\Program Files\Microsoft Visual Studio\2022\Community
+   rem for MSVC toolchain; or x86
+   set VC_ARCH=amd64
+   rem for MSVC toolchain; keep unset if Qt Creator is not installed
+   set QT_CREATOR_DIR=C:\Qt\Tools\QtCreator
+   ```
+3. Navigate to build directory:
+   ```bat
+   rem optional for clean build
+   rmdir /s /q "%BUILD_DIR%"
+   mkdir "%BUILD_DIR%" && cd /d "%BUILD_DIR%"
+   ```
+4. Configure, build and install. For MinGW toolchain:
+   ```bat
+   qmake PREFIX="%INSTALL_DIR%" "%SRC_DIR%\Red_Panda_CPP.pro"
+   mingw32-make -j%NUMBER_OF_PROCESSORS%
+   mingw32-make install
+   windeployqt "%INSTALL_DIR%\RedPandaIDE.exe"
+   ```
+   For MSVC toolchain:
+   ```bat
+   call "%VS_INSTALL_PATH%\Common7\Tools\VsDevCmd.bat" -arch=%VC_ARCH%
+   qmake PREFIX="%INSTALL_DIR%" "%SRC_DIR%\Red_Panda_CPP.pro"
+
+   set JOM=%QT_CREATOR_DIR%\bin\jom\jom.exe
+   if "%QT_CREATOR_DIR%" neq "" (
+      "%JOM%" -j%NUMBER_OF_PROCESSORS%
+      "%JOM%" install
+   ) else (
+      nmake
+      nmake install
+   )
+   windeployqt "%INSTALL_DIR%\RedPandaIDE.exe"
+   ```
+
+For development:
+
+1. Open `Red_Panda_CPP.pro` with Qt Creator.
+
+## Advanced Option: vcpkg Qt Static Library with MSVC Toolchain
+
+Prerequisites:
+
+0. Windows 7 x64 or later. ARM64 is not supported.
+   - For a fresh installation of Windows 7, install following components in order:
+     1. SHA-2 code signing support (prerequisite of .NET Framework 4.8),
+     2. .NET Framework 4.8 (prerequisite of Windows Management Framework 5.1 and Visual Studio; also optional dependency of Git for Windows),
+     3. Windows Management Framework 5.1 (prerequisite of vcpkg bootstrapping).
+1. Install Visual Studio 2017 or later, or Visual Studio Build Tools 2017 or later, with _Desktop Development with C++_ workload.
+   - In _Installation Details_ panel, under the _Desktop Development with C++_ workload, select at least one _MSVC x86/x64 build tools_ and one _Windows SDK_.
+2. Install [standalone vcpkg](https://vcpkg.io/en/getting-started).
+   - As of 2023.08.09, [a patch](./packages/windows/vcpkg-win7-2023.08.09.patch) is required for Windows 7 to use compatible version of Python. Affected files will change over time, so manually edit them to apply the patch.
+3. Install Qt with vcpkg.
+   ```ps1
+   $TARGET = "x64-windows-static" # or "x86-windows-static"
+   vcpkg install qt5-base:$TARGET qt5-svg:$TARGET qt5-tools:$TARGET
+   ```
+
+To build with VS 2019 or later in PowerShell (Core) or Windows PowerShell:
+
+1. Set related variables:
+   ```ps1
+   $SRC_DIR = "C:\src\redpanda-src"
+   $BUILD_DIR = "C:\src\redpanda-build"
+   $INSTALL_DIR = "C:\src\redpanda-pkg"
+   $VCPKG_ROOT = "C:\src\vcpkg"
+   $VCPKG_TARGET = "x64-windows-static" # or "x86-windows-static"
+   $VS_INSTALL_PATH = "C:\Program Files\Microsoft Visual Studio\2022\Community"
+   $VC_ARCH = "amd64" # or "x86"
+   $JOM = "$VCPKG_ROOT\downloads\tools\jom\jom-1.1.3\jom.exe" # check the version
+   ```
+2. Navigate to build directory:
+   ```ps1
+   Remove-Item -Recurse -Force "$BUILD_DIR" # optional for clean build
+   (New-Item -ItemType Directory -Force "$BUILD_DIR") -and (Set-Location "$BUILD_DIR")
+   ```
+3. Configure, build and install:
+   ```ps1
+   Import-Module "$VS_INSTALL_PATH\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+   Enter-VsDevShell -VsInstallPath "$VS_INSTALL_PATH" -SkipAutomaticLocation -DevCmdArguments "-arch=$VC_ARCH"
+   & "$VCPKG_ROOT\installed\$VCPKG_TARGET\tools\qt5\bin\qmake.exe" PREFIX="$INSTALL_DIR" "$SRC_DIR\Red_Panda_CPP.pro"
+   & "$JOM" "-j${Env:NUMBER_OF_PROCESSORS}"
+   & "$JOM" install
+   ```
+
+To build with VS 2017 or later in Command Prompt:
+
+1. Launch proper VC environment from Start Menu.
+2. Set related variables:
+   ```bat
+   rem no quotes even if path contains spaces
+   set SRC_DIR=C:\src\redpanda-src
+   set BUILD_DIR=C:\src\redpanda-build
+   set INSTALL_DIR=C:\src\redpanda-pkg
+   set VCPKG_ROOT=C:\src\vcpkg
+   rem or x86-windows-static
+   set VCPKG_TARGET=x64-windows-static
+   rem check the version
+   set JOM=%VCPKG_ROOT%\downloads\tools\jom\jom-1.1.3\jom.exe
+   ```
+3. Navigate to build directory:
+   ```bat
+   rem optional for clean build
+   rmdir /s /q "%BUILD_DIR%"
+   mkdir "%BUILD_DIR%" && cd /d "%BUILD_DIR%"
+   ```
+4. Configure, build and install:
+   ```bat
+   "%VCPKG_ROOT%\installed\%VCPKG_TARGET%\tools\qt5\bin\qmake.exe" PREFIX="%INSTALL_DIR%" "%SRC_DIR%\Red_Panda_CPP.pro"
+   "%JOM%" -j%NUMBER_OF_PROCESSORS%
+   "%JOM%" install
+   ```
 
 # Linux
 

--- a/RedPandaIDE/widgets/ojproblempropertywidget.h
+++ b/RedPandaIDE/widgets/ojproblempropertywidget.h
@@ -24,7 +24,7 @@ namespace Ui {
 class OJProblemPropertyWidget;
 }
 
-class OJProblem;
+struct OJProblem;
 using POJProblem = std::shared_ptr<OJProblem>;
 class OJProblemPropertyWidget : public QDialog
 {

--- a/packages/windows/vcpkg-win7-2023.08.09.patch
+++ b/packages/windows/vcpkg-win7-2023.08.09.patch
@@ -1,0 +1,29 @@
+diff --git a/scripts/cmake/vcpkg_find_acquire_program(PYTHON3).cmake b/scripts/cmake/vcpkg_find_acquire_program(PYTHON3).cmake
+index 6734b0bb6..2900ddf9e 100644
+--- a/scripts/cmake/vcpkg_find_acquire_program(PYTHON3).cmake
++++ b/scripts/cmake/vcpkg_find_acquire_program(PYTHON3).cmake
+@@ -1,20 +1,20 @@
+ if(CMAKE_HOST_WIN32)
+     set(program_name python)
+-    set(program_version 3.11.4)
++    set(program_version 3.8.10)
+     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+         set(tool_subdirectory "python-${program_version}-x86")
+         set(download_urls "https://www.python.org/ftp/python/${program_version}/python-${program_version}-embed-win32.zip")
+         set(download_filename "python-${program_version}-embed-win32.zip")
+-        set(download_sha512 4cdbb2efdc7764a87edfb7370716c1caf660d38bce37a280ec59b7aecab5672c5798aabe19a8ae395224bea7dfe644bd92656f0bbc44348717981b45a909c024)
++        set(download_sha512 a6f0c35ba37c07c6e8815fb43c20095541117f3b6cc034b8ef0acfc908de8951bdffa38706bac802f820290b39ae84f934f27a8e32f548735f470277f7a70550)
+     else()
+         set(tool_subdirectory "python-${program_version}-x64")
+         set(download_urls "https://www.python.org/ftp/python/${program_version}/python-${program_version}-embed-amd64.zip")
+         set(download_filename "python-${program_version}-embed-amd64.zip")
+-        set(download_sha512 3f93c2a16764b9ea6343315b70c0c6319aac8edaefbf4e21206fb30eff365e8fe37264a9133bebe12e664ea5d8fd232d587a5603a51fd96e1252a2fc01a2e550)
++        set(download_sha512 86e55911be78205a61f886feff2195c78a6f158a760cc1697ce4340dcb5ca118360251de2f707b6d2a78b7469d92c87b045b7326d6f194bfa92e665af1cd55a5)
+     endif()
+ 
+     set(paths_to_search "${DOWNLOADS}/tools/python/${tool_subdirectory}")
+-    vcpkg_list(SET post_install_command "${CMAKE_COMMAND}" -E rm python311._pth)
++    vcpkg_list(SET post_install_command "${CMAKE_COMMAND}" -E rm python38._pth)
+ else()
+     set(program_name python3)
+     set(brew_package_name "python")

--- a/tools/astyle/ASLocalizer.cpp
+++ b/tools/astyle/ASLocalizer.cpp
@@ -40,7 +40,7 @@
 #include "ASLocalizer.h"
 
 #ifdef _WIN32
-	#include <Windows.h>
+	#include <windows.h>
 #endif
 
 #ifdef __VMS

--- a/tools/astyle/astyle_main.cpp
+++ b/tools/astyle/astyle_main.cpp
@@ -45,7 +45,7 @@
 // includes for recursive getFileNames() function
 #ifdef _WIN32
 	#undef UNICODE		// use ASCII windows functions
-	#include <Windows.h>
+	#include <windows.h>
 #else
 	#include <dirent.h>
 	#include <sys/stat.h>

--- a/tools/consolepauser/consolepauser.pro
+++ b/tools/consolepauser/consolepauser.pro
@@ -3,10 +3,6 @@ QT -= gui
 CONFIG += c++11 console
 CONFIG -= app_bundle
 
-msvc {
-    CONFIG += windows
-}
-
 isEmpty(APP_NAME) {
     APP_NAME = RedPandaCPP
 }

--- a/tools/consolepauser/main.windows.cpp
+++ b/tools/consolepauser/main.windows.cpp
@@ -135,7 +135,7 @@ DWORD ExecuteCommand(string& command,bool reInp, LONGLONG &peakMemory, LONGLONG 
     }
     WINBOOL bSuccess = AssignProcessToJobObject( hJob, pi.hProcess );
     if ( bSuccess == FALSE ) {
-        printf( "AssignProcessToJobObject failed: error %u\n", GetLastError() );
+        printf( "AssignProcessToJobObject failed: error %lu\n", GetLastError() );
         return 0;
     }
 
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
     hJob= CreateJobObject( &sa, NULL );
 
     if ( hJob == NULL ) {
-        printf( "CreateJobObject failed: error %d\n", GetLastError() );
+        printf( "CreateJobObject failed: error %lu\n", GetLastError() );
         return 0;
     }
 
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
     info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
     WINBOOL bSuccess = SetInformationJobObject( hJob, JobObjectExtendedLimitInformation, &info, sizeof( info ) );
     if ( bSuccess == FALSE ) {
-        printf( "SetInformationJobObject failed: error %d\n", GetLastError() );
+        printf( "SetInformationJobObject failed: error %lu\n", GetLastError() );
         return 0;
     }
 
@@ -263,7 +263,7 @@ int main(int argc, char** argv) {
 
     // Done? Print return value of executed program
     printf("\n--------------------------------");
-    printf("\nProcess exited after %.4g seconds with return value %lu (%.4g ms cpu time, %d KB mem used).\n",seconds,returnvalue, execSeconds, peakMemory);
+    printf("\nProcess exited after %.4g seconds with return value %lu (%.4g ms cpu time, %lld KB mem used).\n",seconds,returnvalue, execSeconds, peakMemory);
     if (pauseAfterExit)
         PauseExit(returnvalue,reInp);
     return 0;

--- a/tools/redpanda-win-git-askpass/main.cpp
+++ b/tools/redpanda-win-git-askpass/main.cpp
@@ -39,7 +39,7 @@ LRESULT CALLBACK TxtPasswordWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
         if (wParam==VK_RETURN) {
             char s[500+1];
             Edit_GetText(hwndTxtPassword,s,500);
-            printf(s);
+            printf("%s", s);
             DestroyWindow(hMainDlg);
             return TRUE;
         }


### PR DESCRIPTION
Fix:
- Mismatched class-key in RedPandaIDE (MSVC linker error).
- consolepauser qmake project (MSVC runtime crash).
- Mismatched case in `#include <windows.h>` in astyle (cross MinGW on Linux preprocessor error).
- Format string security in consolepauser (Arch Linux MinGW compiler error).

Add detailed build instructions for:
- MSYS2 Qt library + MinGW toolchain;
- Qt.io Qt library + MinGW or MSVC toolchain;
- vcpkg Qt static library + MSVC toolchain.