### PR TITLE
Terminal arguments fix and cleanup

### DIFF
--- a/RedPandaIDE/compiler/compilermanager.cpp
+++ b/RedPandaIDE/compiler/compilermanager.cpp
@@ -325,7 +325,7 @@ void CompilerManager::run(
             } + splitProcessCommand(arguments);
         }
         auto [filename, args, fileOwner] = wrapCommandForTerminalEmulator(
-            pSettings->environment().terminalPathForExec(),
+            pSettings->environment().terminalPath(),
             pSettings->environment().terminalArgumentsPattern(),
             execArgs
         );

--- a/RedPandaIDE/debugger.cpp
+++ b/RedPandaIDE/debugger.cpp
@@ -3068,7 +3068,7 @@ void DebugTarget::run()
     cmd= mGDBServer;
     arguments = QString(" localhost:%1 \"%2\" %3").arg(mPort).arg(mInferior,mArguments);
 #else
-    cmd= pSettings->environment().terminalPathForExec();
+    cmd= pSettings->environment().terminalPath();
     arguments = QString(" -e \"%1\" localhost:%2 \"%3\"").arg(mGDBServer).arg(mPort).arg(mInferior);
 #endif
     QString workingDir = QFileInfo(mInferior).path();

--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4680,7 +4680,7 @@ void MainWindow::onFilesViewOpenInTerminal()
 #ifdef Q_OS_WIN
         openShell(fileInfo.path(),"cmd.exe",getDefaultCompilerSetBinDirs());
 #else
-        openShell(fileInfo.path(),pSettings->environment().terminalPathForExec(),getDefaultCompilerSetBinDirs());
+        openShell(fileInfo.path(),pSettings->environment().terminalPath(),getDefaultCompilerSetBinDirs());
 #endif
     }
 }
@@ -6888,7 +6888,7 @@ void MainWindow::on_actionOpen_Terminal_triggered()
 #ifdef Q_OS_WIN
             openShell(info.path(),"cmd.exe",getBinDirsForCurrentEditor());
 #else
-            openShell(info.path(),pSettings->environment().terminalPathForExec(),getBinDirsForCurrentEditor());
+            openShell(info.path(),pSettings->environment().terminalPath(),getBinDirsForCurrentEditor());
 #endif
         }
     }
@@ -7225,7 +7225,7 @@ void MainWindow::on_actionProject_Open_In_Terminal_triggered()
 #ifdef Q_OS_WIN
     openShell(mProject->directory(),"cmd.exe",mProject->binDirs());
 #else
-    openShell(mProject->directory(),pSettings->environment().terminalPathForExec(),mProject->binDirs());
+    openShell(mProject->directory(),pSettings->environment().terminalPath(),mProject->binDirs());
 #endif
 }
 

