### PR TITLE
Update Linux packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@
 /packages/archlinux/* eol=lf
 /packages/debian/01-in-docker.sh eol=lf
 /packages/debian/rules eol=lf
+/packages/fedora/* eol=lf
+/packages/opensuse/* eol=lf
 
 # files to be processed with Unix utils
 /packages/windows/qtbase-5.6.3-redpanda.patch eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 
 # script run in docker
 /packages/appimage/01-in-docker.sh eol=lf
+/packages/archlinux/* eol=lf
 /packages/debian/01-in-docker.sh eol=lf
 /packages/debian/rules eol=lf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 ##################################
 
 # script run in docker
+/packages/alpine/* eol=lf
 /packages/appimage/01-in-docker.sh eol=lf
 /packages/archlinux/* eol=lf
 /packages/debian/01-in-docker.sh eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,24 +172,7 @@ jobs:
 
       - name: Build
         run: |
-          cat <<EOF >$GITHUB_WORKSPACE/archlinux-in-docker.sh
-          #!/bin/bash
-          set -euxo pipefail
-
-          pacman -Syu --noconfirm --needed base-devel
-          cd /src/packages/archlinux
-          bash -c 'source PKGBUILD && pacman -S --noconfirm --needed --asdeps "\${makedepends[@]}" "\${depends[@]}"'  # heredoc: escape variable expansion
-
-          useradd -m builduser
-          chmod o+w .
-          su builduser -c 'makepkg'
-
-          mkdir -p /src/dist
-          mv *.pkg.tar.zst /src/dist/
-          EOF
-
-          chmod +x $GITHUB_WORKSPACE/archlinux-in-docker.sh
-          podman run --rm -e SOURCE_DIR=/src -v $GITHUB_WORKSPACE:/src --platform linux/amd64 docker.io/amd64/archlinux:latest /src/archlinux-in-docker.sh
+          podman run --rm -e SOURCE_DIR=/src -v $GITHUB_WORKSPACE:/src --platform linux/amd64 docker.io/amd64/archlinux:latest /src/packages/archlinux/01-in-docker.sh
 
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,27 @@ jobs:
           name: RPM on openSUSE Tumbleweed
           path: dist/*.rpm
 
+  musl:
+    name: musl-based Linux (latest Alpine)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch container image
+        run: |
+          podman pull --platform linux/amd64 docker.io/amd64/alpine:latest
+
+      - name: Build
+        run: |
+          podman run --rm -e SOURCE_DIR=/src -v $GITHUB_WORKSPACE:/src --platform linux/amd64 docker.io/amd64/alpine:latest /src/packages/alpine/01-in-docker.sh
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: musl-based Linux (latest Alpine)
+          path: dist/*.apk
+
   macos_x86_64:
     name: macOS x86_64
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@
 /.vscode
 /dist
 /packages/appimage/*/*.AppImage
