### PR TITLE
Improve custom terminal settings

### DIFF
--- a/RedPandaIDE/compiler/compilermanager.cpp
+++ b/RedPandaIDE/compiler/compilermanager.cpp
@@ -265,15 +265,21 @@ void CompilerManager::run(
                 sharedMemoryId,
                 localizePath(filename)
             } + splitProcessCommand(arguments);
-            auto [filename, args, fileOwner] = wrapCommandForTerminalEmulator(
-                pSettings->environment().terminalPathForExec(),
-                pSettings->environment().terminalArgumentsPattern(),
-                execArgs
-            );
-            //delete when thread finished
-            execRunner = new ExecutableRunner(filename, args, workDir);
-            execRunner->setShareMemoryId(sharedMemoryId);
-            mTempFileOwner = std::move(fileOwner);
+            if (pSettings->environment().useCustomTerminal()) {
+                auto [filename, args, fileOwner] = wrapCommandForTerminalEmulator(
+                    pSettings->environment().terminalPathForExec(),
+                    pSettings->environment().terminalArgumentsPattern(),
+                    execArgs
+                );
+                //delete when thread finished
+                execRunner = new ExecutableRunner(filename, args, workDir);
+                execRunner->setShareMemoryId(sharedMemoryId);
+                mTempFileOwner = std::move(fileOwner);
+            } else {
+                //delete when thread finished
+                execRunner = new ExecutableRunner(execArgs[0], execArgs.mid(1), workDir);
+                execRunner->setShareMemoryId(sharedMemoryId);
+            }
         } else {
             //delete when thread finished
             execRunner = new ExecutableRunner(filename,splitProcessCommand(arguments),workDir);

--- a/RedPandaIDE/defaultconfigs.qrc
+++ b/RedPandaIDE/defaultconfigs.qrc
@@ -3,5 +3,7 @@
         <file alias="autolink.json">resources/autolink.json</file>
         <file alias="codesnippets.json">resources/codesnippets.json</file>
         <file alias="autolink-xdg.json">resources/autolink-xdg.json</file>
+        <file alias="terminal-windows.json">resources/terminal-windows.json</file>
+        <file alias="terminal-unix.json">resources/terminal-unix.json</file>
     </qresource>
 </RCC>

--- a/RedPandaIDE/resources/terminal-unix.json
+++ b/RedPandaIDE/resources/terminal-unix.json
@@ -1,0 +1,207 @@
+[
+    {
+        "group": "User Installed",
+        "terminals": [
+            {
+                "name": "Alacritty",
+                "path": "alacritty",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "cool-retro-term",
+                "path": "cool-retro-term",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "CoreTerminal",
+                "path": "coreterminal",
+                "argsPattern": "$term -e \"$command\"",
+                "comment": "The pair of quotation mark around `$command` is only a visual symbol, not actually required."
+            },
+            {
+                "name": "iTerm2",
+                "path": "/Applications/iTerm.app/Contents/MacOS/iTerm2",
+                "argsPattern": "$term $tmpfile"
+            },
+            {
+                "name": "kermit",
+                "path": "kermit",
+                "argsPattern": "$term -e \"$command\""
+            },
+            {
+                "name": "Kitty",
+                "path": "kitty",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "ROXTerm",
+                "path": "roxterm",
+                "argsPattern": "$term -e \"$command\""
+            },
+            {
+                "name": "sakura",
+                "path": "sakura",
+                "argsPattern": "$term -e \"$command\""
+            },
+            {
+                "name": "Termit",
+                "path": "termit",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Termite",
+                "path": "termite",
+                "argsPattern": "$term -e \"$command\""
+            },
+            {
+                "name": "Tilix",
+                "path": "tilix",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Wayst",
+                "path": "wayst",
+                "argsPattern": "$term -e $argv"
+            }
+        ]
+    },
+    {
+        "group": "Desktop Default",
+        "terminals": [
+            {
+                "name": "Deepin Terminal",
+                "path": "deepin-terminal",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Konsole (KDE)",
+                "path": "konsole",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "GNOME Terminal",
+                "path": "gnome-terminal",
+                "argsPattern": "$term -- $argv"
+            },
+            {
+                "name": "GNOME Terminator",
+                "path": "terminator",
+                "argsPattern": "$term -x $argv"
+            },
+            {
+                "name": "LXTerminal (LXDE)",
+                "path": "lxterminal",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "MATE Terminal",
+                "path": "mate-terminal",
+                "argsPattern": "$term -x $argv"
+            },
+            {
+                "name": "QTerminal (LXQt)",
+                "path": "qterminal",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Terminal.app (macOS 10.14 or earlier)",
+                "path": "/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+                "argsPattern": "$term $tmpfile"
+            },
+            {
+                "name": "Terminal.app (macOS 10.15 or later)",
+                "path": "/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+                "argsPattern": "$term $tmpfile"
+            },
+            {
+                "name": "Terminology (Enlightenment)",
+                "path": "terminology",
+                "argsPattern": "$term -e \"$command\""
+            },
+            {
+                "name": "Xfce Terminal",
+                "path": "xfce4-terminal",
+                "argsPattern": "$term -x $argv"
+            }
+        ]
+    },
+    {
+        "group": "Bundled",
+        "terminals": [
+            {
+                "name": "Alacritty (Bundled)",
+                "path": "./alacritty",
+                "argsPattern": "$term -e $argv"
+            }
+        ]
+    },
+    {
+        "group": "With minor issue",
+        "terminals": [
+            {
+                "name": "Elementary Terminal",
+                "path": "io.elementary.terminal",
+                "argsPattern": "$term -e \"$command\"",
+                "comment": "confirm to quit"
+            },
+            {
+                "name": "foot",
+                "path": "foot",
+                "argsPattern": "$term -e $argv",
+                "comment": "wayland only"
+            },
+            {
+                "name": "GNOME Console",
+                "path": "kgx",
+                "argsPattern": "$term -- $argv",
+                "comment": "confirm to quit"
+            },
+            {
+                "name": "mlterm",
+                "path": "mlterm",
+                "argsPattern": "$term -e $argv",
+                "comment": "no out of box HiDPI support"
+            },
+            {
+                "name": "st",
+                "path": "st",
+                "argsPattern": "$term -e $argv",
+                "comment": "no out of box HiDPI support"
+            },
+            {
+                "name": "urxvt",
+                "path": "urxvt",
+                "argsPattern": "$term -e $argv",
+                "comment": "no out of box HiDPI support"
+            },
+            {
+                "name": "xterm",
+                "path": "xterm",
+                "argsPattern": "$term -e $argv",
+                "comment": "no out of box HiDPI support"
+            },
+            {
+                "name": "zutty",
+                "path": "zutty",
+                "argsPattern": "$term -e $argv",
+                "comment": "no out of box HiDPI support"
+            }
+        ]
+    },
+    {
+        "group": "Unavailable",
+        "terminals": [],
+        "unavailableTerminals": {
+            "aterm": "AUR broken, unable to test",
+            "eterm": "AUR broken, unable to test",
+            "guake": "drop down terminal",
+            "hyper": "no execute support",
+            "liri-terminal": "no execute support",
+            "rxvt": "no unicode support",
+            "shellinabox": "AUR broken, unable to test",
+            "station": "no execute support",
+            "tilda": "drop down terminal",
+            "yakuake": "drop down terminal"
+        }
+    }
+]

--- a/RedPandaIDE/resources/terminal-windows.json
+++ b/RedPandaIDE/resources/terminal-windows.json
@@ -1,0 +1,52 @@
+[
+    {
+        "group": "Bundled",
+        "terminals": [
+            {
+                "name": "UTF-8 compatible Console Host",
+                "path": "./OpenConsole.exe",
+                "argsPattern": "$term -- $argv"
+            }
+        ]
+    },
+    {
+        "group": "System",
+        "terminals": [
+            {
+                "name": "System Default",
+                "path": "",
+                "argsPattern": "$argv"
+            }
+        ]
+    },
+    {
+        "group": "Predefined arguments pattern (will not be searched)",
+        "terminals": [
+            {
+                "name": "Console Host",
+                "path": "conhost.exe",
+                "argsPattern": "$term -- $argv"
+            },
+            {
+                "name": "Windows Terminal",
+                "path": "wt.exe",
+                "argsPattern": "$term -- $argv"
+            },
+            {
+                "name": "Alacritty",
+                "path": "alacritty.exe",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Konsole",
+                "path": "konsole.exe",
+                "argsPattern": "$term -e $argv"
+            },
+            {
+                "name": "Mintty",
+                "path": "mintty.exe",
+                "argsPattern": "$term -e $argv"
+            }
+        ]
+    }
+]

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -575,8 +575,8 @@ public:
         QString AStylePath() const;
         void setAStylePath(const QString &aStylePath);
 
-        TerminalEmulatorArgumentsPattern terminalArgumentsPattern() const;
-        void setTerminalArgumentsPattern(const TerminalEmulatorArgumentsPattern &argsPattern);
+        QString terminalArgumentsPattern() const;
+        void setTerminalArgumentsPattern(const QString &argsPattern);
 
         bool useCustomIconSet() const;
         void setUseCustomIconSet(bool newUseCustomIconSet);
@@ -593,7 +593,22 @@ public:
         double iconZoomFactor() const;
         void setIconZoomFactor(double newIconZoomFactor);
 
+        QJsonArray availableTerminals() const;
+        void setAvailableTerminals(const QJsonArray &availableTerminals);
+
+        QMap<QString, QString> predefinedTerminalArgumentsPattern() const;
+        void setPredefinedTerminalArgumentsPattern(const QMap<QString, QString> &newPredefinedTerminalArgumentsPattern);
+        // it should be `std::optional<QString>`.
+        // `std::unique_ptr` is a work around for Debian 10, where Qt 5.11 doesnt recognize `CONFIG += c++17`,
+        // and macOS, where official Qt 5.15 is built against macOS 10.13 and `std::optional` is explicitly disabled.
+        std::unique_ptr<QString> queryPredefinedTerminalArgumentsPattern(const QString &executable) const;
+
+        bool useCustomTerminal() const;
+        void setUseCustomTerminal(bool newUseCustomTerminal);
+
     private:
+        bool checkAndSetTerminal(QString terminalPath, QString argsPattern);
+        bool updateTerminalList();
 
         //Appearance
         QString mTheme;
@@ -609,7 +624,9 @@ public:
         QString mDefaultOpenFolder;
         QString mTerminalPath;
         QString mAStylePath;
-        TerminalEmulatorArgumentsPattern mTerminalArgumentsPattern;
+        QString mTerminalArgumentsPattern;
+        QMap<QString, QString> mPredefinedTerminalArgumentsPattern;
+        bool mUseCustomTerminal;
         bool mHideNonSupportFilesInFileView;
         bool mOpenFilesInSingleInstance;
         // _Base interface

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.h
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.h
@@ -31,10 +31,12 @@ class EnvironmentProgramsWidget : public SettingsWidget
 public:
     explicit EnvironmentProgramsWidget(const QString& name, const QString& group, QWidget *parent = nullptr);
     ~EnvironmentProgramsWidget();
-    void hideMacosSpecificPattern();
 
 private:
-    void testTerminal(const TerminalEmulatorArgumentsPattern &pattern);
+    auto resolveExecArguments(const QString &terminalPath, const QString &argsPatter)
+        -> std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>>;
+    void updateCommandPreview(const QString &terminalPath, const QString &argsPatter);
+    void autoDetectAndUpdateArgumentsPattern(const QString &terminalPath);
 
 private:
     Ui::EnvironmentProgramsWidget *ui;
@@ -47,12 +49,9 @@ protected:
 private slots:
     void on_btnChooseTerminal_clicked();
     void on_txtTerminal_textChanged(const QString &terminalPath);
-    void on_pbImplicitSystem_clicked();
-    void on_pbMinusEAppendArgs_clicked();
-    void on_pbMinusXAppendArgs_clicked();
-    void on_pbMinusMinusAppendArgs_clicked();
-    void on_pbMinusEAppendCommandLine_clicked();
-    void on_pbWriteCommandLineToTempFileThenTempFilename_clicked();
+    void on_txtArgsPattern_textChanged(const QString &argsPattern);
+    void on_btnAutoDetectArgsPattern_clicked();
+    void on_btnTest_clicked();
 };
 
 #endif // ENVIRONMENTPROGRAMSWIDGET_H

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.ui
@@ -13,163 +13,100 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="txtTerminal"/>
-   </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="btnChooseTerminal">
-     <property name="text">
-      <string>...</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../icons.qrc">
-       <normaloff>:/icons/images/newlook24/053-open.png</normaloff>:/icons/images/newlook24/053-open.png</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Terminal</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="grpUseCustomTerminal">
      <property name="title">
