### PR TITLE
Add runner args abstraction and fix shm on macOS/BSD

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -198,11 +198,33 @@ To build with VS 2017 or later in Command Prompt:
    "%JOM%" install
    ```
 
-# Linux
+# Linux and Other freedesktop.org-conforming (XDG) Desktop Systems
 
- - Install gcc and qt5
- - Optionally install fcitx5-qt for building with static version of Qt
- - Open `Red_Panda_CPP.pro` with Qt Creator
+General steps:
+
+- Install recent version of GCC (≥ 7) or Clang (≥ 6) that supports C++17.
+- Install Qt 5 (≥ 5.12) Base, SVG and Tools modules, including both libraries and development files.
+- Optionally install fcitx5-qt for building with static Qt library.
+- Optionally install Qt Creator for development.
+
+For build only:
+
+1. Configure:
+   ```bash
+   qmake PREFIX=/usr/local /path/to/src/Red_Panda_CPP.pro
+   ```
+2. Make:
+   ```bash
+   make -j$(nproc)
+   ```
+3. Install:
+   ```bash
+   sudo make install
+   ```
+
+For development:
+
+1. Open `Red_Panda_CPP.pro` with Qt Creator
 
 qmake variables:
 - `PREFIX`: default to `/usr/local`. It should be set to `/usr` or `/opt/redpanda-cpp` when packaging.
@@ -296,7 +318,7 @@ Enter `RedPandaIDE` to launch RedPanda C++.
 
 Note that makepkg checks out HEAD of the repo, so any change should be committed before building.
 
-## AppImage
+## Linux AppImage
 
 1. Install dependency: Docker or Podman.
 
@@ -336,9 +358,9 @@ Note that makepkg checks out HEAD of the repo, so any change should be committed
 
 It is possible to build Red Panda C++ for foreign architectures using targets’ native toolchains with QEMU user space emulation.
 
-Note: Always run emulated native build **in containers**. Mixing architectures may kill your system.
+Note: Always run emulated native build **in containers or jails**. Mixing architectures may kill your system.
 
-For Linux host, install statically linked QEMU user space emulator (package name is likely `qemu-user-static`) and make sure that binfmt support is enabled.
+For Linux or BSD host, install statically linked QEMU user space emulator (package name is likely `qemu-user-static`) and make sure that binfmt support is enabled.
 
 For Windows host, Docker and Podman should have QEMU user space emulation enabled. If not,
 * For Docker:
@@ -350,3 +372,38 @@ For Windows host, Docker and Podman should have QEMU user space emulation enable
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-riscv64-static.conf /proc/sys/fs/binfmt_misc/register
   ```