-/packages/archlinux/*
-!/packages/archlinux/PKGBUILD
 *.bak
 *.pro.user

--- a/BUILD.md
+++ b/BUILD.md
@@ -377,61 +377,24 @@ Extra requirements for Windows host:
    RedPandaIDE
    ```
 
-## Arch Linux
+## Alpine Linux, Arch Linux, Fedora, openSUSE
 
-A reference PKGBUILD is available at `packages/archlinux`. Build RedPanda C++ with [makepkg](https://wiki.archlinux.org/title/Makepkg) and then install.
-
-Enter `RedPandaIDE` to launch RedPanda C++.
-
-Note that makepkg checks out HEAD of the repo, so any change should be committed before building.
-
-## Fedora
-
-1. Install dependency:
-   ```bash
-   sudo dnf install \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-static libstdc++-static libasan \
-     qt5-qtbase-devel qt5-qtsvg-devel qt5-qttools-devel
-
-   rpmdev-setuptree  # first time only
-   ```
-2. Build the package:
-   ```bash
-   ./packages/fedora/buildrpm.sh
-   ```
+1. Setup build environment (documentation for [Alpine](https://wiki.alpinelinux.org/wiki/Abuild_and_Helpers), [Arch](https://wiki.archlinux.org/title/Makepkg), [RPM](https://rpm-packaging-guide.github.io/#prerequisites)).
+2. Call build script:
+   - Alpine Linux: `./packages/alpine/buildapk.sh`
+   - Arch Linux: `./packages/archlinux/buildpkg.sh`
+   - Fedora: `./packages/fedora/buildrpm.sh`
+   - openSUSE: `./packages/opensuse/buildrpm.sh`
 3. Install the package:
-   ```bash
-   sudo dnf install ~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm
-   ```
+   - Alpine Linux: `~/packages/unsupported/$(uname -m)/redpanda-cpp-git-*.apk`
+   - Arch Linux: `/tmp/redpanda-cpp-git/redpanda-cpp-git-*.pkg.tar.zst`
+   - Fedora, openSUSE: `~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm`
 4. Run Red Panda C++:
    ```bash
    RedPandaIDE
    ```
 
-## openSUSE
-
-1. Install dependency:
-   ```bash
-   sudo zypper in \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-devel-static \
-     libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
-
-   rpmdev-setuptree  # first time only
-   ```
-2. Build the package:
-   ```bash
-   ./packages/opensuse/buildrpm.sh
-   ```
-3. Install the package:
-   ```bash
-   sudo zypper --no-gpg-checks in ~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm
-   ```
-4. Run Red Panda C++:
-   ```bash
-   RedPandaIDE
-   ```
+Note that these build scripts check out HEAD of the repo, so any changes should be committed before building.
 
 ## Linux AppImage
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -377,61 +377,24 @@ Windows 宿主的额外要求：
    RedPandaIDE
    ```
 
-## Arch Linux 及衍生版本
+## Alpine Linux, Arch Linux, Fedora, openSUSE
 
-`packages/archlinux` 目录下提供了一个参考 PKGBUILD，使用 [makepkg](https://wiki.archlinuxcn.org/wiki/Makepkg) 构建小熊猫 C++ 并安装。
-
-小熊猫 C++ 可以通过 `RedPandaIDE` 命令启动。
-
-注意：makepkg 签出此存储库的 HEAD，因此构建之前务必提交所有变更。
-
-## Fedora
-
-1. 安装依赖包：
-   ```bash
-   sudo dnf install \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-static libstdc++-static libasan \
-     qt5-qtbase-devel qt5-qtsvg-devel qt5-qttools-devel
-
-   rpmdev-setuptree  # 仅第一次
-   ```
-2. 构建 rpm 包：
-   ```bash
-   ./packages/fedora/buildrpm.sh
-   ```
-3. 安装 rpm 包：
-   ```bash
-   sudo dnf install ~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm
-   ```
+1. 准备构建环境（[Alpine](https://wiki.alpinelinux.org/wiki/Abuild_and_Helpers)、[Arch](https://wiki.archlinux.org/title/Makepkg)、[RPM](https://rpm-packaging-guide.github.io/#prerequisites) 文档）。
+2. 调用构建脚本：
+   - Alpine Linux：`./packages/alpine/buildapk.sh`
+   - Arch Linux：`./packages/archlinux/buildpkg.sh`
+   - Fedora：`./packages/fedora/buildrpm.sh`
+   - openSUSE：`./packages/opensuse/buildrpm.sh`
+3. 安装软件包：
+   - Alpine Linux：`~/packages/unsupported/$(uname -m)/redpanda-cpp-git-*.apk`
+   - Arch Linux：`/tmp/redpanda-cpp-git/redpanda-cpp-git-*.pkg.tar.zst`
+   - Fedora、openSUSE：`~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm`
 4. 运行小熊猫 C++：
    ```bash
    RedPandaIDE
    ```
 
-## openSUSE
-
-1. 安装依赖包：
-   ```bash
-   sudo zypper in \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-devel-static \
-     libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
-
-   rpmdev-setuptree  # 仅第一次
-   ```
-2. 构建 rpm 包：
-   ```bash
-   ./packages/opensuse/buildrpm.sh
-   ```
-3. 安装 rpm 包：
-   ```bash
-   sudo zypper --no-gpg-checks in ~/rpmbuild/RPMS/$(uname -m)/redpanda-cpp-git-*.rpm
-   ```
-4. 运行小熊猫 C++：
-   ```bash
-   RedPandaIDE
-   ```
+注意：这些构建脚本签出此存储库的 HEAD，因此构建之前务必提交所有变更。
 
 ## Linux AppImage
 

--- a/packages/alpine/01-in-docker.sh
+++ b/packages/alpine/01-in-docker.sh
@@ -1,0 +1,16 @@
+#!/bin/ash
+
+set -xeuo pipefail
+
+if (env | grep '^MIRROR=') && [[ -n $MIRROR ]]
+then
+  sed -i "s|dl-cdn.alpinelinux.org|$MIRROR|" /etc/apk/repositories
+fi
+apk add alpine-sdk git
+abuild-keygen -an
+
+cd $SOURCE_DIR
+./packages/alpine/buildapk.sh
+
+mkdir -p $SOURCE_DIR/dist
+cp ~/packages/unsupported/$(uname -m)/redpanda-cpp-git-*.apk $SOURCE_DIR/dist/

--- a/packages/alpine/APKBUILD.in
+++ b/packages/alpine/APKBUILD.in
@@ -1,0 +1,30 @@
+_pkgname=RedPanda-CPP
+pkgname=redpanda-cpp-git
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc='A fast, lightweight, open source, and cross platform C++ IDE (development version)'
+arch='all'
+url="https://github.com/royqh1979/$_pkgname"
+license='GPL-3.0'
+depends='qt5-qtbase qt5-qtsvg gcc g++ gdb'
+makedepends='qt5-qtbase-dev qt5-qtsvg-dev qt5-qttools-dev'
+provides='redpanda-cpp'
+source="$_pkgname.tar.gz"
+options='!check'
+
+build() {
+    mkdir "$srcdir/redpanda-build"
+    cd "$srcdir/redpanda-build"
+    qmake-qt5 \
+        PREFIX='/usr' \
+        XDG_ADAPTIVE_ICON=ON \
+        "$srcdir/$_pkgname/Red_Panda_CPP.pro"
+    make
+}
+
+package() {
+    cd "$srcdir/redpanda-build"
+    make INSTALL_ROOT="$pkgdir" install
+}
+
+sha512sums="00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 $_pkgname.tar.gz"

--- a/packages/alpine/buildapk.sh
+++ b/packages/alpine/buildapk.sh
@@ -1,0 +1,17 @@
+#!/bin/ash
+
+set -xeuo pipefail
+
+TMP_FOLDER=/tmp/unsupported/redpanda-cpp-git
+[[ -d $TMP_FOLDER ]] && rm -rf $TMP_FOLDER
+mkdir -p "$TMP_FOLDER"
+
+COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y%m%d)
+VERSION=$(git describe --long --tags | sed 's/^v//;s/-\([^-]*\)-g\([0-9a-f]*\)/_git'$COMMIT_DATE'/') || VERSION="0.0_git$COMMIT_DATE"
+sed "s/__VERSION__/$VERSION/g" packages/alpine/APKBUILD.in >"$TMP_FOLDER/APKBUILD"
+
+git archive --prefix="RedPanda-CPP/" -o "$TMP_FOLDER/RedPanda-CPP.tar.gz" HEAD
+
+cd "$TMP_FOLDER"
+abuild -F checksum
+abuild -Fr

--- a/packages/archlinux/PKGBUILD.in
+++ b/packages/archlinux/PKGBUILD.in
@@ -1,35 +1,20 @@
 _pkgname=RedPanda-CPP
 pkgname=${_pkgname,,}-git
-pkgver=2.23.r14.gd1214e3d
+pkgver=__VERSION__
 pkgrel=1
 pkgdesc='A fast, lightweight, open source, and cross platform C++ IDE (development version)'
 arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64' 'riscv64')
 url="https://github.com/royqh1979/$_pkgname"
 license=('GPL3')
 depends=(qt5-base qt5-svg gcc gdb)
-makedepends=(git qt5-tools)
+makedepends=(qt5-tools)
 optdepends=(
     'clang: C/C++ compiler (alternative)'
-    'git: git integration'
-    'alacritty: run in terminal'
-    'kitty: run in terminal'
-    'tilix: run in terminal'
-    'cool-retro-term: run in terminal'
-    'konsole: run in terminal'
-    'deepin-terminal: run in terminal'
-    'qterminal: run in terminal'
-    'lxterminal: run in terminal'
 )
 conflicts=("${_pkgname,,}")
 provides=("${_pkgname,,}")
-source=("$_pkgname::git+file://${PWD%packages/archlinux}")
+source=("$_pkgname.tar.gz")
 sha256sums=('SKIP')
-
-pkgver() {
-    cd "$srcdir/$_pkgname"
-    # there may be no tag in forked repo, use `--always` to get commit hash as fallback for ci builds
-    git describe --long --tags --always | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
-}
 
 build() {
     mkdir redpanda-build

--- a/packages/archlinux/buildpkg.sh
+++ b/packages/archlinux/buildpkg.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+TMP_FOLDER=/tmp/redpanda-cpp-git
+[[ -d $TMP_FOLDER ]] && rm -rf $TMP_FOLDER
+mkdir -p "$TMP_FOLDER"
+
+VERSION=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g') || VERSION="0.0.r$(git rev-list HEAD --count).g$(git rev-parse --short HEAD)"
+sed "s/__VERSION__/$VERSION/g" packages/archlinux/PKGBUILD.in >"$TMP_FOLDER/PKGBUILD"
+
+git archive --prefix="RedPanda-CPP/" -o "$TMP_FOLDER/RedPanda-CPP.tar.gz" HEAD
+
+cd "$TMP_FOLDER"
+makepkg -s --noconfirm

--- a/packages/fedora/01-in-docker.sh
+++ b/packages/fedora/01-in-docker.sh
@@ -2,10 +2,7 @@
 
 set -xeuo pipefail
 
-dnf install -y \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-static libstdc++-static libasan \
-     qt5-qtbase-devel qt5-qtsvg-devel qt5-qttools-devel
+dnf install -y dnf-plugins-core git rpm-build rpmdevtools
 rpmdev-setuptree
 
 cd $SOURCE_DIR

--- a/packages/fedora/buildrpm.sh
+++ b/packages/fedora/buildrpm.sh
@@ -3,11 +3,14 @@
 set -xeuo pipefail
 
 SPECDIR=$(rpm --eval %{_specdir})
+SOURCEDIR=$(rpm --eval %{_sourcedir})
 BUILDDIR=$(rpm --eval %{_builddir})/redpanda-cpp-git
-VERSION=$(git describe --long --tags --always | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
-
-sed -s "s/__VERSION__/$VERSION/g" packages/fedora/redpanda-cpp-git.spec.in >$SPECDIR/redpanda-cpp-git.spec
-
 [[ -d $BUILDDIR ]] && rm -rf $BUILDDIR
 
-rpmbuild --define "_sourcedir $(pwd)" -bb $SPECDIR/redpanda-cpp-git.spec
+VERSION=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g') || VERSION="0.0.r$(git rev-list HEAD --count).g$(git rev-parse --short HEAD)"
+sed "s/__VERSION__/$VERSION/g" packages/fedora/redpanda-cpp-git.spec.in >$SPECDIR/redpanda-cpp-git.spec
+
+git archive --prefix="RedPanda-CPP/" -o "$SOURCEDIR/RedPanda-CPP.tar.gz" HEAD
+
+sudo dnf builddep -y $SPECDIR/redpanda-cpp-git.spec
+rpmbuild --nodebuginfo -bb $SPECDIR/redpanda-cpp-git.spec

--- a/packages/fedora/redpanda-cpp-git.spec.in
+++ b/packages/fedora/redpanda-cpp-git.spec.in
@@ -4,6 +4,7 @@ Release: 1%{?dist}
 Summary: A fast, lightweight, open source, and cross platform C++ IDE
 License: GPLv3+
 URL: https://github.com/royqh1979/RedPanda-CPP
+Source0: RedPanda-CPP.tar.gz
 
 BuildRequires: gcc gcc-c++
 BuildRequires: qt5-qtbase-devel qt5-qtsvg-devel qt5-qttools-devel
@@ -19,6 +20,7 @@ It's the succesor of Red Panda Dev-C++ 6, which is developed by Delphi 7 and
 can only running under Windows.
 
 %prep
+%setup -n "RedPanda-CPP"
 
 %build
 mkdir -p %{name}
@@ -26,7 +28,7 @@ cd %{name}
 qmake-qt5 \
     PREFIX=/usr \
     XDG_ADAPTIVE_ICON=ON \
-    "%{_sourcedir}/Red_Panda_CPP.pro"
+    "%{_builddir}/RedPanda-CPP/Red_Panda_CPP.pro"
 make %{_smp_mflags}
 
 %install

--- a/packages/opensuse/01-in-docker.sh
+++ b/packages/opensuse/01-in-docker.sh
@@ -5,10 +5,7 @@ set -xeuo pipefail
 DISTRO_ID=$(grep ^ID= /etc/os-release | cut -d= -f2- | tr -d '"')
 VERSION_ID=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2- | tr -d '"')
 
-zypper in -y \
-     gcc gcc-c++ rpm-build rpmdevtools git \
-     glibc-devel-static \
-     libqt5-qtbase-devel libqt5-qtsvg-devel libqt5-qttools-devel
+zypper in -y git rpm-build rpmdevtools sudo
 rpmdev-setuptree
 
 cd $SOURCE_DIR

--- a/packages/opensuse/buildrpm.sh
+++ b/packages/opensuse/buildrpm.sh
@@ -3,11 +3,14 @@
 set -xeuo pipefail
 
 SPECDIR=$(rpm --eval %{_specdir})
+SOURCEDIR=$(rpm --eval %{_sourcedir})
 BUILDDIR=$(rpm --eval %{_builddir})/redpanda-cpp-git
-VERSION=$(git describe --long --tags --always | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
-
-sed -s "s/__VERSION__/$VERSION/g" packages/opensuse/redpanda-cpp-git.spec.in >$SPECDIR/redpanda-cpp-git.spec
-
 [[ -d $BUILDDIR ]] && rm -rf $BUILDDIR
 
-rpmbuild --define "_sourcedir $(pwd)" -bb $SPECDIR/redpanda-cpp-git.spec
+VERSION=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g') || VERSION="0.0.r$(git rev-list HEAD --count).g$(git rev-parse --short HEAD)"
+sed "s/__VERSION__/$VERSION/g" packages/opensuse/redpanda-cpp-git.spec.in >$SPECDIR/redpanda-cpp-git.spec
+
+git archive --prefix="RedPanda-CPP/" -o "$SOURCEDIR/RedPanda-CPP.tar.gz" HEAD
+
+sudo zypper in -y $(rpmspec -q --buildrequires $SPECDIR/redpanda-cpp-git.spec)
+rpmbuild --nodebuginfo -bb $SPECDIR/redpanda-cpp-git.spec

--- a/packages/opensuse/redpanda-cpp-git.spec.in
+++ b/packages/opensuse/redpanda-cpp-git.spec.in
@@ -4,6 +4,7 @@ Release: 1%{?dist}
 Summary: A fast, lightweight, open source, and cross platform C++ IDE
 License: GPLv3+
 URL: https://github.com/royqh1979/RedPanda-CPP
+Source0: RedPanda-CPP.tar.gz
 
 BuildRequires: gcc gcc-c++
 BuildRequires: libqt5-qtbase-devel libqt5-qtsvg-devel libqt5-qttools-devel
@@ -19,6 +20,7 @@ It's the succesor of Red Panda Dev-C++ 6, which is developed by Delphi 7 and
 can only running under Windows.
 
 %prep
+%setup -n "RedPanda-CPP"
 
 %build
 mkdir -p %{name}
@@ -26,7 +28,7 @@ cd %{name}
 qmake-qt5 \
     PREFIX=/usr \
     XDG_ADAPTIVE_ICON=ON \
-    "%{_sourcedir}/Red_Panda_CPP.pro"
+    "%{_builddir}/RedPanda-CPP/Red_Panda_CPP.pro"
 make %{_smp_mflags}
 
 %install

--- a/tools/astyle/astyle_main.cpp
+++ b/tools/astyle/astyle_main.cpp
@@ -50,6 +50,7 @@
 	#include <dirent.h>
 	#include <sys/stat.h>
 	#include <unistd.h>
+	#include <limits.h>
 	#ifdef __VMS
 		#include <unixlib.h>
 		#include <rms.h>


### PR DESCRIPTION
- Update Arch Linux dependencies.
- Remove “git magic” from Arch Linux and RPM packaging. (Now use `git archive` to generate tarball for build system instead.)
- Fix build error with musl libc.
  - Add packaging script and CI for Alpine Linux.