### PR TITLE
Add Qt 5.6 and Windows XP support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,6 +4,8 @@
 
 # Windows
 
+For Windows 7 or later:
+
 | Library + Toolchain \ Target | x86 | x64 | ARM64 |
 | ---------------------------- | --- | --- | ----- |
 | MSYS2 + GNU-based MinGW | ✔️ | ✔️ | ❌ |
@@ -18,6 +20,19 @@ Notes for Windows on ARM:
   - ARM64EC does not bring significant benefit, since Red Panda C++ can be built to ARM64 classic ABI.
   - However, ARM64EC will allow users to use their favorite input methods, fancy Qt styles.
 - With the [ARM32 deprecation in Windows 11 Insider Preview Build 25905](https://blogs.windows.com/windows-insider/2023/07/12/announcing-windows-11-insider-preview-build-25905/), ARM32 support will never be added.
+
+For legacy Windows (NT 5.1 – 6.0):
+
+| Library + Toolchain \ Target | x86 | x64 |
+| ---------------------------- | --- | --- |
+| Qt.io Qt 5.6 + MinGW GCC 8.1.0 | ✔️ | ❌ |
+| Qt 5.6 from source + MinGW | ✔️ | ✔️ |
+
+Notes for legacy Windows:
+- Supported Windows versions:
+  - Windows XP SP3 or later;
+  - Windows Server 2003 x64 Edition (a.k.a. Windows XP x64 Edition) SP2 or later.
+- Red Panda C++ uses [MinHook](https://github.com/TsudaKageyu/minhook) to hook Win32 `CreateProcessW` to implement missing `QProcess` APIs.
 
 ## MSYS2 Qt Library with MinGW Toolchain (Recommended)
 
@@ -197,6 +212,16 @@ To build with VS 2017 or later in Command Prompt:
    "%JOM%" -j%NUMBER_OF_PROCESSORS%
    "%JOM%" install
    ```
+
+## Legacy Windows
+
+Notes for building:
+- Windows 7 x64 or later required.
+- Here is [a script](packages/windows/build-qt5.6-mingw-static.ps1) for building Qt 5.6 from source alongside official Qt installation (with Qt.io MinGW GCC 8.1.0).
+- Set `NT5_SUPPORT=ON` in make phase. e.g.
+  ```ps1
+  mingw32-make NT5_SUPPORT=ON "-j${Env:NUMBER_OF_PROCESSORS}"
+  ```
 
 # Linux and Other freedesktop.org-conforming (XDG) Desktop Systems
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -4,6 +4,8 @@
 
 # Windows
 
+适用于 Windows 7 或更高版本：
+
 | 库 + 工具链 \ 目标 | x86 | x64 | ARM64 |
 | ------------------ | --- | --- | ----- |
 | MSYS2 + 基于 GNU 的 MinGW | ✔️ | ✔️ | ❌ |
@@ -18,6 +20,19 @@
   - 既然小熊猫 C++ 已经可以构建到 ARM64 经典 ABI，ARM64EC 就不能带来明显的好处。
   - 但是 ARM64EC 可以支持用户习惯的输入法和喜欢的 Qt 样式。
 - 随着 [Windows 11 Insider Preview Build 25905 弃用 ARM32](https://blogs.windows.com/windows-insider/2023/07/12/announcing-windows-11-insider-preview-build-25905/)，小熊猫 C++ 今后也不会添加 ARM32 支持了。
+
+适用于旧版 Windows（NT 5.1 – 6.0）：
+
+| 库 + 工具链 \ 目标 | x86 | x64 |
+| ------------------ | --- | --- |
+| Qt.io Qt 5.6 + MinGW GCC 8.1.0 | ✔️ | ❌ |
+| 从源代码构建的 Qt 5.6 + MinGW | ✔️ | ✔️ |
+
+关于旧版 Windows 的注记：
+- 支持的 Windows 版本：
+  - Windows XP SP3 或更高版本；
+  - Windows Server 2003 x64 Edition（也叫 Windows XP x64 Edition）SP2 或更高版本。
+- 小熊猫 C++ 借助 [MinHook](https://github.com/TsudaKageyu/minhook) 对 Win32 `CreateProcessW` 附加挂钩来实现 `QProcess` 缺失的 API。
 
 ## MSYS2 的 Qt 库 + MinGW 工具链（推荐）
 
@@ -197,6 +212,16 @@
    "%JOM%" -j%NUMBER_OF_PROCESSORS%
    "%JOM%" install
    ```
+
+## 旧版 Windows
+
+关于构建的注记：
+- 需要 Windows 7 x64 或更高版本。
+- 从源代码构建 Qt 5.6 并与官方 Qt 安装共存可参考[这个脚本](packages/windows/build-qt5.6-mingw-static.ps1)（使用 Qt.io MinGW GCC 8.1.0）。
+- 在 make 阶段设置变量 `NT5_SUPPORT=ON`，如
+  ```ps1
+  mingw32-make NT5_SUPPORT=ON "-j${Env:NUMBER_OF_PROCESSORS}"
+  ```
 
 # Linux 和其他符合 freedesktop.org（XDG）规范的桌面系统
 

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -1,6 +1,7 @@
 QT       += core gui printsupport network svg xml widgets
 
-CONFIG += c++17
+# without `c++14` old versions of qmake will explicitly set `-std=gnu++98`
+CONFIG += c++14 c++17
 CONFIG += nokey
 
 # uncomment the following line to enable vcs (git) support
@@ -88,6 +89,9 @@ LIBS += $$OUT_PWD/../libs/qsynedit/$${OBJ_OUT_PWD}qsynedit.lib \
         $$OUT_PWD/../libs/redpanda_qt_utils/$${OBJ_OUT_PWD}redpanda_qt_utils.lib
 LIBS += advapi32.lib user32.lib
 }
+
+# `Compat::QProcess_::setCreateProcessArgumentsModifier` hooks `CreateProcessW`
+win32:equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 7): LIBS += -lMinHook
 
 SOURCES += \
     autolinkmanager.cpp \

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -45,9 +45,16 @@ isEmpty(LIBEXECDIR) {
     LIBEXECDIR = $${PREFIX}/libexec
 }
 
-# windows 7 is the minimum windows version
+_NT5_SUPPORT = $$(NT5_SUPPORT)
 win32: {
-DEFINES += _WIN32_WINNT=0x0601
+    equals(_NT5_SUPPORT, "ON") {
+        contains(QMAKE_HOST.arch, x86_64): DEFINES += _WIN32_WINNT=0x0502
+        else: DEFINES += _WIN32_WINNT=0x0501
+        LIBS += -lpsapi  # GetModuleFileNameEx, GetProcessMemoryInfo
+    } else {
+        # defaults to Windows 7 NT 6.1
+        DEFINES += _WIN32_WINNT=0x0601
+    }
 }
 
 DEFINES += PREFIX=\\\"$${PREFIX}\\\"

--- a/RedPandaIDE/compiler/compiler.cpp
+++ b/RedPandaIDE/compiler/compiler.cpp
@@ -81,7 +81,7 @@ void Compiler::run()
         log(tr("- Warnings: %1").arg(mWarningCount));
         if (!mOutputFile.isEmpty()) {
             log(tr("- Output Filename: %1").arg(mOutputFile));
-            QLocale locale = QLocale::system();
+            Compat::QLocale_ locale = QLocale::system();
             log(tr("- Output Size: %1").arg(locale.formattedDataSize(QFileInfo(mOutputFile).size())));
         }
         log(tr("- Compilation Time: %1 secs").arg(timer.elapsed() / 1000.0));

--- a/RedPandaIDE/compiler/compilermanager.cpp
+++ b/RedPandaIDE/compiler/compilermanager.cpp
@@ -289,7 +289,7 @@ void CompilerManager::run(
         }
 #else
         QStringList execArgs;
-        QString sharedMemoryId = "/r"+QUuid::createUuid().toString(QUuid::StringFormat::Id128);
+        QString sharedMemoryId = "/r" + Compat::QUuid_::createUuid().toString(Compat::QUuid_::Id128);
 #ifdef Q_OS_MACOS
         sharedMemoryId = sharedMemoryId.mid(0, PSHMNAMLEN);
 #endif

--- a/RedPandaIDE/compiler/executablerunner.cpp
+++ b/RedPandaIDE/compiler/executablerunner.cpp
@@ -108,7 +108,7 @@ void ExecutableRunner::run()
     mStop = false;
     bool errorOccurred = false;
 
-    mProcess = std::make_shared<QProcess>();
+    mProcess = std::make_shared<Compat::QProcess_>();
     mProcess->setProgram(mFilename);
     mProcess->setArguments(mArguments);
     //qDebug()<<splitProcessCommand(mArguments);
@@ -129,7 +129,7 @@ void ExecutableRunner::run()
         errorOccurred= true;
     });
 #ifdef Q_OS_WIN