+
+# macOS
+
+## Qt.io Qt Library
+
+Prerequisites:
+
+0. macOS 10.13 or later.
+1. Install Xcode Command Line Tools:
+   ```zsh
+   xcode-select --install
+   ```
+2. Install Qt with online installer from [Qt.io](https://www.qt.io/download-qt-installer-oss).
+   - Select the library (in _Qt_ group, _Qt 5.15.2_ subgroup, check _macOS_).
+
+Build:
+
+1. Set related variables:
+   ```bash
+   SRC_DIR="~/redpanda-src"
+   BUILD_DIR="~/redpanda-build"
+   INSTALL_DIR="~/redpanda-pkg"
+   ```
+2. Navigate to build directory:
+   ```bash
+   rm -rf "$BUILD_DIR" # optional for clean build
+   mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
+   ```
+3. Configure, build and install:
+   ```bash
+   ~/Qt/5.15.2/clang_64/bin/qmake PREFIX="$INSTALL_DIR" "$SRC_DIR/Red_Panda_CPP.pro"
+   make -j$(sysctl -n hw.logicalcpu)
+   make install
+   ~/Qt/5.15.2/clang_64/bin/macdeployqt "$INSTALL_DIR/bin/RedPandaIDE.app"
+   ```

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -198,12 +198,33 @@
    "%JOM%" install
    ```
 
-# Linux
+# Linux 和其他符合 freedesktop.org（XDG）规范的桌面系统
 
-步骤:
- - 安装 gcc 和 qt5开发相关包
- - 如果使用静态版本的 Qt 编译，还要安装 fcitx5-qt
- - 使用qtcreator打开Red_Panda_CPP.pro文件
+通用步骤:
+
+- 安装支持 C++17 的 GCC（≥ 7）或 Clang（≥ 6）。
+- 安装 Qt 5（≥ 5.12）Base、SVG、Tools 模块，包括库和开发文件。
+- 如果使用静态版本的 Qt 编译，还要安装 fcitx5-qt。
+- 根据需要，安装 Qt Creator 用于开发。
+
+仅构建：
+
+1. 配置：
+   ```bash
+   qmake PREFIX=/usr/local /path/to/src/Red_Panda_CPP.pro
+   ```
+2. 构建：
+   ```bash
+   make -j$(nproc)
+   ```
+3. 安装：
+   ```bash
+   sudo make install
+   ```
+
+开发：
+
+1. 使用 Qt Creator 打开 `Red_Panda_CPP.pro` 文件。
 
 qmake 变量:
 - `PREFIX`：默认值是 `/usr/local`。打包时应该定义为 `/usr` 或 `/opt/redpanda-cpp`。
@@ -297,7 +318,7 @@ Windows 宿主的额外要求：
 
 注意：makepkg 签出此存储库的 HEAD，因此构建之前务必提交所有变更。
 
-## AppImage
+## Linux AppImage
 
 1. 安装依赖包：Docker 或 Podman。
 
@@ -337,9 +358,9 @@ Windows 宿主的额外要求：
 
 可以借助 QEMU 用户空间模拟，运行目标架构的本机工具链，来构建小熊猫 C++。
 
-注意：始终**在容器中**运行模拟本机构建，因为混用不同架构的程序和库可能会损坏系统。
+注意：始终**在容器或 jail 中**运行模拟本机构建，因为混用不同架构的程序和库可能会损坏系统。
 
-对于 Linux 宿主，需要安装静态链接的 QEMU 用户空间模拟器（包名通常为 `qemu-user-static`）并确认已经启用 binfmt 支持。
+对于 Linux 或 BSD 宿主，需要安装静态链接的 QEMU 用户空间模拟器（包名通常为 `qemu-user-static`）并确认已经启用 binfmt 支持。
 
 对于 Windows 宿主，Docker 和 Podman 应该已经启用了 QEMU 用户空间模拟。如果没有启用，
 * Docker：
@@ -351,3 +372,38 @@ Windows 宿主的额外要求：
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-aarch64-static.conf /proc/sys/fs/binfmt_misc/register
   wsl -d podman-machine-default sudo cp /usr/lib/binfmt.d/qemu-riscv64-static.conf /proc/sys/fs/binfmt_misc/register
   ```
+
+# macOS
+
+## Qt.io 的 Qt 库
+
+前置条件：
+
+0. macOS 10.13 或更高版本。
+1. 安装 Xcode 命令行工具：
+   ```bash
+   xcode-select --install
+   ```
+2. 用 [Qt.io](https://www.qt.io/download-qt-installer-oss) 或[镜像站](https://mirrors.sjtug.sjtu.edu.cn/docs/qt)的在线安装器安装 Qt。
+   - 选中 Qt 库（“Qt” 组下的 “Qt 5.15.2” 小组，勾选 “macOS”）。
+
+构建：
+
+1. 设置相关变量：
+   ```bash
+   SRC_DIR="~/redpanda-src"
+   BUILD_DIR="~/redpanda-build"
+   INSTALL_DIR="~/redpanda-pkg"
+   ```
+2. 定位到构建目录：
+   ```bash
+   rm -rf "$BUILD_DIR" # 根据需要进行全新构建
+   mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
+   ```
+3. 配置、构建、安装：
+   ```bash
+   ~/Qt/5.15.2/clang_64/bin/qmake PREFIX="$INSTALL_DIR" "$SRC_DIR/Red_Panda_CPP.pro"
+   make -j$(sysctl -n hw.logicalcpu)
+   make install
+   ~/Qt/5.15.2/clang_64/bin/macdeployqt "$INSTALL_DIR/bin/RedPandaIDE.app"
+   ```

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -29,10 +29,6 @@ contains(QMAKE_HOST.arch, x86_64):{
 }
 
 macos: {
-    # This package needs to be installed via homebrew before we can compile it
-    INCLUDEPATH += \
-        /opt/homebrew/opt/icu4c/include
-
     QT += gui-private
 
     ICON = ../macos/RedPandaIDE.icns
@@ -131,6 +127,7 @@ SOURCES += \
     settingsdialog/editortooltipswidget.cpp \
     settingsdialog/environmentfolderswidget.cpp \
     settingsdialog/environmentperformancewidget.cpp \
+    settingsdialog/environmentprogramswidget.cpp \
     settingsdialog/environmentshortcutwidget.cpp \
     settingsdialog/executorproblemsetwidget.cpp \
     settingsdialog/formattergeneralwidget.cpp \
@@ -254,6 +251,7 @@ HEADERS += \
     settingsdialog/editortooltipswidget.h \
     settingsdialog/environmentfolderswidget.h \
     settingsdialog/environmentperformancewidget.h \
+    settingsdialog/environmentprogramswidget.h \
     settingsdialog/environmentshortcutwidget.h \
     settingsdialog/executorproblemsetwidget.h \
     settingsdialog/formattergeneralwidget.h \
@@ -349,6 +347,7 @@ FORMS += \
     settingsdialog/editortooltipswidget.ui \
     settingsdialog/environmentfolderswidget.ui \
     settingsdialog/environmentperformancewidget.ui \
+    settingsdialog/environmentprogramswidget.ui \
     settingsdialog/environmentshortcutwidget.ui \
     settingsdialog/executorproblemsetwidget.ui \
     settingsdialog/formattergeneralwidget.ui \
@@ -469,16 +468,13 @@ win32: {
 
 unix: {
     HEADERS += \
-    settingsdialog/formatterpathwidget.h \
-    settingsdialog/environmentprogramswidget.h
+    settingsdialog/formatterpathwidget.h
 
     SOURCES += \
-    settingsdialog/formatterpathwidget.cpp \
-    settingsdialog/environmentprogramswidget.cpp
+    settingsdialog/formatterpathwidget.cpp
 
     FORMS += \
-    settingsdialog/formatterpathwidget.ui \
-    settingsdialog/environmentprogramswidget.ui
+    settingsdialog/formatterpathwidget.ui
 }
 
 linux: {

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -478,8 +478,8 @@ unix: {
 }
 
 linux: {
-    LIBS+= \
-    -lrt
+    # legacy glibc compatibility -- modern Unices have all components in `libc.so`
+    LIBS += -lrt
 
     _LINUX_STATIC_IME_PLUGIN = $$(LINUX_STATIC_IME_PLUGIN)
     equals(_LINUX_STATIC_IME_PLUGIN, "ON") {

--- a/RedPandaIDE/autolinkmanager.cpp
+++ b/RedPandaIDE/autolinkmanager.cpp
@@ -62,11 +62,13 @@ void AutolinkManager::load()
         file.write(content);
         file.close();
         preFile.close();
-#elif defined(Q_OS_LINUX)
-        QFile preFile(":/config/autolink-linux.json");
+#elif defined(Q_OS_MACOS)
+        return;
+#else // XDG desktop
+        QFile preFile(":/config/autolink-xdg.json");
         if (!preFile.open(QFile::ReadOnly)) {
             throw FileError(QObject::tr("Can't open file '%1' for read.")
-                            .arg(":/config/autolink-linux.json"));
+                            .arg(":/config/autolink-xdg.json"));
         }
         QByteArray content=preFile.readAll();
         if (!file.open(QFile::WriteOnly|QFile::Truncate)) {
@@ -76,8 +78,6 @@ void AutolinkManager::load()
         file.write(content);
         file.close();
         preFile.close();
-#else
-        return;
 #endif
     }
     if (file.open(QFile::ReadOnly)) {

--- a/RedPandaIDE/compiler/compilerinfo.cpp
+++ b/RedPandaIDE/compiler/compilerinfo.cpp
@@ -177,9 +177,12 @@ void CompilerInfo::prepareCompilerOptions()
     sl.append(QPair<QString,QString>("Strong","-strong"));
     sl.append(QPair<QString,QString>("All","-all"));
     addOption(CC_CMD_OPT_STACK_PROTECTOR , QObject::tr("Check for stack smashing attacks (-fstack-protector)"), groupName, false, false, true, "-fstack-protector", CompilerOptionType::Choice, sl);
-#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+#if defined(Q_OS_UNIX)
     sl.clear();
     sl.append(QPair<QString,QString>("Address","address"));
+# ifdef __aarch64__
+    sl.append(QPair<QString,QString>("Hardware-assisted Address","hwaddress"));
+# endif
     sl.append(QPair<QString,QString>("Thread","thread"));
     sl.append(QPair<QString,QString>("Leak","leak"));
     sl.append(QPair<QString,QString>("Undefined","undefined"));

--- a/RedPandaIDE/compiler/compilermanager.h
+++ b/RedPandaIDE/compiler/compilermanager.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include <QMutex>
 #include "qt_utils/utils.h"
+#include "../utils.h"
 #include "../common.h"
 
 class Runner;
@@ -96,6 +97,7 @@ private:
     int mSyntaxCheckIssueCount;
     Compiler* mBackgroundSyntaxChecker;
     Runner* mRunner;
+    TemporaryFileOwner mTempFileOwner;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     QRecursiveMutex mCompileMutex;
     QRecursiveMutex mBackgroundSyntaxCheckMutex;

--- a/RedPandaIDE/compiler/executablerunner.h
+++ b/RedPandaIDE/compiler/executablerunner.h
@@ -25,7 +25,7 @@ class ExecutableRunner : public Runner
 {
     Q_OBJECT
 public:
-    ExecutableRunner(const QString& filename, const QString& arguments, const QString& workDir,
+    ExecutableRunner(const QString& filename, const QStringList& arguments, const QString& workDir,
                      QObject* parent = nullptr);
     ExecutableRunner(const ExecutableRunner&)=delete;
     ExecutableRunner& operator=(const ExecutableRunner&)=delete;

--- a/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
+++ b/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
@@ -25,7 +25,7 @@
 #endif
 
 
-OJProblemCasesRunner::OJProblemCasesRunner(const QString& filename, const QString& arguments, const QString& workDir,
+OJProblemCasesRunner::OJProblemCasesRunner(const QString& filename, const QStringList& arguments, const QString& workDir,
                                            const QVector<POJProblemCase>& problemCases, QObject *parent):
     Runner(filename,arguments,workDir,parent),
     mExecTimeout(0),
@@ -37,7 +37,7 @@ OJProblemCasesRunner::OJProblemCasesRunner(const QString& filename, const QStrin
     setWaitForFinishTime(100);
 }
 
-OJProblemCasesRunner::OJProblemCasesRunner(const QString& filename, const QString& arguments, const QString& workDir,
+OJProblemCasesRunner::OJProblemCasesRunner(const QString& filename, const QStringList& arguments, const QString& workDir,
                                            POJProblemCase problemCase, QObject *parent):
     Runner(filename,arguments,workDir,parent),
     mExecTimeout(0),
@@ -64,7 +64,7 @@ void OJProblemCasesRunner::runCase(int index,POJProblemCase problemCase)
     QElapsedTimer elapsedTimer;
     bool execTimeouted = false;
     process.setProgram(mFilename);
-    process.setArguments(splitProcessCommand(mArguments));
+    process.setArguments(mArguments);
     process.setWorkingDirectory(mWorkDir);
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QString path = env.value("PATH");

--- a/RedPandaIDE/compiler/ojproblemcasesrunner.h
+++ b/RedPandaIDE/compiler/ojproblemcasesrunner.h
@@ -25,10 +25,10 @@ class OJProblemCasesRunner : public Runner
 {
     Q_OBJECT
 public:
-    explicit OJProblemCasesRunner(const QString& filename, const QString& arguments, const QString& workDir,
+    explicit OJProblemCasesRunner(const QString& filename, const QStringList& arguments, const QString& workDir,
                                   const QVector<POJProblemCase>& problemCases,
                                   QObject *parent = nullptr);
-    explicit OJProblemCasesRunner(const QString& filename, const QString& arguments, const QString& workDir,
+    explicit OJProblemCasesRunner(const QString& filename, const QStringList& arguments, const QString& workDir,
                                   POJProblemCase problemCase,
                                   QObject *parent = nullptr);
     OJProblemCasesRunner(const OJProblemCasesRunner&)=delete;

--- a/RedPandaIDE/compiler/runner.cpp
+++ b/RedPandaIDE/compiler/runner.cpp
@@ -17,7 +17,7 @@
 #include "runner.h"
 #include <QDebug>
 
-Runner::Runner(const QString &filename, const QString &arguments, const QString &workDir
+Runner::Runner(const QString &filename, const QStringList &arguments, const QString &workDir
                ,QObject *parent) : QThread(parent),
     mPausing(false),
     mStop(false),

--- a/RedPandaIDE/compiler/runner.h
+++ b/RedPandaIDE/compiler/runner.h
@@ -23,7 +23,7 @@ class Runner : public QThread
 {
     Q_OBJECT
 public:
-    explicit Runner(const QString& filename, const QString& arguments, const QString& workDir, QObject *parent = nullptr);
+    explicit Runner(const QString& filename, const QStringList& arguments, const QString& workDir, QObject *parent = nullptr);
     Runner(const Runner&)=delete;
     Runner operator=(const Runner&)=delete;
 
@@ -48,7 +48,7 @@ protected:
     bool mPausing;
     bool mStop;
     QString mFilename;
-    QString mArguments;
+    QStringList mArguments; // without argv[0]
     QString mWorkDir;
     int mWaitForFinishTime;
 };

--- a/RedPandaIDE/defaultconfigs.qrc
+++ b/RedPandaIDE/defaultconfigs.qrc
@@ -2,6 +2,6 @@
     <qresource prefix="/config">
         <file alias="autolink.json">resources/autolink.json</file>
         <file alias="codesnippets.json">resources/codesnippets.json</file>
-        <file alias="autolink-linux.json">resources/autolink-linux.json</file>
+        <file alias="autolink-xdg.json">resources/autolink-xdg.json</file>
     </qresource>
 </RCC>

--- a/RedPandaIDE/main.cpp
+++ b/RedPandaIDE/main.cpp
@@ -248,6 +248,23 @@ int main(int argc, char *argv[])
     qputenv("QT_QPA_PLATFORM", "windows:darkmode=2");
 #endif
 
+#ifdef Q_OS_MACOS
+    // in macOS GUI apps, `/usr/local/bin` is not in PATH by default
+    // follow the Unix way by prepending it to `/usr/bin`
+    {
+        QStringList pathList = getExecutableSearchPaths();
+        if (!pathList.contains("/usr/local/bin")) {
+            auto idxUsrBin = pathList.indexOf("/usr/bin");
+            if (idxUsrBin >= 0)
+                pathList.insert(idxUsrBin, "/usr/local/bin");
+            else
+                pathList.append("/usr/local/bin");
+        }
+        QString newPath = pathList.join(PATH_SEPARATOR);
+        qputenv("PATH", newPath.toUtf8());
+    }
+#endif
+
     QApplication app(argc, argv);
 
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);

--- a/RedPandaIDE/resources/autolink-xdg.json
+++ b/RedPandaIDE/resources/autolink-xdg.json
@@ -1,5 +1,13 @@
 [
     {
+        "header": "fmt/core.h",
+        "links": "-lfmt"
+    },
+    {
+        "header": "math.h",
+        "links": "-lm"
+    },
+    {
         "execUseUTF8": true,
         "header": "raylib.h",
         "links": "-lraylib -lGL -lm -lpthread -ldl -lrt -lX11"
@@ -11,5 +19,13 @@
     {
         "header": "rturtle.h",
         "links": "-lrturtle"
+    },
+    {
+        "header": "thread",
+        "links": "-lpthread"
+    },
+    {
+        "header": "threads.h",
+        "links": "-lpthread"
     }
 ]

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -3733,7 +3733,15 @@ void Settings::Environment::doLoad()
 
     // check saved terminal path
     QString savedTerminalPath = stringValue("terminal_path", "");
-    int savedArgsPattern_ = intValue("terminal_arguments_pattern", int(AP::MinusEAppendArgs)); // smooth migration from old version
+    int savedArgsPattern_ = intValue("terminal_arguments_pattern",
+#ifdef Q_OS_MACOS
+        // macOS: old versions have set Terminal.app as default terminal
+        // fallback to temp file to work with Terminal.app for smooth migration
+        int(AP::WriteCommandLineToTempFileThenTempFilename)
+#else
+        int(AP::MinusEAppendArgs) // Linux: keep old behaviour
+#endif
+    );
     AP savedArgsPattern = static_cast<AP>(savedArgsPattern_);
     if (!checkAndSetTerminalPath(TerminalSearchItem{savedTerminalPath, savedArgsPattern})) {
         // if saved terminal path is invalid, try determing terminal from our list

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -575,6 +575,9 @@ public:
         QString AStylePath() const;
         void setAStylePath(const QString &aStylePath);
 
+        TerminalEmulatorArgumentsPattern terminalArgumentsPattern() const;
+        void setTerminalArgumentsPattern(const TerminalEmulatorArgumentsPattern &argsPattern);
+
         bool useCustomIconSet() const;
         void setUseCustomIconSet(bool newUseCustomIconSet);
 
@@ -606,6 +609,7 @@ public:
         QString mDefaultOpenFolder;
         QString mTerminalPath;
         QString mAStylePath;
+        TerminalEmulatorArgumentsPattern mTerminalArgumentsPattern;
         bool mHideNonSupportFilesInFileView;
         bool mOpenFilesInSingleInstance;
         // _Base interface

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
@@ -28,6 +28,13 @@ EnvironmentProgramsWidget::EnvironmentProgramsWidget(const QString& name, const 
     ui(new Ui::EnvironmentProgramsWidget)
 {
     ui->setupUi(this);
+    QFont monoFont(DEFAULT_MONO_FONT);
+    ui->rbImplicitSystem->setFont(monoFont);
+    ui->rbMinusEAppendArgs->setFont(monoFont);
+    ui->rbMinusXAppendArgs->setFont(monoFont);
+    ui->rbMinusMinusAppendArgs->setFont(monoFont);
+    ui->rbMinusEAppendCommandLine->setFont(monoFont);
+    ui->rbWriteCommandLineToTempFileThenTempFilename->setFont(monoFont);
 #ifndef Q_OS_MACOS
     hideMacosSpecificPattern();
 #endif

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
@@ -19,6 +19,7 @@
 #include "../settings.h"
 #include "../iconsmanager.h"
 #include "../systemconsts.h"
+#include "../compiler/executablerunner.h"
 
 #include <QFileDialog>
 
@@ -27,6 +28,9 @@ EnvironmentProgramsWidget::EnvironmentProgramsWidget(const QString& name, const 
     ui(new Ui::EnvironmentProgramsWidget)
 {
     ui->setupUi(this);
+#ifndef Q_OS_MACOS
+    hideMacosSpecificPattern();
+#endif
 }
 
 EnvironmentProgramsWidget::~EnvironmentProgramsWidget()
@@ -34,14 +38,62 @@ EnvironmentProgramsWidget::~EnvironmentProgramsWidget()
     delete ui;
 }
 
+void EnvironmentProgramsWidget::hideMacosSpecificPattern()
+{
+    ui->rbWriteCommandLineToTempFileThenTempFilename->setVisible(false);
+    ui->rbWriteCommandLineToTempFileThenTempFilename->setEnabled(false);
+    ui->pbWriteCommandLineToTempFileThenTempFilename->setVisible(false);
+    ui->pbWriteCommandLineToTempFileThenTempFilename->setEnabled(false);
+}
+
+void EnvironmentProgramsWidget::testTerminal(const TerminalEmulatorArgumentsPattern &pattern)
+{
+    auto [filename, arguments, fileOwner] = wrapCommandForTerminalEmulator(ui->txtTerminal->text(), pattern, {defaultShell(), "-c", "echo hello; sleep 3"});
+    ExecutableRunner runner(filename, arguments, "", nullptr);
+    runner.start();
+    runner.wait();
+}
+
 void EnvironmentProgramsWidget::doLoad()
 {
     ui->txtTerminal->setText(pSettings->environment().terminalPath());
+    switch (pSettings->environment().terminalArgumentsPattern()) {
+    case TerminalEmulatorArgumentsPattern::ImplicitSystem:
+        ui->rbImplicitSystem->setChecked(true);
+        break;
+    case TerminalEmulatorArgumentsPattern::MinusEAppendArgs:
+        ui->rbMinusEAppendArgs->setChecked(true);
+        break;
+    case TerminalEmulatorArgumentsPattern::MinusXAppendArgs:
+        ui->rbMinusXAppendArgs->setChecked(true);
+        break;
+    case TerminalEmulatorArgumentsPattern::MinusMinusAppendArgs:
+        ui->rbMinusMinusAppendArgs->setChecked(true);
+        break;
+    case TerminalEmulatorArgumentsPattern::MinusEAppendCommandLine:
+        ui->rbMinusEAppendCommandLine->setChecked(true);
+        break;
+    case TerminalEmulatorArgumentsPattern::WriteCommandLineToTempFileThenTempFilename:
+        ui->rbWriteCommandLineToTempFileThenTempFilename->setChecked(true);
+        break;
+    }
 }
 
 void EnvironmentProgramsWidget::doSave()
 {
     pSettings->environment().setTerminalPath(ui->txtTerminal->text());
+    if (ui->rbImplicitSystem->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::ImplicitSystem);
+    if (ui->rbMinusEAppendArgs->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::MinusEAppendArgs);
+    if (ui->rbMinusXAppendArgs->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::MinusXAppendArgs);
+    if (ui->rbMinusMinusAppendArgs->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::MinusMinusAppendArgs);
+    if (ui->rbMinusEAppendCommandLine->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::MinusEAppendCommandLine);
+    if (ui->rbWriteCommandLineToTempFileThenTempFilename->isChecked())
+        pSettings->environment().setTerminalArgumentsPattern(TerminalEmulatorArgumentsPattern::WriteCommandLineToTempFileThenTempFilename);
     pSettings->environment().save();
 }
 
@@ -61,3 +113,62 @@ void EnvironmentProgramsWidget::on_btnChooseTerminal_clicked()
         ui->txtTerminal->setText(filename);
     }
 }
+
+void EnvironmentProgramsWidget::on_txtTerminal_textChanged(const QString &terminalPath)
+{
+    QString terminalPathForExec;
+    if (getPathUnixExecSemantics(terminalPath) == UnixExecSemantics::RelativeToCwd) {
+        QDir appDir(pSettings->dirs().appDir());
+        terminalPathForExec = appDir.absoluteFilePath(terminalPath);
+    } else
+        terminalPathForExec = terminalPath;
+    QString terminalPathEscaped = escapeArgument(terminalPathForExec, true);
+    QString shell = defaultShell();
+    QStringList execArgs{shell, "-c", "echo hello; sleep 3"};
+
+    auto displayCommand = [this, &execArgs](const TerminalEmulatorArgumentsPattern &pattern) {
+        auto [filename, arguments, fileOwner] = wrapCommandForTerminalEmulator(ui->txtTerminal->text(), pattern, execArgs);
+        for (auto &arg : arguments)
+            arg = escapeArgument(arg, false);
+        return escapeArgument(filename, true) + " " + arguments.join(' ');
+    };
+
+    ui->rbImplicitSystem->setText(displayCommand(TerminalEmulatorArgumentsPattern::ImplicitSystem));
+    ui->rbMinusEAppendArgs->setText(displayCommand(TerminalEmulatorArgumentsPattern::MinusEAppendArgs));
+    ui->rbMinusXAppendArgs->setText(displayCommand(TerminalEmulatorArgumentsPattern::MinusXAppendArgs));
+    ui->rbMinusMinusAppendArgs->setText(displayCommand(TerminalEmulatorArgumentsPattern::MinusMinusAppendArgs));
+    ui->rbMinusEAppendCommandLine->setText(displayCommand(TerminalEmulatorArgumentsPattern::MinusEAppendCommandLine));
+    if (ui->rbWriteCommandLineToTempFileThenTempFilename->isEnabled())
+        ui->rbWriteCommandLineToTempFileThenTempFilename->setText(displayCommand(TerminalEmulatorArgumentsPattern::WriteCommandLineToTempFileThenTempFilename));
+}
+
+void EnvironmentProgramsWidget::on_pbImplicitSystem_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::ImplicitSystem);
+}
+
+void EnvironmentProgramsWidget::on_pbMinusEAppendArgs_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::MinusEAppendArgs);
+}
+
+void EnvironmentProgramsWidget::on_pbMinusXAppendArgs_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::MinusXAppendArgs);
+}
+
+void EnvironmentProgramsWidget::on_pbMinusMinusAppendArgs_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::MinusMinusAppendArgs);
+}
+
+void EnvironmentProgramsWidget::on_pbMinusEAppendCommandLine_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::MinusEAppendCommandLine);
+}
+
+void EnvironmentProgramsWidget::on_pbWriteCommandLineToTempFileThenTempFilename_clicked()
+{
+    testTerminal(TerminalEmulatorArgumentsPattern::WriteCommandLineToTempFileThenTempFilename);
+}
+

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.h
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.h
@@ -18,6 +18,7 @@
 #define ENVIRONMENTPROGRAMSWIDGET_H
 
 #include "settingswidget.h"
+#include "utils.h"
 
 namespace Ui {
 class EnvironmentProgramsWidget;
@@ -30,6 +31,10 @@ class EnvironmentProgramsWidget : public SettingsWidget
 public:
     explicit EnvironmentProgramsWidget(const QString& name, const QString& group, QWidget *parent = nullptr);
     ~EnvironmentProgramsWidget();
+    void hideMacosSpecificPattern();
+
+private:
+    void testTerminal(const TerminalEmulatorArgumentsPattern &pattern);
 
 private:
     Ui::EnvironmentProgramsWidget *ui;
@@ -41,6 +46,13 @@ protected:
     void updateIcons(const QSize &size) override;
 private slots:
     void on_btnChooseTerminal_clicked();
+    void on_txtTerminal_textChanged(const QString &terminalPath);
+    void on_pbImplicitSystem_clicked();
+    void on_pbMinusEAppendArgs_clicked();
+    void on_pbMinusXAppendArgs_clicked();
+    void on_pbMinusMinusAppendArgs_clicked();
+    void on_pbMinusEAppendCommandLine_clicked();
+    void on_pbWriteCommandLineToTempFileThenTempFilename_clicked();
 };
 
 #endif // ENVIRONMENTPROGRAMSWIDGET_H

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
@@ -35,7 +35,183 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Terminal emulator arguments pattern</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="rbImplicitSystem">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>sh -c &quot;echo hello; sleep 3&quot;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="pbImplicitSystem">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="rbMinusEAppendArgs">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>term -e sh -c &quot;echo hello; sleep 3&quot;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="pbMinusEAppendArgs">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="rbMinusXAppendArgs">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>term -x sh -c &quot;echo hello; sleep 3&quot;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QPushButton" name="pbMinusXAppendArgs">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="rbMinusMinusAppendArgs">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>term -- sh -c &quot;echo hello; sleep 3&quot;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="pbMinusMinusAppendArgs">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="rbMinusEAppendCommandLine">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QPushButton" name="pbMinusEAppendCommandLine">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QRadioButton" name="rbWriteCommandLineToTempFileThenTempFilename">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>term /tmp/redpanda_XXXXXX.command</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QPushButton" name="pbWriteCommandLineToTempFileThenTempFilename">
+        <property name="text">
+         <string>Test</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="3">
+       <widget class="QLabel" name="lExpectedBahavior0">
+        <property name="text">
+         <string>On clicking “Test” for the correct pattern, the terminal emulator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="3">
+       <widget class="QLabel" name="lExpectedBahavior1">
+        <property name="text">
+         <string>• pops up;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="3">
+       <widget class="QLabel" name="lExpectedBahavior2">
+        <property name="text">
+         <string>• shows “hello”; and</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="3">
+       <widget class="QLabel" name="lExpectedBahavior3">
+        <property name="text">
+         <string>• quits in 3 seconds.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
@@ -43,13 +43,6 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QRadioButton" name="rbImplicitSystem">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>sh -c &quot;echo hello; sleep 3&quot;</string>
         </property>
@@ -77,13 +70,6 @@
       </item>
       <item row="1" column="0">
        <widget class="QRadioButton" name="rbMinusEAppendArgs">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>term -e sh -c &quot;echo hello; sleep 3&quot;</string>
         </property>
@@ -98,13 +84,6 @@
       </item>
       <item row="2" column="0">
        <widget class="QRadioButton" name="rbMinusXAppendArgs">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>term -x sh -c &quot;echo hello; sleep 3&quot;</string>
         </property>
@@ -119,13 +98,6 @@
       </item>
       <item row="3" column="0">
        <widget class="QRadioButton" name="rbMinusMinusAppendArgs">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>term -- sh -c &quot;echo hello; sleep 3&quot;</string>
         </property>
@@ -140,13 +112,6 @@
       </item>
       <item row="4" column="0">
        <widget class="QRadioButton" name="rbMinusEAppendCommandLine">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</string>
         </property>
@@ -161,13 +126,6 @@
       </item>
       <item row="5" column="0">
        <widget class="QRadioButton" name="rbWriteCommandLineToTempFileThenTempFilename">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
         <property name="text">
          <string>term /tmp/redpanda_XXXXXX.command</string>
         </property>

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
@@ -29,6 +29,7 @@ ExecutorGeneralWidget::ExecutorGeneralWidget(const QString& name, const QString&
     ui(new Ui::ExecutorGeneralWidget)
 {
     ui->setupUi(this);
+    ui->txtParsedArgsInJson->setFont(QFont(DEFAULT_MONO_FONT));
 }
 
 ExecutorGeneralWidget::~ExecutorGeneralWidget()

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
@@ -21,6 +21,8 @@
 #include "../systemconsts.h"
 
 #include <QFileDialog>
+#include <QJsonDocument>
+#include <QJsonArray>
 
 ExecutorGeneralWidget::ExecutorGeneralWidget(const QString& name, const QString& group, QWidget *parent):
     SettingsWidget(name,group,parent),
@@ -71,5 +73,13 @@ void ExecutorGeneralWidget::on_btnBrowse_clicked()
 void ExecutorGeneralWidget::updateIcons(const QSize &/*size*/)
 {
     pIconsManager->setIcon(ui->btnBrowse,IconsManager::ACTION_FILE_OPEN_FOLDER);
+}
+
+
+void ExecutorGeneralWidget::on_txtExecuteParamaters_textChanged(const QString &commandLine)
+{
+    QStringList parsed = splitProcessCommand(commandLine);
+    QJsonArray obj = QJsonArray::fromStringList(parsed);
+    ui->txtParsedArgsInJson->setText(QJsonDocument{obj}.toJson());
 }
 

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.h
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.h
@@ -43,6 +43,8 @@ private slots:
     void on_btnBrowse_clicked();
 
     // SettingsWidget interface
+    void on_txtExecuteParamaters_textChanged(const QString &commandLine);
+
 protected:
     void updateIcons(const QSize &size) override;
 };

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.ui
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.ui
@@ -55,9 +55,27 @@
      <property name="checkable">
       <bool>true</bool>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="QLineEdit" name="txtExecuteParamaters"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelParseArgsInJson">
+        <property name="text">
+         <string>Parsed argv array (represented in JSON):</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextBrowser" name="txtParsedArgsInJson">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <family>Menlo</family>
+          <family>Consolas</family>
+         </font>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -75,7 +93,6 @@
        <widget class="QLabel" name="label_3">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -88,7 +105,6 @@
        <widget class="QLabel" name="label_2">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -101,7 +117,6 @@
        <widget class="QLabel" name="label_4">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.ui
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.ui
@@ -68,13 +68,6 @@
       </item>
       <item>
        <widget class="QTextBrowser" name="txtParsedArgsInJson">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <family>Menlo</family>
-          <family>Consolas</family>
-         </font>
-        </property>
        </widget>
       </item>
      </layout>

--- a/RedPandaIDE/settingsdialog/settingsdialog.cpp
+++ b/RedPandaIDE/settingsdialog/settingsdialog.cpp
@@ -36,6 +36,7 @@
 #include "environmentshortcutwidget.h"
 #include "environmentfolderswidget.h"
 #include "environmentperformancewidget.h"
+#include "environmentprogramswidget.h"
 #include "executorgeneralwidget.h"
 #include "executorproblemsetwidget.h"
 #include "debuggeneralwidget.h"
@@ -59,7 +60,6 @@
 #include "projectversioninfowidget.h"
 #endif
 #ifdef Q_OS_LINUX
-#include "environmentprogramswidget.h"
 #include "formatterpathwidget.h"
 #endif
 #include <QDebug>
@@ -156,10 +156,8 @@ PSettingsDialog SettingsDialog::optionDialog()
     widget = new EnvironmentShortcutWidget(tr("Shortcuts"),tr("Environment"));
     dialog->addWidget(widget);
 
-#ifdef Q_OS_LINUX
     widget = new EnvironmentProgramsWidget(tr("Terminal"),tr("Environment"));
     dialog->addWidget(widget);
-#endif
 
     widget = new EnvironmentPerformanceWidget(tr("Performance"),tr("Environment"));
     dialog->addWidget(widget);

--- a/RedPandaIDE/settingsdialog/settingsdialog.cpp
+++ b/RedPandaIDE/settingsdialog/settingsdialog.cpp
@@ -59,7 +59,7 @@
 #include "environmentfileassociationwidget.h"
 #include "projectversioninfowidget.h"
 #endif
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) // XDG desktop
 #include "formatterpathwidget.h"
 #endif
 #include <QDebug>
@@ -228,7 +228,7 @@ PSettingsDialog SettingsDialog::optionDialog()
     widget = new FormatterGeneralWidget(tr("General"),tr("Code Formatter"));
     dialog->addWidget(widget);
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) // XDG desktop
     widget = new FormatterPathWidget(tr("Program"),tr("Code Formatter"));
     dialog->addWidget(widget);
 #endif

--- a/RedPandaIDE/systemconsts.h
+++ b/RedPandaIDE/systemconsts.h
@@ -22,7 +22,6 @@
 #define APP_SETTSINGS_FILENAME "redpandacpp.ini"
 #ifdef Q_OS_WIN
 #define CONSOLE_PAUSER  "consolepauser.exe"
-#define ASSEMBLER   "nasm.exe"
 #define GCC_PROGRAM     "gcc.exe"
 #define GPP_PROGRAM     "g++.exe"
 #define GDB_PROGRAM     "gdb.exe"
@@ -42,7 +41,6 @@
 #define MAKEBIN_PROGRAM   "makebin.exe"
 #elif defined(Q_OS_LINUX)
 #define CONSOLE_PAUSER  "consolepauser"
-#define ASSEMBLER   "nasm"
 #define GCC_PROGRAM     "gcc"
 #define GPP_PROGRAM     "g++"
 #define GDB_PROGRAM     "gdb"
@@ -63,7 +61,6 @@
 #define MAKEBIN_PROGRAM   "makebin"
 #elif defined(Q_OS_MACOS)
 #define CONSOLE_PAUSER  "consolepauser"
-#define ASSEMBLER   "nasm"
 #define GCC_PROGRAM     "gcc"
 #define GPP_PROGRAM     "g++"
 #define GDB_PROGRAM     "gdb"

--- a/RedPandaIDE/systemconsts.h
+++ b/RedPandaIDE/systemconsts.h
@@ -39,7 +39,7 @@
 #define SDCC_PROGRAM   "sdcc.exe"
 #define PACKIHX_PROGRAM   "packihx.exe"
 #define MAKEBIN_PROGRAM   "makebin.exe"
-#elif defined(Q_OS_LINUX)
+#else // Unix
 #define CONSOLE_PAUSER  "consolepauser"
 #define GCC_PROGRAM     "gcc"
 #define GPP_PROGRAM     "g++"
@@ -59,27 +59,6 @@
 #define SDCC_PROGRAM   "sdcc"
 #define PACKIHX_PROGRAM   "packihx"
 #define MAKEBIN_PROGRAM   "makebin"
-#elif defined(Q_OS_MACOS)
-#define CONSOLE_PAUSER  "consolepauser"
-#define GCC_PROGRAM     "gcc"
-#define GPP_PROGRAM     "g++"
-#define GDB_PROGRAM     "gdb"
-#define GDB_SERVER_PROGRAM     "gdbserver"
-#define GDB32_PROGRAM   "gdb32"
-#define MAKE_PROGRAM    "make"
-#define WINDRES_PROGRAM ""
-#define CLEAN_PROGRAM   "rm -rf"
-#define CPP_PROGRAM     "cpp"
-#define GIT_PROGRAM     "git"
-#define CLANG_PROGRAM   "clang"
-#define CLANG_CPP_PROGRAM   "clang++"
-#define LLDB_MI_PROGRAM   "lldb-mi"
-#define LLDB_SERVER_PROGRAM   "lldb-server"
-#define SDCC_PROGRAM   "sdcc"
-#define PACKIHX_PROGRAM   "packihx"
-#define MAKEBIN_PROGRAM   "makebin"
-#else
-#error "Only support windows, Linux and MacOS now!"
 #endif
 
 #define DEV_PROJECT_EXT "dev"
@@ -125,7 +104,7 @@
 #   define MAKEFILE_NAME    "makefile.win"
 #   define XMAKEFILE_NAME    "xmake.lua"
 #   define ALL_FILE_WILDCARD "*.*"
-#elif defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+#else // Unix
 #   define PATH_SENSITIVITY Qt::CaseSensitive
 #   define PATH_SEPARATOR   ":"
 #   define LINE_BREAKER     "\n"
@@ -139,8 +118,6 @@
 #   define MAKEFILE_NAME    "makefile"
 #   define XMAKEFILE_NAME    "xmake.lua"
 #   define ALL_FILE_WILDCARD "*"
-#else
-#error "Only support windows, linux and macos now!"
 #endif
 
 #define SDCC_IHX_SUFFIX "ihx"
@@ -148,6 +125,40 @@
 #define SDCC_HEX_SUFFIX "hex"
 #define SDCC_REL_SUFFIX "rel"
 
+#if defined(Q_OS_WIN)
+#   define DEFAULT_UI_FONT   "Segoe UI"
+#   define CJK_UI_FONT_SC    "Microsoft YaHei UI"
+#   define CJK_UI_FONT_TC    "Microsoft JhengHei UI"
+#   define CJK_UI_FONT_J     "Yu Gothic UI"
+#   define CJK_UI_FONT_K     "Malgun Gothic"
+#   define DEFAULT_MONO_FONT "Consolas"
+#   define CJK_MONO_FONT_SC  "Microsoft YaHei"
+#   define CJK_MONO_FONT_TC  "Microsoft JhengHei"
+#   define CJK_MONO_FONT_J   "Yu Gothic"
+#   define CJK_MONO_FONT_K   "Malgun Gothic"
+#elif defined(Q_OS_MACOS)
+#   define DEFAULT_UI_FONT   "Helvetica Neue"
+#   define CJK_UI_FONT_SC    "PingFang SC"
+#   define CJK_UI_FONT_TC    "PingFang TC"
+#   define CJK_UI_FONT_J     "Hiragino Sans"
+#   define CJK_UI_FONT_K     "Apple SD Gothic Neo"
+#   define DEFAULT_MONO_FONT "Menlo"
+#   define CJK_MONO_FONT_SC  CJK_UI_FONT_SC
+#   define CJK_MONO_FONT_TC  CJK_UI_FONT_TC
+#   define CJK_MONO_FONT_J   CJK_UI_FONT_J
+#   define CJK_MONO_FONT_K   CJK_UI_FONT_K
+#else // XDG desktop
+#   define DEFAULT_UI_FONT   "Sans"             // use fontconfig default
+#   define CJK_UI_FONT_SC    "Noto Sans CJK SC"
+#   define CJK_UI_FONT_TC    "Noto Sans CJK TC"
+#   define CJK_UI_FONT_J     "Noto Sans CJK JP"
+#   define CJK_UI_FONT_K     "Noto Sans CJK KR"
+#   define DEFAULT_MONO_FONT "Monospace"        // use fontconfig default
+#   define CJK_MONO_FONT_SC  CJK_UI_FONT_SC     // intentionally: the "Mono" version is not stricly monospaced either, and has less weights
+#   define CJK_MONO_FONT_TC  CJK_UI_FONT_TC
+#   define CJK_MONO_FONT_J   CJK_UI_FONT_J
+#   define CJK_MONO_FONT_K   CJK_UI_FONT_K
+#endif
 
 class SystemConsts
 {

--- a/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
@@ -1958,6 +1958,54 @@
         <source>All files (%1)</source>
         <translation>Todos os arquivos (%1)</translation>
     </message>
+    <message>
+        <source>Terminal emulator arguments pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished">Testar</translation>
+    </message>
+    <message>
+        <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• pops up;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• shows “hello”; and</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• quits in 3 seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term /tmp/redpanda_XXXXXX.command</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EnvironmentShortcutModel</name>
@@ -2057,6 +2105,10 @@
     <message>
         <source>All files (%1)</source>
         <translation>Todos os arquivos (%1)</translation>
+    </message>
+    <message>
+        <source>Parsed argv array (represented in JSON):</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
@@ -2689,7 +2689,72 @@ Are you really want to continue?</oldsource>
         <translation>终端</translation>
     </message>
     <message>
-        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="57"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="41"/>
+        <source>Terminal emulator arguments pattern</source>
+        <translation>终端模拟器参数模式</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="54"/>
+        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="74"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="95"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="116"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="137"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="158"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="179"/>
+        <source>Test</source>
+        <translation>测试</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="88"/>
+        <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="109"/>
+        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="130"/>
+        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="151"/>
+        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="172"/>
+        <source>term /tmp/redpanda_XXXXXX.command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="186"/>
+        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
+        <translation>点击正确的模式对应的 “测试” 按钮，终端模拟器将会</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="193"/>
+        <source>• pops up;</source>
+        <translation>• 弹出；</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="200"/>
+        <source>• shows “hello”; and</source>
+        <translation>• 显示 “hello”；</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="207"/>
+        <source>• quits in 3 seconds.</source>
+        <translation>• 并在 3 秒后关闭。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="109"/>
         <source>Choose Terminal Program</source>
         <translation>选择终端程序</translation>
     </message>
@@ -2797,6 +2862,11 @@ Are you really want to continue?</oldsource>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="53"/>
         <source>Parameters to pass to your program</source>
         <translation>运行程序的命令行参数</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="65"/>
+        <source>Parsed argv array (represented in JSON):</source>
+        <translation>argv 数组解析结果（以 JSON 表示）：</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="68"/>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
@@ -1791,6 +1791,54 @@
         <source>All files (%1)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Terminal emulator arguments pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• pops up;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• shows “hello”; and</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>• quits in 3 seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>term /tmp/redpanda_XXXXXX.command</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EnvironmentShortcutModel</name>
@@ -1889,6 +1937,10 @@
     </message>
     <message>
         <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Parsed argv array (represented in JSON):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/RedPandaIDE/vcs/gitmanager.cpp
+++ b/RedPandaIDE/vcs/gitmanager.cpp
@@ -25,7 +25,7 @@ void GitManager::createRepository(const QString &folder)
     contents.append("*.o");
     contents.append("*.exe");
     contents.append("*.layout");
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
     contents.append("*.");
 #endif
 
@@ -593,7 +593,7 @@ QString GitManager::runGit(const QString& workingFolder, const QStringList &args
 #ifdef Q_OS_WIN
     env.insert("PATH",pSettings->dirs().appDir());
     env.insert("GIT_ASKPASS",includeTrailingPathDelimiter(pSettings->dirs().appDir())+"redpanda-win-git-askpass.exe");
-#elif defined(Q_OS_LINUX)
+#else // Unix
     env.insert(QProcessEnvironment::systemEnvironment());
     env.insert("LANG","en");
     env.insert("LANGUAGE","en");

--- a/libs/qsynedit/qsynedit/qsynedit.cpp
+++ b/libs/qsynedit/qsynedit/qsynedit.cpp
@@ -56,15 +56,7 @@ QSynEdit::QSynEdit(QWidget *parent) : QAbstractScrollArea(parent),
     mPaintLock = 0;
     mPainterLock = 0;
     mPainting = false;
-#ifdef Q_OS_WIN
-    mFontDummy = QFont("Consolas",12);
-#elif defined(Q_OS_LINUX)
-    mFontDummy = QFont("terminal",14);
-#elif defined(Q_OS_MACOS)
-    mFontDummy = QFont("Menlo", 14);
-#else
-#error "Not supported!"
-#endif
+    mFontDummy = QFont("monospace",14);
     mFontDummy.setStyleStrategy(QFont::PreferAntialias);
     mDocument = std::make_shared<Document>(mFontDummy, mFontDummy, this);
     //fPlugins := TList.Create;

--- a/libs/qsynedit/qsynedit/syntaxer/asm.cpp
+++ b/libs/qsynedit/qsynedit/syntaxer/asm.cpp
@@ -108,7 +108,7 @@ const QSet<QString> ASMSyntaxer::ATTDirectives {
     ".seh_setframe",".seh_stackalloc",".seh_pushreg",
     ".seh_savereg",".seh_savemm",".seh_savexmm",
     ".seh_pushframe",".seh_scope",
-#elif defined(Q_OS_LINUX)
+#else // Unix
     ".cfi_sections",".cfi_startproc",".cfi_endproc",
     ".cfi_personality",".cfi_personality_id",".cfi_fde_data",
     ".cfi_lsda",".cfi_inline_lsda",".cfi_def_cfa",

--- a/tools/consolepauser/main.unix.cpp
+++ b/tools/consolepauser/main.unix.cpp
@@ -22,6 +22,7 @@ using std::string;
 using std::vector;
 #include <string.h>
 #include <stdio.h>
+#include <errno.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -184,15 +185,11 @@ int main(int argc, char** argv) {
         //todo: handle error
         printf("shm open failed %d:%s\n",errno,strerror(errno));
     } else {
-        if (ftruncate(fd_shm,BUF_SIZE)==-1){
-            printf("ftruncate failed %d:%s\n",errno,strerror(errno));
-            //todo: set size error
-        } else {
-            pBuf = (char*)mmap(NULL,BUF_SIZE,PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm,0);
-            if (pBuf == MAP_FAILED) {
-                printf("mmap failed %d:%s\n",errno,strerror(errno));
-                pBuf = nullptr;
-            }
+        // `ftruncate` has already done in RedPandaIDE
+        pBuf = (char*)mmap(NULL,BUF_SIZE,PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm,0);
+        if (pBuf == MAP_FAILED) {
+            printf("mmap failed %d:%s\n",errno,strerror(errno));
+            pBuf = nullptr;
         }
     }
 


### PR DESCRIPTION
- Add runner args abstraction.
  - Change `QString arguments` in runner parameters to `QStringList arguments` to allow further manipulation and avoid multiple escaping.
  - Add support for multiple terminal app args patterns.
  - Reunion terminal options on Windows, Linux and macOS.
- Fix shm on macOS.
  - Truncate name to adapt to macOS’s limit.
  - Fix `ftruncate` calls on shm fd. (Only creator can do `ftruncate` on most non-Linux Unices.) 
- With such effort of reunification, also extend platform support to FreeBSD (and hopefully all freedesktop.org-conforming desktops, though not tested) with minor effort.
  - Some adjustment on font and other platform-specific constants.