-      <string>Terminal emulator arguments pattern</string>
+      <string>Use custom terminal</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="rbImplicitSystem">
-        <property name="text">
-         <string>sh -c &quot;echo hello; sleep 3&quot;</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       <widget class="QLineEdit" name="txtTerminal"/>
       </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="pbImplicitSystem">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="txtArgsPattern">
         <property name="text">
-         <string>Test</string>
+         <string>$term -e $argv</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QRadioButton" name="rbMinusEAppendArgs">
+       <widget class="QLabel" name="labelArgsPattern">
+        <property name="text">
+         <string>Args. pattern</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="btnChooseTerminal">
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../icons.qrc">
+          <normaloff>:/icons/images/newlook24/053-open.png</normaloff>:/icons/images/newlook24/053-open.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="btnAutoDetectArgsPattern">
+        <property name="toolTip">
+         <string>Auto Detect Terminal Arguments Pattern</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../icons.qrc">
+          <normaloff>:/icons/images/newlook24/087-update.png</normaloff>:/icons/images/newlook24/087-update.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelTerminal">
+        <property name="text">
+         <string>Terminal</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelCmdPreview">
+        <property name="text">
+         <string>Cmd. preview</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="labelCmdPreviewResult">
         <property name="text">
          <string>term -e sh -c &quot;echo hello; sleep 3&quot;</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pbMinusEAppendArgs">