-    mProcess->setCreateProcessArgumentsModifier([this](QProcess::CreateProcessArguments * args){
+    mProcess->setCreateProcessArgumentsModifier([this](Compat::QProcess_::CreateProcessArguments * args){
         if (mStartConsole) {
             args->flags |=  CREATE_NEW_CONSOLE;
             args->flags &= ~CREATE_NO_WINDOW;

--- a/RedPandaIDE/compiler/executablerunner.h
+++ b/RedPandaIDE/compiler/executablerunner.h
@@ -18,8 +18,10 @@
 #define EXECUTABLERUNNER_H
 
 #include "runner.h"
+#include "qt_utils/compat.h"
 #include <QProcess>
 #include <QSemaphore>
+#include <memory>
 
 class ExecutableRunner : public Runner
 {
@@ -52,7 +54,7 @@ private:
     QString mShareMemoryId;
     bool mRedirectInput;
     bool mStartConsole;
-    std::shared_ptr<QProcess> mProcess;
+    std::shared_ptr<Compat::QProcess_> mProcess;
     QSemaphore mQuitSemaphore;
     QStringList mBinDirs;
 

--- a/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
+++ b/RedPandaIDE/compiler/ojproblemcasesrunner.cpp
@@ -20,7 +20,7 @@
 #include "../systemconsts.h"
 #include <QElapsedTimer>
 #include <QProcess>
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
 #include <psapi.h>
 #endif
 

--- a/RedPandaIDE/debugger.cpp
+++ b/RedPandaIDE/debugger.cpp
@@ -1287,7 +1287,7 @@ void DebugReader::processResultRecord(const QByteArray &line)
                     QStringList newOutput;
                     foreach(const QString& s, disOutput) {
                         QString line = s;
-                        if (!s.isEmpty() && s.front().isDigit()) {
+                        if (!s.isEmpty() && s[0].isDigit()) {
                             QRegularExpressionMatch match = reGdbSourceLine.match(s);
 //                            qDebug()<<s;
                             if (match.hasMatch()) {
@@ -3073,7 +3073,7 @@ void DebugTarget::run()
 #endif
     QString workingDir = QFileInfo(mInferior).path();
 
-    mProcess = std::make_shared<QProcess>();
+    mProcess = std::make_shared<Compat::QProcess_>();
     auto action = finally([&]{
         mProcess.reset();
     });
@@ -3097,7 +3097,7 @@ void DebugTarget::run()
     mProcess->setWorkingDirectory(workingDir);
 
 #ifdef Q_OS_WIN
-    mProcess->setCreateProcessArgumentsModifier([this](QProcess::CreateProcessArguments * args){
+    mProcess->setCreateProcessArgumentsModifier([this](Compat::QProcess_::CreateProcessArguments * args){
         if (programHasConsole(mInferior)) {
             args->flags |=  CREATE_NEW_CONSOLE;
             args->flags &= ~CREATE_NO_WINDOW;

--- a/RedPandaIDE/debugger.h
+++ b/RedPandaIDE/debugger.h
@@ -32,6 +32,7 @@
 #include <QTimer>
 #include <memory>
 #include "gdbmiresultparser.h"
+#include "qt_utils/compat.h"
 
 enum class DebugCommandSource {
     Console,
@@ -447,7 +448,7 @@ private:
     QString mGDBServer;
     int mPort;
     bool mStop;
-    std::shared_ptr<QProcess> mProcess;
+    std::shared_ptr<Compat::QProcess_> mProcess;
     QSemaphore mStartSemaphore;
     bool mErrorOccured;
     QString mInputFile;

--- a/RedPandaIDE/main.cpp
+++ b/RedPandaIDE/main.cpp
@@ -59,6 +59,10 @@ public:
     bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) override;
 };
 
+#ifndef WM_DPICHANGED
+# define WM_DPICHANGED 0x02e0
+#endif
+
 #define WM_APP_OPEN_FILE (WM_APP + 6736 /* “OPEN” on dial pad */)
 static_assert(WM_APP_OPEN_FILE < 0xc000);
 

--- a/RedPandaIDE/main.cpp
+++ b/RedPandaIDE/main.cpp
@@ -28,6 +28,7 @@
 #include <QDesktopWidget>
 #include <QDir>
 #include <QScreen>
+#include <QLockFile>
 #include "common.h"
 #include "colorscheme.h"
 #include "iconsmanager.h"
@@ -58,7 +59,9 @@ public:
     bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) override;
 };
 
-#define WM_USER_OPEN_FILE (WM_USER+1)
+#define WM_APP_OPEN_FILE (WM_APP + 6736 /* “OPEN” on dial pad */)
+static_assert(WM_APP_OPEN_FILE < 0xc000);
+
 HWND prevAppInstance = NULL;
 BOOL CALLBACK GetPreviousInstanceCallback(HWND hwnd, LPARAM param){
     BOOL result = TRUE;
@@ -144,7 +147,7 @@ bool WindowLogoutEventFilter::nativeEventFilter(const QByteArray & /*eventType*/
         }
         break;
         }
-    case WM_USER_OPEN_FILE: {
+    case WM_APP_OPEN_FILE: {
         QSharedMemory sharedMemory("RedPandaCpp/openfiles");
         if (sharedMemory.attach()) {
             QBuffer buffer;
@@ -184,7 +187,7 @@ bool sendFilesToInstance() {
             const char *from = buffer.data().data();
             memcpy(to, from, qMin(sharedMemory.size(), size));
             sharedMemory.unlock();
-            SendMessage(prevInstance,WM_USER_OPEN_FILE,0,0);
+            SendMessage(prevInstance,WM_APP_OPEN_FILE,0,0);
             return true;
         }
     }
@@ -243,7 +246,7 @@ void setTheme(const QString& theme) {
 
 int main(int argc, char *argv[])
 {
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     // Make title bar and palette follow system-wide dark mode setting on recent Windows releases.
     // Use freetype as the fontengine
     qputenv("QT_QPA_PLATFORM", "windows:darkmode=2:fontengine=freetype");
@@ -270,7 +273,7 @@ int main(int argc, char *argv[])
 
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-    QFile tempFile(QDir::tempPath()+QDir::separator()+"RedPandaDevCppStartUp.lock");
+    QLockFile lockFile(QDir::tempPath()+QDir::separator()+"RedPandaDevCppStartUp.lock");
     {
         bool firstRun;
         QString settingFilename = getSettingFilename(QString(), firstRun);
@@ -288,9 +291,8 @@ int main(int argc, char *argv[])
         if (openInSingleInstance) {
             int openCount = 0;
             while (true) {
-                if (tempFile.open(QFile::NewOnly))
+                if (lockFile.tryLock(100))
                     break;
-                QThread::msleep(100);
                 openCount++;
                 if (openCount>100)
                     break;
@@ -299,7 +301,7 @@ int main(int argc, char *argv[])
             if (app.arguments().length()>=2 && openCount<100) {
 #ifdef Q_OS_WIN
                 if (sendFilesToInstance()) {
-                    tempFile.remove();
+                    lockFile.unlock();
                     return 0;
                 }
 #endif
@@ -314,7 +316,7 @@ int main(int argc, char *argv[])
         QDir::setCurrent(QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation)[0]);
     }
     if (settingFilename.isEmpty()) {
-        tempFile.remove();
+        lockFile.unlock();
         return -1;
     }
     QString language;
@@ -360,7 +362,7 @@ int main(int argc, char *argv[])
         if (firstRun) {
             //set theme
             ChooseThemeDialog themeDialog;
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
             // Qt's default style on Windows is not good.
             themeDialog.hideAutoFollowSystemTheme();
 #endif
@@ -433,9 +435,8 @@ int main(int argc, char *argv[])
         WindowLogoutEventFilter filter;
         app.installNativeEventFilter(&filter);
 #endif
-        if (tempFile.isOpen()) {
-            tempFile.close();
-            tempFile.remove();
+        if (lockFile.isLocked()) {
+            lockFile.unlock();
         }
 
         int retCode = app.exec();
@@ -448,7 +449,7 @@ int main(int argc, char *argv[])
         }
         return retCode;
     }  catch (BaseError e) {
-        tempFile.remove();
+        lockFile.unlock();
         QMessageBox::critical(nullptr,QApplication::tr("Error"),e.reason());
         return -1;
     }

--- a/RedPandaIDE/parser/cppparser.h
+++ b/RedPandaIDE/parser/cppparser.h
@@ -24,6 +24,7 @@
 #include "statementmodel.h"
 #include "cpptokenizer.h"
 #include "cpppreprocessor.h"
+#include "qt_utils/compat.h"
 
 class CppParser : public QObject
 {
@@ -386,7 +387,7 @@ private:
 
     QString findFunctionPointerName(int startIdx);
     bool isIdentifier(const QString& token) const {
-        return (!token.isEmpty() && isIdentChar(token.front())
+        return (!token.isEmpty() && isIdentChar(token[0])
                 && !token.contains('\"'));
     }
 
@@ -406,13 +407,13 @@ private:
     bool isIntegerLiteral(const QString& token) const {
         if (token.isEmpty())
             return false;
-        QChar ch = token.front();
+        QChar ch = token[0];
         return (ch>='0' && ch<='9' && !token.contains(".") && !token.contains("e"));
     }
     bool isFloatLiteral(const QString& token) const {
         if (token.isEmpty())
             return false;
-        QChar ch = token.front();
+        QChar ch = token[0];
         return (ch>='0' && ch<='9' && (token.contains(".") || token.contains("e")));
     }
     bool isStringLiteral(const QString& token) const {
@@ -561,6 +562,14 @@ private:
                 || ch == '_';
     }
 
+    bool startsWithIdentChar(const QString &s) const {
+        return isIdentChar(s[0]);
+    }
+
+    bool endsWithIdentChar(const QString &s) const {
+        return isIdentChar(*s.rbegin());
+    }
+
     bool isDigitChar(const QChar& ch) const {
         return (ch>='0' && ch<='9');
     }
@@ -608,6 +617,10 @@ private:
         default:
             return false;
         }
+    }
+
+    bool startsWithBlockChar(const QString &s) const {
+        return isblockChar(s[0]);
     }
 
     /* '#', ',', ';', ':', '{', '}', '!', '/', '+', '-', '<', '>' */

--- a/RedPandaIDE/parser/cpppreprocessor.cpp
+++ b/RedPandaIDE/parser/cpppreprocessor.cpp
@@ -326,7 +326,7 @@ QString CppPreprocessor::getNextPreprocessor()
     QString result;
     for (int i=preProcFrom;i<=preProcTo;i++) {
         if (mBuffer[i].endsWith('\\')) {
-            result+=mBuffer[i].leftRef(mBuffer[i].size()-1)+' ';
+            result+=mBuffer[i].left(mBuffer[i].size()-1)+' ';
         } else {
             result+=mBuffer[i]+' ';
         }

--- a/RedPandaIDE/parser/parserutils.h
+++ b/RedPandaIDE/parser/parserutils.h
@@ -21,6 +21,8 @@
 #include <QSet>
 #include <QVector>
 #include <memory>
+#include <functional>
+#include "qt_utils/compat.h"
 
 using GetFileStreamCallBack = std::function<bool (const QString&, QStringList&)>;
 
@@ -160,7 +162,7 @@ enum StatementProperty {
     spDummyStatement     =  0x0400
 };
 
-Q_DECLARE_FLAGS(StatementProperties, StatementProperty)
+using StatementProperties = Compat::QFlags_<StatementProperty>;
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(StatementProperties)
 

--- a/RedPandaIDE/project.cpp
+++ b/RedPandaIDE/project.cpp
@@ -2693,12 +2693,12 @@ Qt::ItemFlags ProjectModel::flags(const QModelIndex &index) const
     if (p==mProject->rootNode().get())
         return Qt::ItemIsEnabled | Qt::ItemIsDropEnabled | Qt::ItemIsEditable;
     if (mProject && mProject->modelType() == ProjectModelType::FileSystem) {
-        Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+        Compat::QFlags_<Qt::ItemFlag> flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
         if (p->isUnit)
             flags.setFlag(Qt::ItemIsEditable);
         return flags;
     } else {
-        Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
+        Compat::QFlags_<Qt::ItemFlag> flags = Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
         if (!p->isUnit) {
             flags.setFlag(Qt::ItemIsDropEnabled);
             flags.setFlag(Qt::ItemIsDragEnabled,false);

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -3621,7 +3621,7 @@ void Settings::Environment::doLoad()
         mDefaultOpenFolder = QDir::currentPath();
     }
 
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
 # if defined (__aarch64__) || defined(_M_ARM64) || defined (_M_ARM64EC)
     // the only native MinGW toolchain (LLVM-MinGW) does not have local codepage support
     // prefer UTF-8 compatible OpenConsole.exe
@@ -3635,7 +3635,7 @@ void Settings::Environment::doLoad()
 
     // check saved terminal path
     mTerminalPath = stringValue("terminal_path", "");
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     // APP_DIR trick for windows portable app
     // on other platforms multiple instances share the same configuration and thus the trick may break terminal path
     mTerminalPath.replace("%*APP_DIR*%",pSettings->dirs().appDir());
@@ -3838,7 +3838,7 @@ void Settings::Environment::checkAndSetTerminal()
 
 QList<Settings::Environment::TerminalItem> Settings::Environment::loadTerminalList() const
 {
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     QString terminalListFilename(":/config/terminal-windows.json");
 #else // UNIX
     QString terminalListFilename(":/config/terminal-unix.json");
@@ -3914,7 +3914,7 @@ void Settings::Environment::doSave()
     saveValue("current_folder",mCurrentFolder);
     saveValue("default_open_folder",mDefaultOpenFolder);
     QString terminalPath = mTerminalPath;
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     // APP_DIR trick for windows portable app
     // on other platforms multiple instances share the same configuration and thus the trick may break terminal path
     if (terminalPath.startsWith(pSettings->dirs().appDir())) {
@@ -3924,7 +3924,7 @@ void Settings::Environment::doSave()
 
     saveValue("terminal_path",terminalPath);
     saveValue("terminal_arguments_pattern",mTerminalArgumentsPattern);
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     saveValue("use_custom_terminal",mUseCustomTerminal);
 #endif
     saveValue("asyle_path",mAStylePath);

--- a/RedPandaIDE/settingsdialog/editorautosavewidget.cpp
+++ b/RedPandaIDE/settingsdialog/editorautosavewidget.cpp
@@ -38,7 +38,7 @@ void EditorAutoSaveWidget::onAutoSaveStrategyChanged()
         ui->lblFilename->setText(tr("Demo file name: ") + "main.cpp");
     } else if (ui->rbAppendUNIXTimestamp->isChecked()) {
         ui->lblFilename->setText(tr("Demo file name: ") +
-                                 QString("main.%1.cpp").arg(QDateTime::currentSecsSinceEpoch()));
+                                 QString("main.%1.cpp").arg(Compat::QDateTime_::currentSecsSinceEpoch()));
     } else if (ui->rbAppendFormattedTimestamp->isChecked()) {
         QDateTime time = QDateTime::currentDateTime();
         ui->lblFilename->setText(tr("Demo file name: ") +

--- a/RedPandaIDE/settingsdialog/environmentfileassociationwidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentfileassociationwidget.cpp
@@ -156,33 +156,33 @@ bool FileAssociationModel::checkAssociation(const QString &extension, const QStr
     HKEY key;
     LONG result;
 
-    result = RegOpenKeyExA(HKEY_CLASSES_ROOT,extension.toLocal8Bit(),0,KEY_READ,&key);
+    result = RegOpenKeyExW(HKEY_CLASSES_ROOT,extension.toStdWString().c_str(),0,KEY_READ,&key);
     RegCloseKey(key);
     if (result != ERROR_SUCCESS )
         return false;
 
-    result = RegOpenKeyExA(HKEY_CLASSES_ROOT,filetype.toLocal8Bit(),0,KEY_READ,&key);
+    result = RegOpenKeyExW(HKEY_CLASSES_ROOT,filetype.toStdWString().c_str(),0,KEY_READ,&key);
     RegCloseKey(key);
     if (result != ERROR_SUCCESS )
         return false;
 
     QString keyString = QString("%1\\Shell\\%2\\Command").arg(filetype).arg(verb);
     QString value1,value2;
-    if (!readRegistry(HKEY_CLASSES_ROOT,keyString.toLocal8Bit(),"",value1))
+    if (!readRegistry(HKEY_CLASSES_ROOT, keyString, "", value1))
         return false;
-    if (!readRegistry(HKEY_CLASSES_ROOT,extension.toLocal8Bit(),"",value2))
+    if (!readRegistry(HKEY_CLASSES_ROOT, extension, "", value2))
         return false;
 
     return (value2 == filetype)
             && (value1.compare(serverApp,PATH_SENSITIVITY)==0);
 }
 
-bool writeRegistry(HKEY parentKey, const QByteArray& subKey, const QByteArray& value) {
+bool writeRegistry(HKEY parentKey, const QString& subKey, const QString& value) {
     DWORD disposition;
     HKEY key;
-    LONG result = RegCreateKeyExA(
+    LONG result = RegCreateKeyExW(
                 parentKey,
-                subKey,
+                subKey.toStdWString().c_str(),
                 0,
                 NULL,
                 REG_OPTION_NON_VOLATILE,
@@ -190,24 +190,23 @@ bool writeRegistry(HKEY parentKey, const QByteArray& subKey, const QByteArray& v
                 NULL,
                 &key,
                 &disposition);
-    RegCloseKey(key);
     if (result != ERROR_SUCCESS ) {
+        RegCloseKey(key);
         return false;
     }
-    result = RegSetKeyValueA(
-                HKEY_CLASSES_ROOT,
-                subKey,
-                "",
+    result = RegSetValueExW(
+                key,
+                L"",
+                0,
                 REG_SZ,
-                (const BYTE*)value.data(),
-                value.length()+1);
+                (const BYTE*)value.toStdWString().c_str(),
+                (value.length() + 1) * sizeof(wchar_t));
+    RegCloseKey(key);
     return result == ERROR_SUCCESS;
 }
 bool FileAssociationModel::registerAssociation(const QString &extension, const QString &filetype)
 {
-    if (!writeRegistry(HKEY_CLASSES_ROOT,
-                         extension.toLocal8Bit(),
-                         filetype.toLocal8Bit())){
+    if (!writeRegistry(HKEY_CLASSES_ROOT, extension, filetype)){
         return false;
     }
     return true;
@@ -217,47 +216,38 @@ bool FileAssociationModel::unregisterAssociation(const QString &extension)
 {
     LONG result;
     HKEY key;
-    result = RegOpenKeyExA(HKEY_CLASSES_ROOT,extension.toLocal8Bit(),0,KEY_READ,&key);
+    result = RegOpenKeyExW(HKEY_CLASSES_ROOT, extension.toStdWString().c_str(), 0, KEY_READ, &key);
     if (result != ERROR_SUCCESS )
         return true;
     RegCloseKey(key);
 
-    result = RegDeleteTreeA(HKEY_CLASSES_ROOT,extension.toLocal8Bit());
-    return result == ERROR_SUCCESS;
-
+    return deleteRegistryTree(HKEY_CLASSES_ROOT, extension);
 }
 
 bool FileAssociationModel::unregisterFileType(const QString &fileType)
 {
     LONG result;
     HKEY key;
-    result = RegOpenKeyExA(HKEY_CLASSES_ROOT,fileType.toLocal8Bit(),0,KEY_READ,&key);
+    result = RegOpenKeyExW(HKEY_CLASSES_ROOT, fileType.toStdWString().c_str(), 0, KEY_READ, &key);
     if (result != ERROR_SUCCESS )
         return true;
     RegCloseKey(key);
 
-    result = RegDeleteTreeA(HKEY_CLASSES_ROOT,fileType.toLocal8Bit());
-    return result == ERROR_SUCCESS;
+    return deleteRegistryTree(HKEY_CLASSES_ROOT, fileType);
 }
 
 bool FileAssociationModel::registerFileType(const QString &filetype, const QString &description, const QString &verb, const QString &serverApp, int icon)
 {
-    if (!writeRegistry(HKEY_CLASSES_ROOT,
-                       filetype.toLocal8Bit(),
-                       description.toLocal8Bit()))
+    if (!writeRegistry(HKEY_CLASSES_ROOT, filetype, description))
         return false;
 
     QString keyString = QString("%1\\DefaultIcon").arg(filetype);
     QString value = QString("%1,%2").arg(serverApp).arg(icon);
-    if (!writeRegistry(HKEY_CLASSES_ROOT,
-                         keyString.toLocal8Bit(),
-                         value.toLocal8Bit()))
+    if (!writeRegistry(HKEY_CLASSES_ROOT, keyString, value))
         return false;
     keyString = QString("%1\\Shell\\%2\\Command").arg(filetype).arg(verb);
     value = serverApp+" \"%1\"";
-    if (!writeRegistry(HKEY_CLASSES_ROOT,
-                         keyString.toLocal8Bit(),
-                         value.toLocal8Bit()))
+    if (!writeRegistry(HKEY_CLASSES_ROOT, keyString, value))
         return false;
     return true;
 }

--- a/RedPandaIDE/settingsdialog/environmentfileassociationwidget.h
+++ b/RedPandaIDE/settingsdialog/environmentfileassociationwidget.h
@@ -19,6 +19,7 @@
 
 #include <QAbstractListModel>
 #include <QWidget>
+#include <memory>
 #include "settingswidget.h"
 
 namespace Ui {

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
@@ -30,7 +30,7 @@ EnvironmentProgramsWidget::EnvironmentProgramsWidget(const QString& name, const 
 {
     ui->setupUi(this);
     ui->labelCmdPreviewResult->setFont(QFont(DEFAULT_MONO_FONT));
-#ifndef Q_OS_WINDOWS
+#ifndef Q_OS_WIN
     ui->grpUseCustomTerminal->setCheckable(false);
 #endif
 }
@@ -72,7 +72,7 @@ void EnvironmentProgramsWidget::autoDetectAndUpdateArgumentsPattern(const QStrin
 
 void EnvironmentProgramsWidget::doLoad()
 {
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     ui->grpUseCustomTerminal->setChecked(pSettings->environment().useCustomTerminal());
 #endif
     ui->txtTerminal->setText(pSettings->environment().terminalPath());
@@ -81,7 +81,7 @@ void EnvironmentProgramsWidget::doLoad()
 
 void EnvironmentProgramsWidget::doSave()
 {
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     pSettings->environment().setUseCustomTerminal(ui->grpUseCustomTerminal->isChecked());
 #endif
     pSettings->environment().setTerminalPath(ui->txtTerminal->text());

--- a/RedPandaIDE/settingsdialog/environmentshortcutwidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentshortcutwidget.cpp
@@ -167,7 +167,7 @@ QVariant EnvironmentShortcutModel::headerData(int section, Qt::Orientation orien
 
 Qt::ItemFlags EnvironmentShortcutModel::flags(const QModelIndex &index) const
 {
-    Qt::ItemFlags flags = Qt::ItemIsEnabled;
+    Compat::QFlags_<Qt::ItemFlag> flags = Qt::ItemIsEnabled;
     if (index.isValid() && index.column()==1) {
         flags.setFlag(Qt::ItemIsEditable);
     }

--- a/RedPandaIDE/settingsdialog/settingsdialog.cpp
+++ b/RedPandaIDE/settingsdialog/settingsdialog.cpp
@@ -71,7 +71,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SettingsDialog)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
 
     QItemSelectionModel *m=ui->widgetsView->selectionModel();

--- a/RedPandaIDE/utils.cpp
+++ b/RedPandaIDE/utils.cpp
@@ -595,7 +595,7 @@ QStringList getExecutableSearchPaths()
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QString path = env.value("PATH");
     QStringList pathList = path.split(PATH_SEPARATOR);
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     /* follow Windows `CreateProcessW` search semantics.
      * ref. https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw .
      */
@@ -627,7 +627,7 @@ QString escapeArgument(const QString &arg, [[maybe_unused]] bool isFirstArg)
 {
     auto argContainsOneOf = [&arg](auto... ch) { return (arg.contains(ch) || ...); };
 
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     // See https://stackoverflow.com/questions/31838469/how-do-i-convert-argv-to-lpcommandline-parameter-of-createprocess ,
     // and https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way .
 
@@ -738,9 +738,18 @@ QString escapeArgument(const QString &arg, [[maybe_unused]] bool isFirstArg)
 
 QString defaultShell()
 {
-#ifdef Q_OS_WINDOWS
+#ifdef Q_OS_WIN
     return "powershell.exe";
 #else
     return "sh";
+#endif
+}
+
+void disableWindowContextHelpButtonHint(QWidget *widget)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+    widget->setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+#else
+    widget->windowFlags() &= ~Qt::WindowContextHelpButtonHint;
 #endif
 }

--- a/RedPandaIDE/utils.cpp
+++ b/RedPandaIDE/utils.cpp
@@ -389,9 +389,9 @@ bool isGreenEdition()
     if (!gIsGreenEditionInited) {
         QString keyString = QString("Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\RedPanda-C++");
         QString value;
-        if (!readRegistry(HKEY_LOCAL_MACHINE,keyString.toLocal8Bit(),"UninstallString",value)) {
+        if (!readRegistry(HKEY_LOCAL_MACHINE, keyString, "UninstallString", value)) {
             keyString = "SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\RedPanda-C++";
-            if (!readRegistry(HKEY_LOCAL_MACHINE,keyString.toLocal8Bit(),"UninstallString",value)) {
+            if (!readRegistry(HKEY_LOCAL_MACHINE, keyString, "UninstallString", value)) {
                 value="";
             }
         }
@@ -465,31 +465,79 @@ void executeFile(const QString &fileName, const QString &params, const QString &
 }
 
 #ifdef Q_OS_WIN
-bool readRegistry(HKEY key,const QByteArray& subKey, const QByteArray& name, QString& value) {
-    DWORD dataSize;
+
+bool readRegistry(HKEY key,const QString& subKey, const QString& name, QString& value) {
     LONG result;
-    result = RegGetValueA(key,subKey,
-                 name, RRF_RT_REG_SZ | RRF_RT_REG_MULTI_SZ,
-                 NULL,
-                 NULL,
-                 &dataSize);
-    if (result!=ERROR_SUCCESS)
+    HKEY hkey;
+    result = RegOpenKeyExW(key, subKey.toStdWString().c_str(), 0, KEY_READ, &hkey);
+    if (result != ERROR_SUCCESS)
         return false;
-    char * buffer = new char[dataSize+10];
-    result = RegGetValueA(key,subKey,
-                 name, RRF_RT_REG_SZ | RRF_RT_REG_MULTI_SZ,
-                 NULL,
-                 buffer,
-                 &dataSize);
-    if (result!=ERROR_SUCCESS) {
+
+    DWORD dataType;
+    DWORD dataSize;
+    result = RegQueryValueExW(hkey, name.toStdWString().c_str(), NULL, &dataType, NULL, &dataSize);
+    if (result != ERROR_SUCCESS || (dataType != REG_SZ && dataType != REG_MULTI_SZ)) {
+        RegCloseKey(hkey);
+        return false;
+    }
+
+    wchar_t * buffer = new wchar_t[dataSize / sizeof(wchar_t) + 10];
+    result = RegQueryValueExW(hkey, name.toStdWString().c_str(), NULL, &dataType, (LPBYTE)buffer, &dataSize);
+    RegCloseKey(hkey);
+    if (result != ERROR_SUCCESS) {
         delete[] buffer;
         return false;
     }
-    value=QString::fromLocal8Bit(buffer);
+
+    value = QString::fromWCharArray(buffer);
     delete [] buffer;
     return true;
 }
-#endif
+
+# if _WIN32_WINNT >= 0x0600
+
+bool deleteRegistryTree(HKEY key, const QString &subKey)
+{
+    return ERROR_SUCCESS == RegDeleteTreeW(key, subKey.toStdWString().c_str());
+}
+
+# else
+
+static bool deleteRegistryTreeImpl(HKEY key)
+{
+    DWORD index = 0;
+    WCHAR subKeyName[256];
+    DWORD subKeyNameLength = 256;
+    while (ERROR_SUCCESS == RegEnumKeyExW(key, index, subKeyName, &subKeyNameLength, NULL, NULL, NULL, NULL)) {
+        HKEY hSubKey;
+        if (ERROR_SUCCESS == RegOpenKeyExW(key, subKeyName, 0, KEY_READ | KEY_WRITE, &hSubKey)) {
+            if (!deleteRegistryTreeImpl(hSubKey)) {
+                RegCloseKey(hSubKey);
+                return false;
+            }
+            RegCloseKey(hSubKey);
+        } else {
+            return false;
+        }
+        subKeyNameLength = 256;
+        index++;
+    }
+    return ERROR_SUCCESS == RegDeleteKeyW(key, L"");
+}
+
+bool deleteRegistryTree(HKEY key, const QString &subKey)
+{
+    HKEY hkey;
+    if (ERROR_SUCCESS != RegOpenKeyExW(key, subKey.toStdWString().c_str(), 0, KEY_READ | KEY_WRITE, &hkey))
+        return false;
+    bool result = deleteRegistryTreeImpl(hkey);
+    RegCloseKey(hkey);
+    return result;
+}
+
+# endif // _WIN32_WINNT
+
+#endif // Q_OS_WIN
 
 qulonglong stringToHex(const QString &str, bool &isOk)
 {

--- a/RedPandaIDE/utils.h
+++ b/RedPandaIDE/utils.h
@@ -173,4 +173,6 @@ QString escapeArgument(const QString &arg, bool isFirstArg);
 
 QString defaultShell();
 
+void disableWindowContextHelpButtonHint(QWidget *widget);
+
 #endif // UTILS_H

--- a/RedPandaIDE/utils.h
+++ b/RedPandaIDE/utils.h
@@ -145,7 +145,8 @@ void executeFile(const QString& fileName,
 bool isGreenEdition();
 
 #ifdef Q_OS_WIN
-bool readRegistry(HKEY key,const QByteArray& subKey, const QByteArray& name, QString& value);
+bool readRegistry(HKEY key, const QString& subKey, const QString& name, QString& value);
+bool deleteRegistryTree(HKEY key, const QString &subKey);
 #endif
 
 qulonglong stringToHex(const QString& str, bool &isOk);

--- a/RedPandaIDE/widgets/aboutdialog.cpp
+++ b/RedPandaIDE/widgets/aboutdialog.cpp
@@ -25,7 +25,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AboutDialog)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     ui->lblTitle->setText(ui->lblTitle->text() + tr("Version: ") + REDPANDA_CPP_VERSION);
 

--- a/RedPandaIDE/widgets/codecompletionpopup.cpp
+++ b/RedPandaIDE/widgets/codecompletionpopup.cpp
@@ -1312,19 +1312,19 @@ void CodeCompletionListItemDelegate::paint(QPainter *painter, const QStyleOption
                 QString t = text.mid(pos,matchPosition->start-pos);
                 painter->setPen(normalColor);
                 painter->drawText(x,y,t);
-                x+=painter->fontMetrics().horizontalAdvance(t);
+                x += Compat::QFontMetrics_(painter->fontMetrics()).horizontalAdvance(t);
             }
             QString t = text.mid(matchPosition->start, matchPosition->end-matchPosition->start);
             painter->setPen(mMatchedColor);
             painter->drawText(x,y,t);
-            x+=painter->fontMetrics().horizontalAdvance(t);
+            x += Compat::QFontMetrics_(painter->fontMetrics()).horizontalAdvance(t);
             pos=matchPosition->end;
         }
         if (pos<text.length()) {
             QString t = text.mid(pos,text.length()-pos);
             painter->setPen(normalColor);
             painter->drawText(x,y,t);
-            x+=painter->fontMetrics().horizontalAdvance(t);
+            x += Compat::QFontMetrics_(painter->fontMetrics()).horizontalAdvance(t);
         }
         painter->restore();
     } else {

--- a/RedPandaIDE/widgets/cpudialog.cpp
+++ b/RedPandaIDE/widgets/cpudialog.cpp
@@ -31,7 +31,7 @@ CPUDialog::CPUDialog(QWidget *parent) :
     mSetting(false)
 {
     setWindowFlags(windowFlags() | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     ui->txtCode->setSyntaxer(syntaxerManager.getSyntaxer(QSynedit::ProgrammingLanguage::Assembly));
     ui->txtCode->setReadOnly(true);

--- a/RedPandaIDE/widgets/darkfusionstyle.cpp
+++ b/RedPandaIDE/widgets/darkfusionstyle.cpp
@@ -869,7 +869,7 @@ void DarkFusionStyle::drawControl(ControlElement element, const QStyleOption *op
                     proxy()->drawItemText(painter, menuItem->rect.adjusted(margin, 0, -margin, 0), Qt::AlignLeft | Qt::AlignVCenter,
                                           menuItem->palette, menuItem->state & State_Enabled, menuItem->text,
                                           QPalette::Text);
-                    w = menuItem->fontMetrics.horizontalAdvance(menuItem->text) + margin;
+                    w = static_cast<const Compat::QFontMetrics_ &>(menuItem->fontMetrics).horizontalAdvance(menuItem->text) + margin;
                 }
                 painter->setPen(shadow.darker(150));
                 bool reverse = menuItem->direction == Qt::RightToLeft;

--- a/RedPandaIDE/widgets/functiontooltipwidget.cpp
+++ b/RedPandaIDE/widgets/functiontooltipwidget.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "functiontooltipwidget.h"
+#include "qt_utils/compat.h"
 
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -137,7 +138,7 @@ void FunctionTooltipWidget::updateTip()
     if (mInfos.length()>1) {
         mTotalLabel->setText(QString("%1/%2").arg(mInfoIndex+1).arg(mInfos.length()));
     }
-    int width = mInfoLabel->fontMetrics().horizontalAdvance(text);
+    int width = Compat::QFontMetrics_(mInfoLabel->fontMetrics()).horizontalAdvance(text);
     if (width > 400) {
         mInfoLabel->setMinimumWidth(410);
     } else {

--- a/RedPandaIDE/widgets/linenumbertexteditor.cpp
+++ b/RedPandaIDE/widgets/linenumbertexteditor.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "linenumbertexteditor.h"
+#include "qt_utils/compat.h"
 
 #include <QPainter>
 #include <QTextBlock>
@@ -40,7 +41,7 @@ int LineNumberTextEditor::lineNumberAreaWidth()
         ++digits;
     }
 
-    int space = 10 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+    int space = 10 + Compat::QFontMetrics_(fontMetrics()).horizontalAdvance(QLatin1Char('9')) * digits;
 
     return space;
 }

--- a/RedPandaIDE/widgets/newclassdialog.cpp
+++ b/RedPandaIDE/widgets/newclassdialog.cpp
@@ -26,7 +26,7 @@ NewClassDialog::NewClassDialog(PCppParser parser, QWidget *parent) :
     ui(new Ui::NewClassDialog),
     mModel(parser)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     resize(pSettings->ui().newClassDialogWidth(),pSettings->ui().newClassDialogHeight());
     onUpdateIcons();

--- a/RedPandaIDE/widgets/newheaderdialog.cpp
+++ b/RedPandaIDE/widgets/newheaderdialog.cpp
@@ -25,7 +25,7 @@ NewHeaderDialog::NewHeaderDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::NewHeaderDialog)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     resize(pSettings->ui().newHeaderDialogWidth(),pSettings->ui().newHeaderDialogHeight());
     onUpdateIcons();

--- a/RedPandaIDE/widgets/newprojectdialog.cpp
+++ b/RedPandaIDE/widgets/newprojectdialog.cpp
@@ -29,7 +29,7 @@ NewProjectDialog::NewProjectDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::NewProjectDialog)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     ui->lstTemplates->setItemAlignment(Qt::AlignCenter);

--- a/RedPandaIDE/widgets/qconsole.cpp
+++ b/RedPandaIDE/widgets/qconsole.cpp
@@ -29,6 +29,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include "../utils.h"
+#include "qt_utils/compat.h"
 
 QConsole::QConsole(QWidget *parent):
     QAbstractScrollArea(parent),
@@ -105,7 +106,7 @@ int QConsole::charColumns(QChar ch, int columnsBefore) const
     }
     if (ch == ' ')
         return 1;
-    return std::ceil((int)(fontMetrics().horizontalAdvance(ch)) / (double) mColumnWidth);
+    return std::ceil((int)(Compat::QFontMetrics_(fontMetrics()).horizontalAdvance(ch)) / (double) mColumnWidth);
 }
 
 void QConsole::invalidate()
@@ -258,7 +259,7 @@ QString QConsole::selText()
 
 void QConsole::recalcCharExtent() {
     mRowHeight = fontMetrics().lineSpacing();
-    mColumnWidth = fontMetrics().horizontalAdvance("M");
+    mColumnWidth = Compat::QFontMetrics_(fontMetrics()).horizontalAdvance("M");
 }
 
 void QConsole::sizeOrFontChanged(bool)

--- a/RedPandaIDE/widgets/searchdialog.cpp
+++ b/RedPandaIDE/widgets/searchdialog.cpp
@@ -16,7 +16,7 @@ SearchDialog::SearchDialog(QWidget *parent) :
     ui(new Ui::SearchDialog),
     mSearchOptions()
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     mTabBar=new QTabBar(this);
     mTabBar->setExpanding(false);

--- a/RedPandaIDE/widgets/searchinfiledialog.cpp
+++ b/RedPandaIDE/widgets/searchinfiledialog.cpp
@@ -37,7 +37,7 @@ SearchInFileDialog::SearchInFileDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SearchInFileDialog)
 {
-    setWindowFlag(Qt::WindowContextHelpButtonHint,false);
+    disableWindowContextHelpButtonHint(this);
     ui->setupUi(this);
     mSearchOptions&=0;
     mBasicSearchEngine= QSynedit::PSynSearchBase(new QSynedit::BasicSearcher());

--- a/RedPandaIDE/widgets/searchresultview.cpp
+++ b/RedPandaIDE/widgets/searchresultview.cpp
@@ -298,7 +298,7 @@ void SearchResultTreeModel::onResultModelChanged()
 
 Qt::ItemFlags SearchResultTreeModel::flags(const QModelIndex &) const
 {
-    Qt::ItemFlags flags=Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    Compat::QFlags_<Qt::ItemFlag> flags=Qt::ItemIsEnabled | Qt::ItemIsSelectable;
     if (mSelectable) {
         flags.setFlag(Qt::ItemIsUserCheckable);
     }
@@ -451,7 +451,7 @@ void SearchResultTreeViewDelegate::paint(QPainter *painter, const QStyleOptionVi
      option.text = fullText;
      QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
 
-     QFontMetrics metrics = option.fontMetrics;
+     Compat::QFontMetrics_ metrics = QFontMetrics(option.fontMetrics);
      int x=textRect.left();
      int y=textRect.top() + metrics.ascent();
      if (item->parent==nullptr) { //is filename

--- a/libs/qsynedit/qsynedit.pro
+++ b/libs/qsynedit/qsynedit.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 QT += core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-CONFIG += c++17
+CONFIG += c++14 c++17
 CONFIG += nokey
 CONFIG += staticlib
 contains(QMAKE_HOST.arch, x86_64):{

--- a/libs/qsynedit/qsynedit.pro
+++ b/libs/qsynedit/qsynedit.pro
@@ -15,7 +15,7 @@ contains(QMAKE_HOST.arch, x86_64):{
 
 
 win32: {
-DEFINES += _WIN32_WINNT=0x0601
+    DEFINES += _WIN32_WINNT=0x0501
 }
 
 gcc {

--- a/libs/qsynedit/qsynedit/document.h
+++ b/libs/qsynedit/qsynedit/document.h
@@ -27,6 +27,7 @@
 #include "miscprocs.h"
 #include "types.h"
 #include "qt_utils/utils.h"
+#include "qt_utils/compat.h"
 
 namespace QSynedit {
 
@@ -149,8 +150,8 @@ private:
 
     //SynEdit* mEdit;
 
-    QFontMetrics mFontMetrics;
-    QFontMetrics mNonAsciiFontMetrics;
+    Compat::QFontMetrics_ mFontMetrics;
+    Compat::QFontMetrics_ mNonAsciiFontMetrics;
     int mTabWidth;
     int mCharWidth;
     //int mCount;

--- a/libs/qsynedit/qsynedit/exporter/rtfexporter.cpp
+++ b/libs/qsynedit/qsynedit/exporter/rtfexporter.cpp
@@ -144,7 +144,7 @@ QString RTFExporter::getFormatName()
 
 QString RTFExporter::getHeader()
 {
-    QFontMetrics fm(mFont);
+    Compat::QFontMetrics_ fm(mFont);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)    
     int tabWidth = mTabSize * fm.horizontalAdvance("M")*72*20/fm.fontDpi();
 #else  

--- a/libs/qsynedit/qsynedit/miscprocs.h
+++ b/libs/qsynedit/qsynedit/miscprocs.h
@@ -26,6 +26,7 @@
 #include <QTextStream>
 #include <QVector>
 #include <initializer_list>
+#include <functional>
 //#include <QRect>
 //#include <QColor>
 

--- a/libs/qsynedit/qsynedit/qsynedit.cpp
+++ b/libs/qsynedit/qsynedit/qsynedit.cpp
@@ -3179,7 +3179,7 @@ void QSynEdit::recalcCharExtent()
 
     mTextHeight  = 0;
     mCharWidth = 0;
-    QFontMetrics fm(font());
+    Compat::QFontMetrics_ fm(font());
     QFontMetrics fm2(font());
     mTextHeight = std::max(fm.lineSpacing(),fm2.lineSpacing());
     mCharWidth = fm.horizontalAdvance("M");
@@ -3187,7 +3187,7 @@ void QSynEdit::recalcCharExtent()
     if (hasStyles[0]) { // has bold font
         QFont f = font();
         f.setBold(true);
-        QFontMetrics fm(f);
+        Compat::QFontMetrics_ fm(f);
         QFont f2 = font();
         f2.setBold(true);
         QFontMetrics fm2(f);
@@ -3201,7 +3201,7 @@ void QSynEdit::recalcCharExtent()
     if (hasStyles[1]) { // has strike out font
         QFont f = font();
         f.setItalic(true);
-        QFontMetrics fm(f);
+        Compat::QFontMetrics_ fm(f);
         QFont f2 = font();
         f2.setItalic(true);
         QFontMetrics fm2(f);
@@ -3215,7 +3215,7 @@ void QSynEdit::recalcCharExtent()
     if (hasStyles[2]) { // has strikeout
         QFont f = font();
         f.setStrikeOut(true);
-        QFontMetrics fm(f);
+        Compat::QFontMetrics_ fm(f);
         QFont f2 = font();
         f2.setStrikeOut(true);
         QFontMetrics fm2(f);
@@ -3229,7 +3229,7 @@ void QSynEdit::recalcCharExtent()
     if (hasStyles[3]) { // has underline
         QFont f = font();
         f.setUnderline(true);
-        QFontMetrics fm(f);
+        Compat::QFontMetrics_ fm(f);
         QFont f2 = font();
         f2.setUnderline(true);
         QFontMetrics fm2(f);
@@ -3248,7 +3248,7 @@ QString QSynEdit::expandAtWideGlyphs(const QString &S)
     QString Result(S.length()*2); // speed improvement
     int  j = 0;
     for (int i=0;i<S.length();i++) {
-        int CountOfAvgGlyphs = ceil(fontMetrics().horizontalAdvance(S[i])/(double)mCharWidth);
+        int CountOfAvgGlyphs = ceil(Compat::QFontMetrics_(fontMetrics()).horizontalAdvance(S[i])/(double)mCharWidth);
         if (j+CountOfAvgGlyphs>=Result.length())
             Result.resize(Result.length()+128);
         // insert CountOfAvgGlyphs filling chars
@@ -5972,6 +5972,11 @@ bool QSynEdit::isIdentStartChar(const QChar &ch)
         }
         return false;
     }
+}
+
+bool QSynEdit::startsWithIndentStartChar(const QString &s)
+{
+    return isIdentStartChar(s[0]);
 }
 
 void QSynEdit::setRainbowAttrs(const PTokenAttribute &attr0, const PTokenAttribute &attr1, const PTokenAttribute &attr2, const PTokenAttribute &attr3)

--- a/libs/qsynedit/qsynedit/qsynedit.h
+++ b/libs/qsynedit/qsynedit/qsynedit.h
@@ -31,6 +31,7 @@
 #include "keystrokes.h"
 #include "searcher/baseseacher.h"
 #include "formatter/formatter.h"
+#include "qt_utils/utils.h"
 
 namespace QSynedit {
 
@@ -57,7 +58,7 @@ enum StatusChange {
     scModified = 0x0400
 };
 
-Q_DECLARE_FLAGS(StatusChanges, StatusChange)
+using StatusChanges = Compat::QFlags_<StatusChange>;
 Q_DECLARE_OPERATORS_FOR_FLAGS(StatusChanges)
 
 enum class StateFlag  {
@@ -70,7 +71,7 @@ enum class StateFlag  {
     sfWaitForDragging = 0x0040
 };
 
-Q_DECLARE_FLAGS(StateFlags,StateFlag)
+using StateFlags = Compat::QFlags_<StateFlag>;
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(StateFlags)
 
@@ -102,7 +103,7 @@ enum EditorOption {
   eoShowLineBreaks      =   0x01000000,
 };
 
-Q_DECLARE_FLAGS(EditorOptions, EditorOption)
+using EditorOptions = Compat::QFlags_<EditorOption>;
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(EditorOptions)
 
@@ -299,6 +300,7 @@ public:
     bool pointToLine(const QPoint& point, int& line);
     bool isIdentChar(const QChar& ch);
     bool isIdentStartChar(const QChar& ch);
+    bool startsWithIndentStartChar(const QString &s);
 
     void setRainbowAttrs(const PTokenAttribute &attr0,
                          const PTokenAttribute &attr1,

--- a/libs/qsynedit/qsynedit/searcher/baseseacher.h
+++ b/libs/qsynedit/qsynedit/searcher/baseseacher.h
@@ -19,6 +19,7 @@
 
 #include <QObject>
 #include <memory>
+#include "qt_utils/compat.h"
 
 namespace QSynedit {
 
@@ -32,7 +33,7 @@ enum SearchOption {
     ssoRegExp       = 0x0080
 };
 
-Q_DECLARE_FLAGS(SearchOptions, SearchOption)
+using SearchOptions = Compat::QFlags_<SearchOption>;
 Q_DECLARE_OPERATORS_FOR_FLAGS(SearchOptions)
 
 class BaseSearcher : public QObject

--- a/libs/qsynedit/qsynedit/types.h
+++ b/libs/qsynedit/qsynedit/types.h
@@ -21,6 +21,7 @@
 #include <QList>
 #include <QFlags>
 #include <memory>
+#include "qt_utils/compat.h"
 
 namespace QSynedit {
 
@@ -64,7 +65,7 @@ enum FontStyle {
     fsStrikeOut = 0x0008
 };
 
-Q_DECLARE_FLAGS(FontStyles,FontStyle)
+using FontStyles = Compat::QFlags_<FontStyle>;
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(FontStyles)
 

--- a/libs/redpanda_qt_utils/qt_utils/compat.cpp
+++ b/libs/redpanda_qt_utils/qt_utils/compat.cpp
@@ -1,0 +1,163 @@
+#include "compat.h"
+
+#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+# include <MinHook.h>
+#endif
+
+namespace Compat {
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+
+QString QLocale_::formattedDataSize(qint64 bytes, int precision)
+{
+    if (-1024 < bytes && bytes < 1024)
+        return toString(bytes) + " bytes";
+    const QString units[] = {
+        QStringLiteral("bytes"), QStringLiteral("KiB"), QStringLiteral("MiB"), QStringLiteral("GiB"),
+        QStringLiteral("TiB"),   QStringLiteral("PiB"), QStringLiteral("EiB"),
+    };
+    int order = std::__lg(bytes > 0 ? bytes : -bytes) / 10;
+    double value = double(bytes) / (1LL << (order * 10));
+    return QString("%1 %2").arg(toString(value, 'f', precision)).arg(units[order]);
+}
+
+#endif
+
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+
+QString QUuid_::toString(StringFormat mode)
+{
+    QString repr = this->QUuid::toString();
+    if (mode & 0x1)
+        // remove braces
+        repr = repr.mid(1, repr.length() - 2);
+    if (mode & 0x2)
+        // remove hyphen
+        repr.remove('-');
+    return repr;
+}
+
+#endif
+
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+
+bool QProcess_::startDetached(qint64 *pid)
+{
+    const QString &program = this->program();
+    const QStringList &arguments = this->arguments();
+    const QString &workingDirectory = this->workingDirectory();
+
+    // calculate delta
+    const QProcessEnvironment &expectedEnvironment = this->processEnvironment();
+    const QProcessEnvironment &systemEnvironment = QProcessEnvironment::systemEnvironment();
+    QSet<QString> addition = QSet<QString>::fromList(expectedEnvironment.keys()) - QSet<QString>::fromList(systemEnvironment.keys());
+    QSet<QString> deletion = QSet<QString>::fromList(systemEnvironment.keys()) - QSet<QString>::fromList(expectedEnvironment.keys());
+    QSet<QString> modification;
+    for (const QString &key : expectedEnvironment.keys()) {
+        if (systemEnvironment.contains(key) && systemEnvironment.value(key) != expectedEnvironment.value(key))
+            modification.insert(key);
+    }
+
+    // set environment variables
+    for (const QString &key : addition)
+        qputenv(key.toLocal8Bit(), expectedEnvironment.value(key).toLocal8Bit());
+    for (const QString &key : deletion)
+        qunsetenv(key.toLocal8Bit());
+    for (const QString &key : modification)
+        qputenv(key.toLocal8Bit(), expectedEnvironment.value(key).toLocal8Bit());
+
+    // run subprocess detached
+    bool result = QProcess::startDetached(program, arguments, workingDirectory, pid);
+
+    // restore environment variables
+    for (const QString &key : addition)
+        qunsetenv(key.toLocal8Bit());
+    for (const QString &key : deletion)
+        qputenv(key.toLocal8Bit(), systemEnvironment.value(key).toLocal8Bit());
+    for (const QString &key : modification)
+        qputenv(key.toLocal8Bit(), systemEnvironment.value(key).toLocal8Bit());
+
+    return result;
+}
+
+# if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+struct MinHookManager {
+    bool initialized;
+    bool created;
+    bool enabled;
+
+    MinHookManager() {
+        initialized = MH_OK == MH_Initialize();
+        created = initialized && MH_OK == MH_CreateHook((void *)&CreateProcessW, (void *)&QProcess_::detourCreateProcessW, (void **)&QProcess_::gpCreateProcessW);
+        enabled = created && MH_OK == MH_EnableHook((void *)&CreateProcessW);
+    }
+    ~MinHookManager() {
+        if (enabled)
+            MH_DisableHook((void *)&CreateProcessW);
+        if (created)
+            MH_RemoveHook((void *)&CreateProcessW);
+        if (initialized)
+            MH_Uninitialize();
+    }
+
+    operator bool() { return enabled; }
+};
+
+decltype(&CreateProcessW) QProcess_::gpCreateProcessW = nullptr;
+QProcess_::CreateProcessArgumentModifier QProcess_::gProcessArgumentModifier{};
+
+static MinHookManager gMinHookManager; // after `QProcess_::gpCreateProcessW` initialized
+
+void QProcess_::setCreateProcessArgumentsModifier(CreateProcessArgumentModifier modifier)
+{
+    if (gMinHookManager) // dont remove: touch `gMinHookManager` so that the linker will keep it
+        gProcessArgumentModifier = modifier;
+}
+
+void QProcess_::start(QIODevice::OpenMode mode)
+{
+    this->QProcess::start(mode);
+    gProcessArgumentModifier = CreateProcessArgumentModifier{};
+}
+
+BOOL QProcess_::detourCreateProcessW(LPCWSTR applicationName,
+                                     LPWSTR commandLine,
+                                     LPSECURITY_ATTRIBUTES processAttributes,
+                                     LPSECURITY_ATTRIBUTES threadAttributes,
+                                     BOOL inheritHandles,
+                                     DWORD creationFlags,
+                                     LPVOID environment,
+                                     LPCWSTR currentDirectory,
+                                     LPSTARTUPINFOW startupInfo,
+                                     LPPROCESS_INFORMATION processInformation)
+{
+    CreateProcessArguments args{applicationName,
+                                commandLine,
+                                processAttributes,
+                                threadAttributes,
+                                bool(inheritHandles),
+                                creationFlags,
+                                environment,
+                                currentDirectory,
+                                startupInfo,
+                                processInformation};
+    if (gProcessArgumentModifier)
+        gProcessArgumentModifier(&args);
+    return gpCreateProcessW(args.applicationName,
+                            args.arguments,
+                            args.processAttributes,
+                            args.threadAttributes,
+                            args.inheritHandles,
+                            args.flags,
+                            args.environment,
+                            args.currentDirectory,
+                            args.startupInfo,
+                            args.processInformation);
+}
+# endif
+
+#endif
+
+}

--- a/libs/redpanda_qt_utils/qt_utils/compat.h
+++ b/libs/redpanda_qt_utils/qt_utils/compat.h
@@ -1,0 +1,313 @@
+#ifndef COMPAT_H
+#define COMPAT_H
+
+/* For compatibility with Qt 5.6 -- 5.11, where `CONFIG += c++17`
+ * does not work, only library features up to C++14 can be used.
+ * i.e. `std::xxx_t` (since C++14) can be used while `std::xxx_v`
+ * (since C++17) should not be used.
+ *
+ * Note that Red Panda C++ still requires C++17 core language support.
+ */
+#include <type_traits>
+#include <utility>
+#include <functional>
+
+#include <QtCore>
+#include <QFontMetrics>
+#include <QWidget>
+
+#ifdef Q_OS_WIN
+# include <windows.h>
+#endif
+
+/* Missing macro:
+ *   QT_CONFIG (undocumented)
+ */
+
+#ifndef QT_CONFIG
+# define QT_CONFIG(feature) QT_SUPPORTS(feature)
+#endif
+
+/* Missing class:
+ *   QOverload (5.7+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+
+template <typename... Args>
+struct QOverload
+{
+    template <typename C, typename R>
+    static constexpr auto of(R (C::*pmf)(Args...)) -> decltype(pmf) { return pmf; }
+};
+
+#endif
+
+/* Missing overloaded operator:
+ *   bool operator==(QChar, const QString &) (undocumented)
+ *   bool operator==(const QString &, QChar) (undocumented)
+ *   bool operator!=(QChar, const QString &) (undocumented)
+ *   bool operator!=(const QString &, QChar) (undocumented)
+ * Since they are undocumented, here we implement these functions as templates to avoid conflicts.
+ */
+
+template <typename T, typename U>
+auto operator==(T ch, const U &str)
+    -> std::enable_if_t<std::is_convertible<T, QChar>::value && std::is_base_of<QString, U>::value, bool>
+{
+    return str.length() == 1 && ch == str[0];
+}
+
+template <typename T, typename U>
+auto operator==(const U &str, T ch)
+    -> std::enable_if_t<std::is_convertible<T, QChar>::value && std::is_base_of<QString, U>::value, bool>
+{
+    return ch == str;
+}
+
+template <typename T, typename U>
+auto operator!=(T ch, const U &str)
+    -> std::enable_if_t<std::is_convertible<T, QChar>::value && std::is_base_of<QString, U>::value, bool>
+{
+    return !(ch == str);
+}
+
+template <typename T, typename U>
+auto operator!=(const U &str, T ch)
+    -> std::enable_if_t<std::is_convertible<T, QChar>::value && std::is_base_of<QString, U>::value, bool>
+{
+    return !(ch == str);
+}
+
+/* Wrapper classes that add missing member functions.
+ *
+ * A wrapper class `Compat::T_` is implemented by inheriting `T` and adding missing
+ * menber functions. `Compat::T_` inherits all constructors of `T` and adds a “move
+ * constructor” `T_(T &&)` for convenience. Note that “copy constructor”
+ * `T_(const T &)` is intentionally not provided to avoid implicit copy.
+ */
+
+namespace Compat {
+
+/* Missing member function:
+ *   QFlags<E>::setFlag (5.7+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+
+template <typename E>
+class QFlags_ : public QFlags<E> {
+public:
+    using QFlags<E>::QFlags;
+    QFlags_(QFlags<E> &&f) : QFlags<E>(std::move(f)) {}
+
+    QFlags_ &setFlag(E flag, bool on = true) {
+        if (on)
+            *this |= QFlags<E>(flag);
+        else
+            *this &= ~QFlags<E>(flag);
+        return *this;
+    }
+};
+
+#else
+
+template <typename E>
+using QFlags_ = QFlags<E>;
+
+#endif
+
+/* Missing member function:
+ *   QFontMetrics::horizontalAdvance (5.11+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+
+class QFontMetrics_ : public QFontMetrics {
+public:
+    using QFontMetrics::QFontMetrics;
+    using QFontMetrics::operator=;
+    QFontMetrics_(QFontMetrics &&fm) : QFontMetrics(std::move(fm)) {}
+
+    int horizontalAdvance(QChar ch) const { return width(ch); }
+    int horizontalAdvance(const QString &text, int len = -1) const { return width(text, len); }
+};
+
+#else
+
+using QFontMetrics_ = QFontMetrics;
+
+#endif
+
+
+/* Missing static member function:
+ *   QDateTime::currentSecsSinceEpoch (5.8+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+
+class QDateTime_ : public QDateTime {
+public:
+    using QDateTime::QDateTime;
+    QDateTime_(QDateTime &&dt) : QDateTime(std::move(dt)) {}
+
+    static qint64 currentSecsSinceEpoch() { return currentMSecsSinceEpoch() / 1000; }
+};
+
+#else
+
+using QDateTime_ = QDateTime;
+
+#endif
+
+
+/* Missing member function:
+ *   QLocale::formattedDataSize (5.10+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+
+class QLocale_ : public QLocale {
+public:
+    using QLocale::QLocale;
+    QLocale_(QLocale &&l) : QLocale(std::move(l)) {}
+
+    QString formattedDataSize(qint64 bytes, int precision = 2);
+};
+
+#else
+
+using QLocale_ = QLocale;
+
+#endif
+
+
+/* Missing member function:
+ *   QDir::isEmpty (5.9+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+
+class QDir_ : public QDir {
+public:
+    using QDir::QDir;
+    QDir_(QDir &&d) : QDir(std::move(d)) {}
+
+    bool isEmpty() const { return count() == 0; }
+};
+
+#else
+
+using QDir_ = QDir;
+
+#endif
+
+
+/* Missing type:
+ *   QUuid::StringFormat (5.11+)
+ * Missing member function overload:
+ *   QUuid::toString(StringFormat) (5.11+)
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+
+class QUuid_ : QUuid {
+public:
+    enum StringFormat {
+        WithBraces = 0,
+        WithoutBraces = 1,
+        Id128 = 3,
+    };
+
+public:
+    using QUuid::QUuid;
+    QUuid_(QUuid &&u) : QUuid(std::move(u)) {}
+
+    QString toString(StringFormat mode);
+
+public:
+    static QUuid_ createUuid() { return QUuid::createUuid(); }
+};
+
+#else
+
+using QUuid_ = QUuid;
+
+#endif
+
+
+/* Missing type:
+ *   CreateProcessArguments        (5.7+)
+ *   CreateProcessArgumentModifier (5.7+)
+ * Missing member function:
+ *   setCreateProcessArgumentsModifier (5.7+)
+ *   startDetached                     (5.10+)
+ *
+ * `setCreateProcessArgumentsModifier` is so low level that a conformant implemetation
+ * requires almost full rewrite of QProcess. Here we hook `CreateProcessW`.
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+
+# if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+struct MinHookManager;
+#endif
+
+class QProcess_ : public QProcess {
+
+public:
+    using QProcess::QProcess;
+
+    bool startDetached(qint64 *pid = nullptr);
+
+# if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+public:
+    struct CreateProcessArguments
+    {
+        const wchar_t *applicationName;
+        wchar_t *arguments;
+        SECURITY_ATTRIBUTES *processAttributes;
+        SECURITY_ATTRIBUTES *threadAttributes;
+        bool inheritHandles;
+        unsigned long flags;
+        void *environment;
+        const wchar_t *currentDirectory;
+        STARTUPINFO *startupInfo;
+        PROCESS_INFORMATION *processInformation;
+    };
+    using CreateProcessArgumentModifier = std::function<void(CreateProcessArguments *)>;
+
+public:
+    void setCreateProcessArgumentsModifier(CreateProcessArgumentModifier modifier);
+    void start(QIODevice::OpenMode mode = ReadWrite);
+
+private:
+    static BOOL detourCreateProcessW(LPCWSTR applicationName,
+                                     LPWSTR commandLine,
+                                     LPSECURITY_ATTRIBUTES processAttributes,
+                                     LPSECURITY_ATTRIBUTES threadAttributes,
+                                     BOOL inheritHandles,
+                                     DWORD creationFlags,
+                                     LPVOID environment,
+                                     LPCWSTR currentDirectory,
+                                     LPSTARTUPINFOW startupInfo,
+                                     LPPROCESS_INFORMATION processInformation);
+
+private:
+    static decltype(&CreateProcessW) gpCreateProcessW;
+    static CreateProcessArgumentModifier gProcessArgumentModifier;
+
+    friend struct MinHookManager;
+#endif
+
+};
+
+#else
+
+using QProcess_ = QProcess;
+
+#endif
+
+}
+
+#endif // COMPAT_H

--- a/libs/redpanda_qt_utils/redpanda_qt_utils.pro
+++ b/libs/redpanda_qt_utils/redpanda_qt_utils.pro
@@ -3,7 +3,7 @@ QT += core gui
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-CONFIG += c++17
+CONFIG += c++14 c++17
 CONFIG += nokey
 CONFIG += staticlib
 
@@ -21,10 +21,12 @@ msvc {
 }
 
 SOURCES += qt_utils/utils.cpp \
-	qt_utils/charsetinfo.cpp
+	qt_utils/charsetinfo.cpp \
+	qt_utils/compat.cpp
 
 HEADERS += qt_utils/utils.h \
-	qt_utils/charsetinfo.h
+	qt_utils/charsetinfo.h \
+	qt_utils/compat.h
 
 TRANSLATIONS += \
     qt_utils_zh_CN.ts

--- a/libs/redpanda_qt_utils/redpanda_qt_utils.pro
+++ b/libs/redpanda_qt_utils/redpanda_qt_utils.pro
@@ -8,7 +8,7 @@ CONFIG += nokey
 CONFIG += staticlib
 
 win32: {
-DEFINES += _WIN32_WINNT=0x0601
+    DEFINES += _WIN32_WINNT=0x0501
 }
 
 gcc {

--- a/packages/windows/build-qt5.6-mingw-static.ps1
+++ b/packages/windows/build-qt5.6-mingw-static.ps1
@@ -1,0 +1,118 @@
+$QtConfigureDebugOrRelease = "-release"
+$OfficialQtDirectory = "C:\Qt"
+$QtInstallPrefix = "C:\Qt\5.6.3"
+
+function Get-QtModuleDirectory {
+    param([string]$ModuleName)
+    "qt$ModuleName-opensource-src-5.6.3"
+}
+
+function Prepare-QtSource {
+    param([string]$ModuleName)
+    $moduleDirectory = $(Get-QtModuleDirectory $ModuleName)
+    $fileName = "$moduleDirectory.zip"
+
+    if (!(Test-Path $moduleDirectory)) {
+        if (!(Test-Path $fileName)) {
+            $downloadUrl = "http://download.qt.io/new_archive/qt/5.6/5.6.3/submodules/$fileName"
+            Invoke-WebRequest $downloadUrl -OutFile $fileName
+        }
+        Expand-Archive $fileName -DestinationPath .
+    }
+}
+
+function Prepare-QtSources {
+    Prepare-QtSource "base"
+    Prepare-QtSource "svg"
+    Prepare-QtSource "tools"
+}
+
+function Prepare-MinHookSource {
+    $directory = "minhook-1.3.3"
+    $fileName = "$directory.zip"
+
+    if (!(Test-Path $directory)) {
+        if (!(Test-Path $fileName)) {
+            $downloadUrl = "https://github.com/TsudaKageyu/minhook/archive/refs/tags/v1.3.3.zip"
+            Invoke-WebRequest $downloadUrl -OutFile $fileName
+        }
+        Expand-Archive $fileName -DestinationPath .
+    }
+}
+
+function Build-QtBase {
+    param([string]$Configuration)
+
+    $buildDir = "build-qtbase-$Configuration"
+    mkdir $buildDir
+    pushd $buildDir
+
+    $prefix = "$QtInstallPrefix\$Configuration"
+    & "..\$(Get-QtModuleDirectory "base")\configure.bat" `
+        -prefix $prefix $QtConfigureDebugOrRelease `
+        -opensource -confirm-license `
+        -no-use-gold-linker -static -static-runtime -platform win32-g++ -target xp `
+        -opengl desktop -no-angle -iconv -gnu-iconv -no-icu -qt-zlib -qt-pcre -qt-libpng -qt-libjpeg -qt-freetype -no-fontconfig -qt-harfbuzz -no-ssl -no-openssl `
+        -nomake examples -nomake tests -nomake tools
+    mingw32-make "-j$Env:NUMBER_OF_PROCESSORS"
+    mingw32-make install
+    $Env:Path = "$prefix\bin;$Env:Path"
+
+    popd
+}
+
+function Build-QtModule {
+    param([string]$Configuration, [string]$ModuleName)
+
+    $buildDir = "build-qt$ModuleName-$Configuration"
+    mkdir $buildDir
+    pushd $buildDir
+
+    qmake "..\$(Get-QtModuleDirectory $ModuleName)"
+    mingw32-make "-j$Env:NUMBER_OF_PROCESSORS"
+    mingw32-make install
+
+    popd
+}
+
+function Build-Qt {
+    param([string]$Configuration)
+
+    Build-QtBase $Configuration
+    Build-QtModule $Configuration "svg"
+    Build-QtModule $Configuration "tools"
+}
+
+function Build-MinHook {
+    param([string]$Configuration)
+
+    $prefix = "$QtInstallPrefix\$Configuration"
+    $directory = "minhook-1.3.3"
+    pushd $directory
+
+    mingw32-make -f build/MinGW/Makefile libMinHook.a "-j$Env:NUMBER_OF_PROCESSORS"
+    mv libMinHook.a "$prefix\lib"
+    cp "include\MinHook.h" "$prefix\include"
+    rm src\*.o
+    rm src\hde\*.o
+
+    popd
+}
+
+function Main {
+    $BasePath = $Env:Path
+    Prepare-QtSources
+    Prepare-MinHookSource
+
+    ## 32-bit
+    $Env:Path = "$OfficialQtDirectory\Tools\mingw810_32\bin;$BasePath"
+    Build-Qt mingw81_32-static
+    Build-MinHook mingw81_32-static
+
+    ## 64-bit
+    $Env:Path = "$OfficialQtDirectory\Tools\mingw810_64\bin;$BasePath"
+    Build-Qt mingw81_64-static
+    Build-MinHook mingw81_64-static
+}
+
+Main

--- a/tools/consolepauser/consolepauser.pro
+++ b/tools/consolepauser/consolepauser.pro
@@ -28,7 +28,8 @@ LIBS+= \
 }
 
 win32: {
-DEFINES += _WIN32_WINNT=0x0601
+    DEFINES += _WIN32_WINNT=0x0501
+    LIBS += -lpsapi  # GetProcessMemoryInfo
 }
 
 CONFIG += lrelease


### PR DESCRIPTION
- Qt 5.6 changes:
  - Implement some new Qt APIs in namespace `Compat` when building with old Qt library.
  - Update remaining part to work with Qt 5.6 APIs.
- Win32 NT 5.1 changes:
  - Switch from high-level registry APIs `RegGetKeyValue`, `RegSetKeyValue` to low-level registry APIs `RegGetValueEx`, `RegSetValueEx` (when targetting any NT version).
  - Use our implementation of `RegDeleteTree` when targetting NT 5.1/5.2.
  - Update registry API calls from ANSI version to Unicode version.