### PR TITLE
Update terminal arguments pattern

### DIFF
--- a/RedPandaIDE/debugger.h
+++ b/RedPandaIDE/debugger.h
@@ -431,7 +431,7 @@ public:
     explicit DebugTarget(const QString& inferior,
                          const QString& GDBServer,
                          int port,
-                         const QString& arguments,
+                         const QStringList& arguments,
                          QObject *parent = nullptr);
     void setInputFile(const QString& inputFile);
     void stopDebug();
@@ -443,7 +443,7 @@ signals:
     void processError(QProcess::ProcessError error);
 private:
     QString mInferior;
-    QString mArguments;
+    QStringList mArguments;
     QString mGDBServer;
     int mPort;
     bool mStop;

--- a/RedPandaIDE/resources/terminal-unix.json
+++ b/RedPandaIDE/resources/terminal-unix.json
@@ -81,7 +81,7 @@
             {
                 "name": "GNOME Terminal",
                 "path": "gnome-terminal",
-                "argsPattern": "$term -- $argv"
+                "argsPattern": "$term --wait -- $argv"
             },
             {
                 "name": "GNOME Terminator",

--- a/RedPandaIDE/resources/terminal-windows.json
+++ b/RedPandaIDE/resources/terminal-windows.json
@@ -39,6 +39,16 @@
                 "argsPattern": "$term -e $argv"
             },
             {
+                "name": "ConEmu",
+                "path": "ConEmu.exe",
+                "argsPattern": "$term -run $argv"
+            },
+            {
+                "name": "ConEmu",
+                "path": "ConEmu64.exe",
+                "argsPattern": "$term -run $argv"
+            },
+            {
                 "name": "Konsole",
                 "path": "konsole.exe",
                 "argsPattern": "$term -e $argv"


### PR DESCRIPTION
- Update debugger to respect args pattern.
- Fix `gnome-terminal` pattern for debugging.
- Add pattern for ConEmu.