-        <property name="text">
-         <string>Test</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="rbMinusXAppendArgs">
-        <property name="text">
-         <string>term -x sh -c &quot;echo hello; sleep 3&quot;</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="2">
-       <widget class="QPushButton" name="pbMinusXAppendArgs">
-        <property name="text">
-         <string>Test</string>
+       <widget class="QToolButton" name="btnTest">
+        <property name="toolTip">
+         <string>Test Command</string>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QRadioButton" name="rbMinusMinusAppendArgs">
         <property name="text">
-         <string>term -- sh -c &quot;echo hello; sleep 3&quot;</string>
+         <string>...</string>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="pbMinusMinusAppendArgs">
-        <property name="text">
-         <string>Test</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QRadioButton" name="rbMinusEAppendCommandLine">
-        <property name="text">
-         <string>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QPushButton" name="pbMinusEAppendCommandLine">
-        <property name="text">
-         <string>Test</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QRadioButton" name="rbWriteCommandLineToTempFileThenTempFilename">
-        <property name="text">
-         <string>term /tmp/redpanda_XXXXXX.command</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <widget class="QPushButton" name="pbWriteCommandLineToTempFileThenTempFilename">
-        <property name="text">
-         <string>Test</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="3">
-       <widget class="QLabel" name="lExpectedBahavior0">
-        <property name="text">
-         <string>On clicking “Test” for the correct pattern, the terminal emulator</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0" colspan="3">
-       <widget class="QLabel" name="lExpectedBahavior1">
-        <property name="text">
-         <string>• pops up;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0" colspan="3">
-       <widget class="QLabel" name="lExpectedBahavior2">
-        <property name="text">
-         <string>• shows “hello”; and</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0" colspan="3">
-       <widget class="QLabel" name="lExpectedBahavior3">
-        <property name="text">
-         <string>• quits in 3 seconds.</string>
+        <property name="icon">
+         <iconset resource="../icons.qrc">
+          <normaloff>:/icons/images/newlook24/069-run.png</normaloff>:/icons/images/newlook24/069-run.png</iconset>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
@@ -1959,51 +1959,31 @@
         <translation>Todos os arquivos (%1)</translation>
     </message>
     <message>