--- a/RedPandaIDE/resources/terminal-unix.json
+++ b/RedPandaIDE/resources/terminal-unix.json
@@ -126,16 +126,6 @@
         ]
     },
     {
-        "group": "Bundled",
-        "terminals": [
-            {
-                "name": "Alacritty (Bundled)",
-                "path": "./alacritty",
-                "argsPattern": "$term -e $argv"
-            }
-        ]
-    },
-    {
         "group": "With minor issue",
         "terminals": [
             {

--- a/RedPandaIDE/resources/terminal-windows.json
+++ b/RedPandaIDE/resources/terminal-windows.json
@@ -1,10 +1,11 @@
 [
     {
         "group": "Bundled",
+        "comment": "Use `%*APP_DIR*%` in path for application directory.",
         "terminals": [
             {
                 "name": "UTF-8 compatible Console Host",
-                "path": "%*APP_DIR*%/OpenConsole.exe",
+                "path": "OpenConsole.exe",
                 "argsPattern": "$term -- $argv"
             }
         ]

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -3628,7 +3628,11 @@ void Settings::Environment::doLoad()
 
     // check saved terminal path
     mTerminalPath = stringValue("terminal_path", "");
+#ifdef Q_OS_WINDOWS
+    // APP_DIR trick for windows portable app
+    // on other platforms multiple instances share the same configuration and thus the trick may break terminal path
     mTerminalPath.replace("%*APP_DIR*%",pSettings->dirs().appDir());
+#endif
     mTerminalArgumentsPattern = stringValue("terminal_arguments_pattern", "");
 
     checkAndSetTerminal();
@@ -3902,9 +3906,13 @@ void Settings::Environment::doSave()
     saveValue("current_folder",mCurrentFolder);
     saveValue("default_open_folder",mDefaultOpenFolder);
     QString terminalPath = mTerminalPath;
+#ifdef Q_OS_WINDOWS
+    // APP_DIR trick for windows portable app
+    // on other platforms multiple instances share the same configuration and thus the trick may break terminal path
     if (terminalPath.startsWith(pSettings->dirs().appDir())) {
         terminalPath="%*APP_DIR*%"+terminalPath.mid(pSettings->dirs().appDir().length());
     }
+#endif
 
     saveValue("terminal_path",terminalPath);
     saveValue("terminal_arguments_pattern",mTerminalArgumentsPattern);

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -3808,6 +3808,7 @@ void Settings::Environment::checkAndSetTerminal()
             if(fileExists(absoluteTerminalPath)) {
                 mTerminalPath = absoluteTerminalPath;
                 mTerminalArgumentsPattern = termItem.param;
+                return;
             }
         } else {
             for (const QString &dirPath: pathList) {
@@ -3816,7 +3817,7 @@ void Settings::Environment::checkAndSetTerminal()
                 if(fileExists(absoluteTerminalPath)) {
                     mTerminalPath = absoluteTerminalPath;
                     mTerminalArgumentsPattern = termItem.param;
-                    break;
+                    return;
                 }
             }
         }

--- a/packages/appimage/01-in-docker.sh
+++ b/packages/appimage/01-in-docker.sh
@@ -24,9 +24,6 @@ ln -s usr/share/icons/hicolor/scalable/apps/redpandaide.svg redpandaide.svg
 install -m755 /build/RedPanda-CPP/packages/appimage/AppRun.sh AppRun
 install -m644 /build/RedPanda-CPP/platform/linux/redpandaide.png .DirIcon
 
-# copy dependency
-cp /usr/local/bin/alacritty usr/bin
-
 # create AppImage
 cd /build
 mksquashfs RedPandaIDE.AppDir $APPIMAGE_FILE -offset $RUNTIME_SIZE -comp zstd -root-owned -noappend -b 1M -mkfs-time 0

--- a/packages/appimage/dockerfile-aarch64/Dockerfile
+++ b/packages/appimage/dockerfile-aarch64/Dockerfile
@@ -86,19 +86,3 @@ RUN mkdir -p /build/qt5 && \
     # cleanup
     cd / && \
     rm -r /build/qt5
-
-# Alacritty
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.71.1 && \
-    . ~/.cargo/env && \
-    mkdir -p /build/alacritty && \
-    cd /build/alacritty && \
-    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
-    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
-    cd alacritty-${ALACRITTY_VERSION} && \
-    echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
-    cargo build --profile minsize && \
-    cp target/minsize/alacritty /usr/local/bin && \
-    # cleanup
-    cd / && \
-    rm -r /build/alacritty && \
-    rustup self uninstall -y

--- a/packages/appimage/dockerfile-riscv64/Dockerfile
+++ b/packages/appimage/dockerfile-riscv64/Dockerfile
@@ -68,19 +68,3 @@ RUN mkdir -p /build/qt5 && \
     # cleanup
     cd / && \
     rm -r /build/qt5
-
-# Alacritty
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.71.1 && \
-    . ~/.cargo/env && \
-    mkdir -p /build/alacritty && \
-    cd /build/alacritty && \
-    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
-    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
-    cd alacritty-${ALACRITTY_VERSION} && \
-    /bin/echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
-    cargo build --profile minsize && \
-    cp target/minsize/alacritty /usr/local/bin && \
-    # cleanup
-    cd / && \
-    rm -r /build/alacritty && \
-    rustup self uninstall -y

--- a/packages/appimage/dockerfile-x86_64/Dockerfile
+++ b/packages/appimage/dockerfile-x86_64/Dockerfile
@@ -83,20 +83,3 @@ RUN mkdir -p /build/qt5 && \
     # cleanup
     cd / && \
     rm -r /build/qt5
-
-# Alacritty
-RUN yum install -y cargo && \
-    mkdir -p /build/alacritty && \
-    cd /build/alacritty && \
-    curl -L -o alacritty-${ALACRITTY_VERSION}.tar.gz "https://github.com/alacritty/alacritty/archive/refs/tags/v${ALACRITTY_VERSION}.tar.gz" && \
-    tar xf alacritty-${ALACRITTY_VERSION}.tar.gz && \
-    cd alacritty-${ALACRITTY_VERSION} && \
-    echo -e '[profile.minsize]\ninherits="release"\ndebug=false\nstrip=true\nopt-level="s"' >>Cargo.toml && \
-    cargo build --profile minsize && \
-    cp target/minsize/alacritty /usr/local/bin && \
-    # cleanup
-    cd / && \
-    rm -r /build/alacritty && \
-    yum autoremove -y cargo && \
-    yum clean all && \
-    rm -r ~/.cargo


### PR DESCRIPTION
- Fix some build error and logic error.
- Remove Alacritty from AppImage.
  - Alacritty was added to AppImage as a fallback terminal.
  - Now that we support almost all popular terminals for Linux, a fallback terminal is no longer required.
- Limit `%*APP_DIR*%` trick to Windows.
  - Multiple editions on Linux/macOS shares the same configuration file, and APP_DIR is not reliable.
- Implement Windows search path following `CreateProcessW`.