### PR TITLE
Fix ibus focus losing behavior

### DIFF
--- a/RedPandaIDE/widgets/codecompletionpopup.cpp
+++ b/RedPandaIDE/widgets/codecompletionpopup.cpp
@@ -48,6 +48,7 @@ CodeCompletionPopup::CodeCompletionPopup(QWidget *parent) :
     setLayout(new QVBoxLayout());
     layout()->addWidget(mListView);
     layout()->setMargin(0);
+    mListView->setFocus();
 
     mShowKeywords=true;
     mRecordUsage = false;
@@ -1109,11 +1110,6 @@ void CodeCompletionPopup::setColors(const std::shared_ptr<QHash<StatementKind, s
 const QString &CodeCompletionPopup::memberPhrase() const
 {
     return mMemberPhrase;
-}
-
-void CodeCompletionPopup::showEvent(QShowEvent *)
-{
-    mListView->setFocus();
 }
 
 const PStatement &CodeCompletionPopup::currentScope() const

--- a/RedPandaIDE/widgets/codecompletionpopup.h
+++ b/RedPandaIDE/widgets/codecompletionpopup.h
@@ -194,7 +194,6 @@ private:
 
     // QWidget interface
 protected:
-    void showEvent(QShowEvent *event) override;
     void hideEvent(QHideEvent *event) override;
 
     // QObject interface


### PR DESCRIPTION
On ibus committing a string:
- Red Panda C++ accepts the string and then
- pops up code completion window and
- set focus to `CodeCompletionPopup::mListView`

With the change of focus, ibus commits the preedit string again, which (currently) leads to double lock on a mutex and of course crash, or (if double lock gets fixed) redundant input.

<hr>

Translations for SEO for CJK developers who may encounter similar problems:

当焦点改变时，ibus 再次提交当前的 preedit 内容，导致（当前的实现）重复锁定同一个 mutex 进而崩溃，或者（重复锁定问题修复后）重复输入。

フォーカスが変更されると、ibus はプリエディット文字列を再度コミットします。これにより、(現時点では) ミューテックスが二重ロックされ、当然クラッシュするか、(二重ロックが修正された場合は) 冗長入力が発生します。

포커스가 변경되면 ibus는 사전 편집 문자열을 다시 커밋합니다. 이로 인해 (현재) 뮤텍스에 대한 이중 잠금이 발생하고 물론 충돌이 발생하거나 (이중 잠금이 수정된 경우) 중복 입력이 발생합니다.