-        <source>Terminal emulator arguments pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Test</source>
-        <translation type="unfinished">Testar</translation>
-    </message>
-    <message>
         <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
+        <source>Auto Detect Terminal Arguments Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
+        <source>Test Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
+        <source>$term -e $argv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
+        <source>Use custom terminal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>• pops up;</source>
+        <source>Args. pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>• shows “hello”; and</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>• quits in 3 seconds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>term /tmp/redpanda_XXXXXX.command</source>
+        <source>Cmd. preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7075,6 +7055,14 @@
     </message>
     <message>
         <source>Replaces lcall/ljmp with acall/ajmp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Detection Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to detect terminal arguments pattern for “%1”.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
@@ -2670,103 +2670,74 @@ Are you really want to continue?</oldsource>
         <source>Editors share one code parser</source>
         <translation>编辑器共享同一个代码分析器</translation>
     </message>
-</context>
-<context>
-    <name>EnvironmentProgramsWidget</name>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="14"/>
-        <source>Form</source>
-        <translation>表单</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="23"/>
-        <source>...</source>
-        <translation>...</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="34"/>
-        <source>Terminal</source>
-        <translation>终端</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="41"/>
-        <source>Terminal emulator arguments pattern</source>
-        <translation>终端模拟器参数模式</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="54"/>
-        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="74"/>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="95"/>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="116"/>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="137"/>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="158"/>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="179"/>
-        <source>Test</source>
-        <translation>测试</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="88"/>
-        <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="109"/>
-        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="130"/>
-        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="151"/>
-        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="172"/>
-        <source>term /tmp/redpanda_XXXXXX.command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="186"/>
-        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
-        <translation>点击正确的模式对应的 “测试” 按钮，终端模拟器将会</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="193"/>
-        <source>• pops up;</source>
-        <translation>• 弹出；</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="200"/>
-        <source>• shows “hello”; and</source>
-        <translation>• 显示 “hello”；</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.ui" line="207"/>
-        <source>• quits in 3 seconds.</source>
-        <translation>• 并在 3 秒后关闭。</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="109"/>
-        <source>Choose Terminal Program</source>
-        <translation>选择终端程序</translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="59"/>
-        <source>All files (%1)</source>
-        <translation>所有文件 (%1)</translation>
-    </message>
-    <message>
-        <source>All files (*.*)</source>
-        <translation type="vanished">所有文件 (*.*)</translation>
-    </message>
+</context><context>
+<name>EnvironmentProgramsWidget</name>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="14"/>
+    <source>Form</source>
+    <translation>表单</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="20"/>
+    <source>Use custom terminal</source>
+    <translation>使用自定义终端</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="49"/>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="63"/>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="98"/>
+    <source>...</source>
+    <translation>...</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="81"/>
+    <source>Cmd. preview</source>
+    <translation>命令行预览</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="60"/>
+    <source>Auto Detect Terminal Arguments Pattern</source>
+    <translation>自动检测终端参数模式</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="74"/>
+    <source>Terminal</source>
+    <translation>终端</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="95"/>
+    <source>Test Command</source>
+    <translation>测试命令</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="35"/>
+    <source>$term -e $argv</source>
+    <translation type="unfinished"></translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="42"/>
+    <source>Args. pattern</source>
+    <translation>参数模式</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.ui" line="88"/>
+    <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
+    <translation type="unfinished"></translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.cpp" line="108"/>
+    <source>Choose Terminal Program</source>
+    <translation>选择终端程序</translation>
+</message>
+<message>
+    <location filename="../settingsdialog/environmentprogramswidget.cpp" line="110"/>
+    <source>All files (%1)</source>
+    <translation>所有文件 (%1)</translation>
+</message>
+<message>
+    <source>All files (*.*)</source>
+    <translation type="vanished">所有文件 (*.*)</translation>
+</message>
 </context>
 <context>
     <name>EnvironmentShortcutModel</name>
@@ -9632,6 +9603,16 @@ Are you really want to continue?</oldsource>
         <location filename="../problems/freeprojectsetformat.cpp" line="188"/>
         <source>Error when writing file &quot;%1&quot;.</source>
         <translation>在写入文件“%1”时出错。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="74"/>
+        <source>Auto Detection Failed</source>
+        <translation>自动检测失败</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="75"/>
+        <source>Failed to detect terminal arguments pattern for “%1”.</source>
+        <translation>无法检测适用于 “%1” 的终端参数模式。</translation>
     </message>
 </context>
 <context>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
@@ -1792,51 +1792,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Terminal emulator arguments pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sh -c &quot;echo hello; sleep 3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Test</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>term -e sh -c &quot;echo hello; sleep 3&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -x sh -c &quot;echo hello; sleep 3&quot;</source>
+        <source>Auto Detect Terminal Arguments Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -- sh -c &quot;echo hello; sleep 3&quot;</source>
+        <source>Test Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>term -e &quot;sh -c \&quot;echo hello; sleep 3\&quot;&quot;</source>
+        <source>$term -e $argv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>On clicking “Test” for the correct pattern, the terminal emulator</source>
+        <source>Use custom terminal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>• pops up;</source>
+        <source>Args. pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>• shows “hello”; and</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>• quits in 3 seconds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>term /tmp/redpanda_XXXXXX.command</source>
+        <source>Cmd. preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6600,6 +6580,14 @@
     </message>
     <message>
         <source>Replaces lcall/ljmp with acall/ajmp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Detection Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to detect terminal arguments pattern for “%1”.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/RedPandaIDE/utils.h
+++ b/RedPandaIDE/utils.h
@@ -121,16 +121,6 @@ enum class UnixExecSemantics {
     SearchInPath,
 };
 
-enum class TerminalEmulatorArgumentsPattern {
-    ImplicitSystem = 0,      //          bash -c  "echo hello, world; sleep 3"
-    MinusEAppendArgs,        // term -e  bash -c  "echo hello, world; sleep 3"   # xterm-compatible
-    MinusXAppendArgs,        // term -x  bash -c  "echo hello, world; sleep 3"   # some VTE-based
-    MinusMinusAppendArgs,    // term --  bash -c  "echo hello, world; sleep 3"   # gnome-terminal, kgx
-    MinusEAppendCommandLine, // term -e "bash -c \"echo hello, world; sleep 3\"" # some lightweighted; alternative form for VTE-based
-
-    WriteCommandLineToTempFileThenTempFilename = 6226700, // macOS Terminal.app and iTerm2.app; 6226700 is how you dial “macOS00”
-};
-
 FileType getFileType(const QString& filename);
 QStringList splitProcessCommand(const QString& cmd);
 
@@ -189,7 +179,10 @@ QStringList getExecutableSearchPaths();
 
 QString escapeArgument(const QString &arg, bool isFirstArg);
 
-auto wrapCommandForTerminalEmulator(const QString &terminal, const TerminalEmulatorArgumentsPattern &argsPattern, const QStringList &argsWithArgv0)
+auto wrapCommandForTerminalEmulator(const QString &terminal, const QStringList &argsPattern, const QStringList &payloadArgsWithArgv0)
+    -> std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>>;
+
+auto wrapCommandForTerminalEmulator(const QString &terminal, const QString &argsPattern, const QStringList &payloadArgsWithArgv0)
     -> std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>>;
 
 QString defaultShell();


### PR DESCRIPTION
- custom terminal on Windows now require explicit enablement
- customizable terminal arguments pattern and its auto detection
- move hard-coded terminals to resource files