### PR TITLE
Add xmake as alternative build system

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -1,0 +1,78 @@
+name: Feature matrix
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu_2204:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        lua_addon: ["y", "n"]
+        sdcc: ["y", "n"]
+        vcs: ["y", "n"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: '2.8.6'
+
+      - name: Setup Qt
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
+
+      - name: Build
+        run: |
+          name="redpanda-cpp-${{ matrix.lua_addon }}-${{ matrix.sdcc }}-${{ matrix.vcs }}"
+          xmake f --qt=/usr --prefix=/ --lua-addon=${{ matrix.lua_addon }} --sdcc=${{ matrix.sdcc }} --vcs=${{ matrix.vcs }}
+          xmake b
+          xmake i -o "pkg/$name"
+          tar -cf "pkg/$name.tar" -C pkg "$name"
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Ubuntu 22.04 - lua-addon=${{ matrix.lua_addon }}, sdcc=${{ matrix.sdcc }}, vcs=${{ matrix.vcs }}
+          path: pkg/*.tar
+
+  windows_msvc_x64:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        lua_addon: ["y", "n"]
+        sdcc: ["y", "n"]
+        vcs: ["y", "n"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: '2.8.6'
+
+      - name: Setup Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '5.15.2'
+          host: windows
+          target: desktop
+          arch: win64_msvc2019_64
+          archives: qtbase qtsvg qttools
+
+      - name: Build
+        run: |
+          $install_dir = "pkg/redpanda-cpp-${{ matrix.lua_addon }}-${{ matrix.sdcc }}-${{ matrix.vcs }}"
+          xmake f -p windows -a x64 --qt="${env:QT_ROOT_DIR}" --lua-addon=${{ matrix.lua_addon }} --sdcc=${{ matrix.sdcc }} --vcs=${{ matrix.vcs }}
+          xmake b
+          xmake i -o $install_dir
+          mv $install_dir/bin/* $install_dir/
+          rmdir $install_dir/bin
+          rm $install_dir/vc_redist.x64.exe
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Windows MSVC x64 - lua-addon=${{ matrix.lua_addon }}, sdcc=${{ matrix.sdcc }}, vcs=${{ matrix.vcs }}
+          path: pkg/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 /assets
 /dist
 /packages/appimage/*/*.AppImage
+.xmake/
+build/
 *.bak
 *.pro.user

--- a/BUILD.md
+++ b/BUILD.md
@@ -11,60 +11,16 @@ Recommended development environments:
    * Debugger integration with Qt.
 
 To setup development environment in Visual Studio Code:
-1. Install [clangd](https://clangd.llvm.org/) and [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd).
-2. Install [Bear](https://github.com/rizsotto/Bear).
-3. Install [CodeLLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
-4. Generate compilation database:
-   ```bash
-   mkdir -p /path/to/build && cd /path/to/build
-   qmake CONFIG+=debug PREFIX=/path/to/pkg /path/to/src
-   bear -- make -j$(nproc)
-   ```
-5. Add `--compile-commands-dir=/path/to/build` to workspace-wide “Clangd: Arguments” or edit `.vscode/settings.json`:
-   ```json
-   {
-     "clangd.arguments": [
-       "--compile-commands-dir=/path/to/build"
-     ]
-   }
-   ```
-6. Set up build task in `.vscode/tasks.json`:
-   ```json
-   {
-     "version": "2.0.0",
-     "tasks": [
-       {
-         "label": "build",
-         "type": "shell",
-         "command": "cd /path/to/build && make -j$(nproc) && make install",
-         "group": {
-           "kind": "build",
-           "isDefault": true
-         }
-       }
-     ]
-   }
-   ```
-   and debug task in `.vscode/launch.json`:
-   ```json
-   {
-     "version": "0.2.0",
-     "configurations": [
-       {
-         "name": "build",
-         "type": "lldb",
-         "request": "launch",
-         "program": "/path/to/pkg/bin/RedPandaIDE",
-         "args": [],
-         "cwd": "/path/to/build",
-         "env": {
-           "QT_ASSUME_STDERR_HAS_CONSOLE": "1"
-         },
-         "preLaunchTask": "build"
-       }
-     ]
-   }
-   ```
+1. Install [xmake](https://xmake.io/) and [XMake extension](https://marketplace.visualstudio.com/items?itemName=tboox.xmake-vscode).
+2. Install [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) for language and debugging support.
+3. Optionally install [clangd](https://clangd.llvm.org/) and [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) for better analysis.
+4. Config workspace:
+   - Compile commands: `.vscode/compile_commands.json` (“C/C++: Edit Configurations (UI)” from the Command Palette);
+   - “Clangd: Arguments”: `--compile-commands-dir=.vscode`;
+   - “Xmake: Additional Config Arguments”: `--qt=/usr` for example.
+5. Run “XMake: UpdateIntellisense” (Command Palette) to generate compilation database.
+
+\* Note: xmake was introduced for compilation database generation and feature matrix test. It is not fully functional yet.
 
 # Windows
 
@@ -281,13 +237,13 @@ General steps:
 - Install Qt 5 (≥ 5.12) Base, SVG and Tools modules, including both libraries and development files.
 - Optionally install fcitx5-qt for building with static Qt library.
 
-To build:
+qmake-based build steps:
 
 1. Configure:
    ```bash
    qmake PREFIX=/usr/local /path/to/src/Red_Panda_CPP.pro
    ```
-2. Make:
+2. Build:
    ```bash
    make -j$(nproc)
    ```
@@ -301,6 +257,23 @@ qmake variables:
 - `LIBEXECDIR`: directory for auxiliary executables, default to `$PREFIX/libexec`. Arch Linux uses `/usr/lib`.
 - `XDG_ADAPTIVE_ICON=ON`: install the icon file following [freedesktop.org Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) for adaptiveness to themes and sizes. Required by AppImage; recommended for Linux packaging if `PREFIX` set to `/usr`.
 - `LINUX_STATIC_IME_PLUGIN=ON` (make phase): link to static ime plugin. Recommended for building with static version of Qt; **DO NOT** set for dynamic version of Qt.
+
+xmake-based build steps:
+
+1. Configure:
+   ```bash
+   xmake f -p linux -a x86_64 -m release --qt=/usr --prefix=/usr/local
+   ```
+2. Build:
+   ```bash
+   xmake
+   ```
+3. Install:
+   ```bash
+   sudo xmake install --root -o /  # `-o ...` imitates `DESTDIR=...` in `make install`
+   ```
+
+Hint: `xmake f --help` for more options.
 
 ## Debian and Its Derivatives
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -11,60 +11,16 @@
    * 调试器的 Qt 集成。
 
 设置 Visual Studio Code 开发环境的步骤：
-1. 安装 [clangd](https://clangd.llvm.org/) 和 [clangd 扩展](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd)。
-2. 安装 [Bear](https://github.com/rizsotto/Bear)。
-3. 安装 [CodeLLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)。
-4. 生成编译数据库：
-   ```bash
-   mkdir -p /path/to/build && cd /path/to/build
-   qmake CONFIG+=debug PREFIX=/path/to/pkg /path/to/src
-   bear -- make -j$(nproc)
-   ```
-5. 在本工作区 “Clangd: Arguments” 中添加 `--compile-commands-dir=/path/to/build` 或直接修改 `.vscode/settings.json`：
-   ```json
-   {
-     "clangd.arguments": [
-       "--compile-commands-dir=/path/to/build"
-     ]
-   }
-   ```
-6. 在 `.vscode/tasks.json` 中配置构建任务：
-   ```json
-   {
-     "version": "2.0.0",
-     "tasks": [
-       {
-         "label": "build",
-         "type": "shell",
-         "command": "cd /path/to/build && make -j$(nproc) && make install",
-         "group": {
-           "kind": "build",
-           "isDefault": true
-         }
-       }
-     ]
-   }
-   ```
-   并在 `.vscode/launch.json` 中配置调试任务：
-   ```json
-   {
-     "version": "0.2.0",
-     "configurations": [
-       {
-         "name": "build",
-         "type": "lldb",
-         "request": "launch",
-         "program": "/path/to/pkg/bin/RedPandaIDE",
-         "args": [],
-         "cwd": "/path/to/build",
-         "env": {
-           "QT_ASSUME_STDERR_HAS_CONSOLE": "1"
-         },
-         "preLaunchTask": "build"
-       }
-     ]
-   }
-   ```
+1. 安装 [xmake](https://xmake.io/) 和 [XMake 扩展](https://marketplace.visualstudio.com/items?itemName=tboox.xmake-vscode)。
+2. 安装 [C/C++ 扩展](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) 以支持语言和调试功能。
+3. 根据需要安装 [clangd](https://clangd.llvm.org/) 和 [clangd 扩展](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd)以获得更好的代码分析能力。
+4. 配置工作区：
+   - 编译命令：`.vscode/compile_commands.json`（命令面板中的 “C/C++: 编辑配置(UI)”）；
+   - “Clangd: Arguments”：`--compile-commands-dir=.vscode`；
+   - “Xmake: Additional Config Arguments”：如 `--qt=/usr`。
+5. 在命令面板中执行 “XMake: UpdateIntellisense” 以生成编译数据库。
+
+\* 提示：xmake 的引入是为了支持编译数据库的生成和功能测试矩阵，目前并不完备。
 
 # Windows
 
@@ -281,7 +237,7 @@ qmake 变量：
 - 安装 Qt 5（≥ 5.12）Base、SVG、Tools 模块，包括库和开发文件。
 - 如果使用静态版本的 Qt 编译，还要安装 fcitx5-qt。
 
-构建：
+基于 qmake 构建：
 
 1. 配置：
    ```bash
@@ -301,6 +257,23 @@ qmake 变量:
 - `LIBEXECDIR`：辅助程序的路径，默认值是 `$PREFIX/libexec`。Arch Linux 使用 `/usr/lib`。
 - `XDG_ADAPTIVE_ICON=ON`：遵循 [freedesktop.org 图标主题规范](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html)安装图标，以适应不同的主题和尺寸。AppImage 需要启用此项；Linux 打包 `PREFIX=/usr` 时推荐启用此项。
 - `LINUX_STATIC_IME_PLUGIN=ON`（make 阶段）：静态链接输入法插件。推荐在使用静态版本的 Qt 编译时启用；**不要**在使用动态版本的 Qt 编译时启用。
+
+基于 xmake 构建：
+
+1. 配置：
+   ```bash
+   xmake f -p linux -a x86_64 -m release --qt=/usr --prefix=/usr/local
+   ```
+2. 构建：
+   ```bash
+   xmake
+   ```
+3. 安装：
+   ```bash
+   sudo xmake install --root -o /  # -o ... 模拟了 make install 的 DESTDIR=...
+   ```
+
+提示：`xmake f --help` 可以查看更多选项。
 
 ## Debian 及其衍生版本
 

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -593,7 +593,6 @@ ENABLE_LUA_ADDON {
 theme_files.files += $$files(themes/*.png, false)
 
 colorscheme_files.files += $$files(colorschemes/*.scheme, false)
-colorscheme_files.prefix = /colorschemes
 
 RESOURCES += qmake_qm_files
 RESOURCES += iconsets_files

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -248,7 +248,7 @@ QString Settings::Dirs::data(Settings::Dirs::DataType dataType) const
     case DataType::None:
         return dataDir;
     case DataType::ColorScheme:
-        return ":/colorschemes/colorschemes";
+        return ":/colorschemes";
     case DataType::IconSet:
         return ":/resources/iconsets";
     case DataType::Theme:

--- a/RedPandaIDE/settingsdialog/projectversioninfowidget.cpp
+++ b/RedPandaIDE/settingsdialog/projectversioninfowidget.cpp
@@ -17,6 +17,7 @@
 #include "projectversioninfowidget.h"
 #include "ui_projectversioninfowidget.h"
 #include <windows.h>
+#include <iterator>
 #include "../mainwindow.h"
 #include "../project.h"
 
@@ -24,15 +25,15 @@ static QStringList languageNames;
 static QList<int> languageIDs;
 
 static BOOL CALLBACK localeEnumProc(
-  _In_ LPTSTR lpLocaleString
+  _In_ wchar_t *lpLocaleString
         ) {
 
     QString s = QString::fromWCharArray(lpLocaleString);
     bool ok;
     int aid = s.mid(4,4).toInt(&ok,16);
     if (ok) {
-        TCHAR buffer [1024];
-        GetLocaleInfo(aid, LOCALE_SLANGUAGE,buffer,sizeof(buffer)/2);
+        wchar_t buffer [1024];
+        GetLocaleInfoW(aid, LOCALE_SLANGUAGE, buffer, sizeof(buffer) / sizeof(wchar_t));
         languageNames.append(QString::fromWCharArray(buffer));
         languageIDs.append(aid);
     }
@@ -45,7 +46,7 @@ ProjectVersionInfoWidget::ProjectVersionInfoWidget(const QString &name, const QS
 {
     ui->setupUi(this);
     if (languageNames.isEmpty()) {
-        EnumSystemLocales(localeEnumProc, LCID_SUPPORTED);
+        EnumSystemLocalesW(localeEnumProc, LCID_SUPPORTED);
     }
     ui->cbLanguage->addItems(languageNames);
 }

--- a/RedPandaIDE/utils.cpp
+++ b/RedPandaIDE/utils.cpp
@@ -205,7 +205,7 @@ bool programHasConsole(const QString & filename)
 {
 #ifdef Q_OS_WIN
     bool result = false;
-    HANDLE handle = CreateFile(filename.toStdWString().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+    HANDLE handle = CreateFileW(filename.toStdWString().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     if (handle != INVALID_HANDLE_VALUE) {
         IMAGE_DOS_HEADER dos_header;
         DWORD signature;

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -1,0 +1,237 @@
+set_languages("cxx17")
+
+target("RedPandaIDE")
+    add_rules("qt.widgetapp", "qt.ts")
+
+    add_deps("redpanda_qt_utils", "qsynedit")
+    add_frameworks("QtNetwork", "QtPrintSupport", "QtSvg")
+    add_includedirs(".")
+
+    -- defines
+
+    add_options("app-name", "prefix", "libexecdir")
+    add_options("lua-addon", "sdcc", "vcs")
+
+    if TEST_VERSION ~= nil then
+        add_defines('REDPANDA_CPP_VERSION="' .. APP_VERSION .. '-' .. TEST_VERSION .. '"')
+    else
+        add_defines('REDPANDA_CPP_VERSION="' .. APP_VERSION .. '"')
+    end
+
+    if is_arch("x86_64") then
+        add_defines("ARCH_X86_64=1")
+    elseif is_arch("i[3456]86") then
+        add_defines("ARCH_X86=1")
+    end
+
+    -- files
+
+    add_files(
+        "autolinkmanager.cpp",
+        "colorscheme.cpp",
+        "customfileiconprovider.cpp",
+        "gdbmiresultparser.cpp",
+        "main.cpp",
+        "projectoptions.cpp",
+        "settings.cpp",
+        "syntaxermanager.cpp",
+        "systemconsts.cpp",
+        "utils.cpp",
+        "visithistorymanager.cpp",
+        -- compiler
+        "compiler/compilerinfo.cpp",
+        -- parser
+        "parser/cpppreprocessor.cpp",
+        "parser/cpptokenizer.cpp",
+        "parser/parserutils.cpp",
+        -- problems
+        "problems/freeprojectsetformat.cpp",
+        "problems/ojproblemset.cpp",
+        "problems/problemcasevalidator.cpp")
+
+    add_moc_classes(
+        "caretlist",
+        "codesnippetsmanager",
+        "cpprefacter",
+        "debugger",
+        "editor",
+        "editorlist",
+        "iconsmanager",
+        "project",
+        "projecttemplate",
+        "shortcutmanager",
+        "symbolusagemanager",
+        "thememanager",
+        "todoparser",
+        "toolsmanager",
+        -- compiler
+        "compiler/compiler",
+        "compiler/compilermanager",
+        "compiler/executablerunner",
+        "compiler/filecompiler",
+        "compiler/ojproblemcasesrunner",
+        "compiler/projectcompiler",
+        "compiler/runner",
+        "compiler/stdincompiler",
+        -- parser
+        "parser/cppparser",
+        "parser/statementmodel",
+        -- settings dialog
+        "settingsdialog/settingswidget",
+        -- widgets
+        "widgets/bookmarkmodel",
+        "widgets/classbrowser",
+        "widgets/classbrowser",
+        "widgets/codecompletionlistview",
+        "widgets/codecompletionpopup",
+        "widgets/coloredit",
+        "widgets/compileargumentswidget",
+        "widgets/consolewidget",
+        "widgets/customdisablediconengine",
+        "widgets/customfilesystemmodel",
+        "widgets/darkfusionstyle",
+        "widgets/editorstabwidget",
+        "widgets/functiontooltipwidget",
+        "widgets/headercompletionpopup",
+        "widgets/issuestable",
+        "widgets/labelwithmenu",
+        "widgets/lightfusionstyle",
+        "widgets/linenumbertexteditor",
+        "widgets/macroinfomodel",
+        "widgets/ojproblemsetmodel",
+        "widgets/qconsole",
+        "widgets/qpatchedcombobox",
+        "widgets/searchresultview",
+        "widgets/shortcutinputedit",
+        "widgets/shrinkabletabwidget")
+
+    add_ui_classes(
+        "mainwindow",
+        -- settings dialog
+        "settingsdialog/compilerautolinkwidget",
+        "settingsdialog/compilersetdirectorieswidget",
+        "settingsdialog/compilersetoptionwidget",
+        "settingsdialog/debuggeneralwidget",
+        "settingsdialog/editorautosavewidget",
+        "settingsdialog/editorclipboardwidget",
+        "settingsdialog/editorcodecompletionwidget",
+        "settingsdialog/editorcolorschemewidget",
+        "settingsdialog/editorcustomctypekeywords",
+        "settingsdialog/editorfontwidget",
+        "settingsdialog/editorgeneralwidget",
+        "settingsdialog/editormiscwidget",
+        "settingsdialog/editorsnippetwidget",
+        "settingsdialog/editorsymbolcompletionwidget",
+        "settingsdialog/editorsyntaxcheckwidget",
+        "settingsdialog/editortooltipswidget",
+        "settingsdialog/environmentappearancewidget",
+        "settingsdialog/environmentfolderswidget",
+        "settingsdialog/environmentperformancewidget",
+        "settingsdialog/environmentprogramswidget",
+        "settingsdialog/environmentshortcutwidget",
+        "settingsdialog/executorgeneralwidget",
+        "settingsdialog/executorproblemsetwidget",
+        "settingsdialog/formattergeneralwidget",
+        "settingsdialog/languageasmgenerationwidget",
+        "settingsdialog/projectcompileparamaterswidget",
+        "settingsdialog/projectcompilerwidget",
+        "settingsdialog/projectdirectorieswidget",
+        "settingsdialog/projectdllhostwidget",
+        "settingsdialog/projectfileswidget",
+        "settingsdialog/projectgeneralwidget",
+        "settingsdialog/projectmakefilewidget",
+        "settingsdialog/projectoutputwidget",
+        "settingsdialog/projectprecompilewidget",
+        "settingsdialog/settingsdialog",
+        "settingsdialog/toolsgeneralwidget",
+        -- widgets
+        "widgets/aboutdialog",
+        "widgets/choosethemedialog",
+        "widgets/cpudialog",
+        "widgets/custommakefileinfodialog",
+        "widgets/filepropertiesdialog",
+        "widgets/infomessagebox",
+        "widgets/newclassdialog",
+        "widgets/newheaderdialog",
+        "widgets/newprojectdialog",
+        "widgets/newprojectunitdialog",
+        "widgets/newtemplatedialog",
+        "widgets/ojproblempropertywidget",
+        "widgets/projectalreadyopendialog",
+        "widgets/searchdialog",
+        "widgets/searchinfiledialog",
+        "widgets/signalmessagedialog")
+
+    add_files("*.qrc", "translations/*.ts")
+
+    add_files(
+        "resources/iconsets/**.svg", "resources/iconsets/**.json",
+        "themes/*.png",
+        "colorschemes/*.scheme",
+        {rule = "RedPandaIDE.auto_qrc"})
+
+    if is_os("windows") then
+        add_ui_classes(
+            "settingsdialog/environmentfileassociationwidget",
+            "settingsdialog/projectversioninfowidget")
+    else
+        add_ui_classes(
+            "settingsdialog/formatterpathwidget")
+    end
+
+    if has_config("lua-addon") then
+        add_deps("lua")
+        add_files(
+            "addon/api.cpp",
+            "addon/executor.cpp",
+            "addon/runtime.cpp")
+        add_files(
+            "themes/*.lua",
+            {rule = "RedPandaIDE.auto_qrc"})
+        add_links("lua")
+    else
+        add_files(
+            "themes/*.json",
+            {rule = "RedPandaIDE.auto_qrc"})
+    end
+
+    if has_config("sdcc") then
+        add_moc_classes(
+            "compiler/sdccfilecompiler",
+            "compiler/sdccprojectcompiler")
+    end
+
+    if has_config("vcs") then
+        add_moc_classes(
+            "vcs/gitmanager",
+            "vcs/gitrepository",
+            "vcs/gitutils")
+        add_ui_classes(
+            "settingsdialog/toolsgitwidget",
+            "vcs/gitbranchdialog",
+            "vcs/gitfetchdialog",
+            "vcs/gitlogdialog",
+            "vcs/gitmergedialog",
+            "vcs/gitpulldialog",
+            "vcs/gitpushdialog",
+            "vcs/gitremotedialog",
+            "vcs/gitresetdialog",
+            "vcs/gituserconfigdialog")
+    end
+
+    -- libs
+
+    if is_plat("windows") then
+        add_links("redpanda_qt_utils", "qsynedit")  -- xmake 2.8.6 workaround
+    else
+        add_linkgroups("redpanda_qt_utils", "qsynedit", {whole = true})
+    end
+    if is_os("windows") then
+        add_links("psapi", "shlwapi")
+    end
+
+    -- install
+
+    if is_xdg() then
+        on_install(install_bin)
+    end

--- a/libs/lua/xmake.lua
+++ b/libs/lua/xmake.lua
@@ -1,0 +1,49 @@
+target("lua")
+    set_kind("static")
+
+    if is_os("macosx") then
+        add_defines("LUA_USE_MACOSX")
+    elseif is_os("linux", "bsd") then
+        add_defines("LUA_USE_LINUX")  -- BSDs are Linux in Lua source
+    end
+
+    add_files(
+        "lua/lapi.c",
+        "lua/lcode.c",
+        "lua/lctype.c",
+        "lua/ldebug.c",
+        "lua/ldo.c",
+        "lua/ldump.c",
+        "lua/lfunc.c",
+        "lua/lgc.c",
+        "lua/llex.c",
+        "lua/lmem.c",
+        "lua/lobject.c",
+        "lua/lopcodes.c",
+        "lua/lparser.c",
+        "lua/lstate.c",
+        "lua/lstring.c",
+        "lua/ltable.c",
+        "lua/ltm.c",
+        "lua/lundump.c",
+        "lua/lvm.c",
+        "lua/lzio.c")
+    add_files(
+        "lua/lauxlib.c",
+        "lua/lbaselib.c",
+        "lua/lcorolib.c",
+        "lua/ldblib.c",
+        "lua/liolib.c",
+        "lua/lmathlib.c",
+        "lua/loadlib.c",
+        "lua/loslib.c",
+        "lua/lstrlib.c",
+        "lua/ltablib.c",
+        "lua/lutf8lib.c",
+        "lua/linit.c")
+
+    add_includedirs(".", {public = true})
+    add_headerfiles("lua/lua.h", "lua/lua.hpp")
+
+    -- do not install
+    on_install(function (target) end)

--- a/libs/qsynedit/xmake.lua
+++ b/libs/qsynedit/xmake.lua
@@ -1,0 +1,44 @@
+target("qsynedit")
+    add_rules("qt.static")
+    add_rules("qt.ts")
+    add_frameworks("QtGui", "QtWidgets")
+    add_deps("redpanda_qt_utils")
+
+    add_files(
+        "qsynedit/codefolding.cpp",
+        "qsynedit/constants.cpp",
+        "qsynedit/keystrokes.cpp",
+        "qsynedit/miscprocs.cpp",
+        "qsynedit/painter.cpp",
+        "qsynedit/types.cpp",
+        -- exporter
+        "qsynedit/exporter/exporter.cpp",
+        "qsynedit/exporter/htmlexporter.cpp",
+        "qsynedit/exporter/qtsupportedhtmlexporter.cpp",
+        "qsynedit/exporter/rtfexporter.cpp",
+        -- formatter
+        "qsynedit/formatter/cppformatter.cpp",
+        "qsynedit/formatter/formatter.cpp",
+        -- syntaxer
+        "qsynedit/syntaxer/asm.cpp",
+        "qsynedit/syntaxer/cpp.cpp",
+        "qsynedit/syntaxer/glsl.cpp",
+        "qsynedit/syntaxer/lua.cpp",
+        "qsynedit/syntaxer/makefile.cpp",
+        "qsynedit/syntaxer/syntaxer.cpp")
+
+    add_moc_classes(
+        "qsynedit/document",
+        "qsynedit/gutter",
+        "qsynedit/qsynedit",
+        -- searcher
+        "qsynedit/searcher/baseseacher",
+        "qsynedit/searcher/basicsearcher",
+        "qsynedit/searcher/regexsearcher")
+
+    add_ui_classes()
+
+    add_includedirs(".", {interface = true})
+
+    -- do not install
+    on_install(function (target) end)

--- a/libs/redpanda_qt_utils/qt_utils/utils.cpp
+++ b/libs/redpanda_qt_utils/qt_utils/utils.cpp
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "qt_utils/utils.h"
+#include "utils.h"
 #include <QApplication>
 #include <QByteArray>
 #include <QDir>

--- a/libs/redpanda_qt_utils/xmake.lua
+++ b/libs/redpanda_qt_utils/xmake.lua
@@ -1,0 +1,11 @@
+target("redpanda_qt_utils")
+    add_rules("qt.static")
+    add_rules("qt.ts")
+    add_frameworks("QtGui", "QtWidgets")
+
+    add_files("qt_utils/utils.cpp")
+    add_moc_classes("qt_utils/charsetinfo")
+    add_includedirs(".", {interface = true})
+
+    -- do not install
+    on_install(function (target) end)

--- a/tools/astyle/xmake.lua
+++ b/tools/astyle/xmake.lua
@@ -1,0 +1,20 @@
+target("astyle")
+    set_kind("binary")
+
+    add_options("mingw-static")
+
+    if is_os("windows") then
+        add_links("shell32")
+    end
+
+    add_files(
+        "ASBeautifier.cpp",
+        "ASEnhancer.cpp",
+        "ASFormatter.cpp",
+        "ASLocalizer.cpp",
+        "ASResource.cpp",
+        "astyle_main.cpp")
+
+    if is_xdg() then
+        on_install(install_libexec)
+    end

--- a/tools/consolepauser/xmake.lua
+++ b/tools/consolepauser/xmake.lua
@@ -1,0 +1,20 @@
+target("consolepauser")
+    set_kind("binary")
+
+    add_options("mingw-static")
+
+    if is_os("windows") then
+        add_files("main.windows.cpp")
+    else
+        add_files("main.unix.cpp")
+    end
+
+    if is_os("windows") then
+        add_syslinks("psapi")
+    elseif is_os("linux") then
+        add_syslinks("rt")
+    end
+
+    if is_xdg() then
+        on_install(install_libexec)
+    end

--- a/tools/redpanda-git-askpass/xmake.lua
+++ b/tools/redpanda-git-askpass/xmake.lua
@@ -1,0 +1,9 @@
+target("redpanda-git-askpass")
+    add_rules("qt.widgetapp")
+
+    add_files("main.cpp")
+    add_ui_classes("dialog")
+
+    if is_xdg() then
+        on_install(install_libexec)
+    end

--- a/tools/redpanda-win-git-askpass/xmake.lua
+++ b/tools/redpanda-win-git-askpass/xmake.lua
@@ -1,0 +1,10 @@
+target("redpanda-win-git-askpass")
+    set_kind("binary")
+
+    add_files("main.cpp")
+
+    add_files(
+        -- "redpanda-git-askpass_private.rc",  -- drives xmake crazy
+        "resource.rc")
+
+    add_links("user32")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,246 @@
+APP_VERSION = "2.26"
+TEST_VERSION = "alpha8"
+
+add_rules("mode.debug", "mode.release")
+set_warnings("all", "extra", "pedantic")
+set_languages("cxx17", "c11")
+set_encodings("utf-8")
+
+function is_xdg()
+    return is_os("linux", "bsd")
+end
+
+if is_os("windows") then
+    add_defines("NOMINMAX")
+    add_defines("_WIN32_WINNT=0x0501")
+end
+
+option("app-name")
+    set_default("RedPandaCPP")
+    set_showmenu(true)
+    add_defines("APP_NAME=\"$(app-name)\"")
+
+option("prefix")
+    if is_xdg() then
+        set_showmenu(true)
+        set_default("/usr/local")
+    else
+        set_showmenu(false)
+        set_default("")
+    end
+    add_defines('PREFIX="$(prefix)"')
+
+option("libexecdir")
+    add_deps("prefix")
+    if is_xdg() then
+        set_default("$prefix/libexec")  -- dummy
+        set_showmenu(true)
+        before_check(function (option)
+            option:set_value(option:dep("prefix"):value() .. "/libexec")
+        end)
+    else
+        set_default("")
+        set_showmenu(false)
+    end
+    add_defines('LIBEXECDIR="$(libexecdir)"')
+
+-- feature flags
+
+option("lua-addon")
+    set_default(true)
+    set_showmenu(true)
+    add_defines("ENABLE_LUA_ADDON")
+
+option("sdcc")
+    set_default(true)
+    set_showmenu(true)
+    add_defines("ENABLE_SDCC")
+
+option("vcs")
+    set_default(false)
+    set_showmenu(true)
+    add_defines("ENABLE_VCS")
+
+option_end()
+
+rule("qt.ts")
+    add_deps("qt.env", "qt.qrc")
+    set_extensions(".ts")
+    on_config(function (target)
+        -- get lrelease
+        local qt = assert(target:data("qt"), "Qt not found!")
+        local lrelease = path.join(qt.bindir, is_host("windows") and "lrelease.exe" or "lrelease")
+        assert(os.isexec(lrelease), "lrelease not found!")
+        -- save lrelease
+        target:data_set("qt.lrelease", lrelease)
+    end)
+    on_buildcmd_file(function (target, batchcmds, sourcefile_ts, opt)
+        -- get tools
+        local lrelease = target:data("qt.lrelease")
+        local rcc = target:data("qt.rcc")
+        -- get qm file
+        local sourcefile_qm = path.join(target:autogendir(), "rules", "qt", "ts", path.basename(sourcefile_ts) .. ".qm")
+        local sourcefile_dir = path.directory(sourcefile_qm)
+        -- prepare qrc file
+        local sourcefile_qrc = path.join(target:autogendir(), "rules", "qt", "ts", path.basename(sourcefile_ts) .. ".qrc")
+        io.writefile(sourcefile_qrc, [[
+            <RCC>
+            <qresource prefix="/i18n">
+                <file alias="]] .. path.filename(sourcefile_qm) .. [[">]] .. path.absolute(sourcefile_qm) .. [[</file>
+            </qresource>
+            </RCC>
+        ]])
+        -- get c++ source file for qrc
+        local sourcefile_cpp = path.join(target:autogendir(), "rules", "qt", "ts", path.basename(sourcefile_ts) .. ".cpp")
+        -- add objectfile
+        local objectfile = target:objectfile(sourcefile_cpp)
+        table.insert(target:objectfiles(), objectfile)
+        -- add commands
+        batchcmds:show_progress(opt.progress, "${color.build.object}compiling.qt.ts %s", sourcefile_ts)
+        batchcmds:mkdir(sourcefile_dir)
+        batchcmds:vrunv(lrelease, {sourcefile_ts, "-qm", sourcefile_qm})
+        batchcmds:vrunv(rcc, {"-name", path.basename(sourcefile_qrc), sourcefile_qrc, "-o", sourcefile_cpp})
+        batchcmds:compile(sourcefile_cpp, objectfile)
+        -- add deps
+        batchcmds:add_depfiles(sourcefile_ts)
+        batchcmds:set_depmtime(os.mtime(objectfile))
+        batchcmds:set_depcache(target:dependfile(objectfile))
+    end)
+
+rule("RedPandaIDE.auto_qrc")
+    add_deps("qt.env", "qt.qrc")
+    on_buildcmd_files(function (target, batchcmds, sourcebatch, opt)
+        local name = 'RedPandaIDE_auto_qrc'
+        -- prepare qrc file
+        local qrc_content = [[
+            <RCC>
+                <qresource prefix="/">
+        ]]
+        for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+            if is_host("windows") then
+                sourcefile = sourcefile:gsub("\\", "/")
+            end
+            qrc_content = qrc_content .. [[
+                   <file alias="]] .. string.gsub(sourcefile, "^RedPandaIDE/", "") .. [[">]] .. path.absolute(sourcefile) .. [[</file>
+            ]]
+        end
+        qrc_content = qrc_content .. [[
+                </qresource>
+            </RCC>
+        ]]
+        local sourcefile_qrc = path.join(target:autogendir(), "rules", "qt", "auto_qrc", name .. ".qrc")
+        io.writefile(sourcefile_qrc, qrc_content)
+        -- get rcc
+        local rcc = target:data("qt.rcc")
+        -- get c++ source file for qrc
+        local sourcefile_cpp = path.join(target:autogendir(), "rules", "qt", "auto_qrc", name .. ".cpp")
+        -- add objectfile
+        local objectfile = target:objectfile(sourcefile_cpp)
+        table.insert(target:objectfiles(), objectfile)
+        -- add commands
+        batchcmds:show_progress(opt.progress, "${color.build.object}compiling.RedPandaIDE.auto_qrc")
+        batchcmds:vrunv(rcc, {"-name", name, sourcefile_qrc, "-o", sourcefile_cpp})
+        batchcmds:compile(sourcefile_cpp, objectfile)
+        -- add deps
+        batchcmds:add_depfiles(sourcebatch.sourcefiles)
+        batchcmds:set_depmtime(os.mtime(objectfile))
+        batchcmds:set_depcache(target:dependfile(objectfile))
+    end)
+
+rule_end()
+
+function add_moc_classes(...)
+    local classes = {...}
+    for _, class in ipairs(classes) do
+        add_files(
+            class .. ".cpp",
+            class .. ".h")
+    end
+end
+
+function add_ui_classes(...)
+    local classes = {...}
+    for _, class in ipairs(classes) do
+        add_files(
+            class .. ".cpp",
+            class .. ".h",
+            class .. ".ui")
+    end
+end
+
+-- imitate `make DESTDIR=... install` on XDG platforms
+
+function install_libexec(target)
+    local installdir = target:installdir() .. "/$(libexecdir)/$(app-name)"
+    print("installing", target:name(), "to", installdir, "..")
+    os.cp(target:targetfile(), installdir .. "/" .. target:filename())
+end
+
+function install_bin(target)
+    local installdir = target:installdir() .. "/$(prefix)/bin"
+    print("installing", target:name(), "to", installdir, "..")
+    os.cp(target:targetfile(), installdir .. "/" .. target:filename())
+end
+
+includes("RedPandaIDE")
+if has_config("lua-addon") then
+    includes("libs/lua")
+end
+includes("libs/qsynedit")
+includes("libs/redpanda_qt_utils")
+includes("tools/astyle")
+includes("tools/consolepauser")
+if has_config("vcs") then
+    if is_os("windows") then
+        includes("tools/redpanda-win-git-askpass")
+    else
+        includes("tools/redpanda-git-askpass")
+    end
+end
+
+target("resources")
+    set_kind("phony")
+
+    -- templates
+
+    if is_xdg() then
+        add_installfiles("platform/linux/templates/(**.*)", {prefixdir = "$(prefix)/share/$(app-name)/templates"})
+    elseif is_os("windows") then
+        add_installfiles("platform/windows/templates/(**.*)", {prefixdir = "bin/templates"})
+        if is_arch("x86_64") then
+            add_installfiles("platform/windows/templates-win64/(**.*)", {prefixdir = "bin/templates"})
+        end
+    end
+
+    -- docs
+
+    if is_xdg() then
+        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "$(prefix)/share/doc/$(app-name)"})
+    else
+        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "bin"})
+    end
+
+    -- icon
+
+    if is_xdg() then
+        add_installfiles("platform/linux/redpandaide.svg", {prefixdir = "$(prefix)/share/icons/hicolor/scalable/apps"})
+    end
+
+    -- desktop entry
+
+    if is_xdg() then
+        add_configfiles("platform/linux/redpandaide.desktop.in", {
+            pattern = "$${(.-)}",
+            variables = {
+                PREFIX = get_config("prefix"),
+                REDPANDA_ICON_PATH = "redpandaide",
+            },
+        })
+        add_installfiles("$(buildir)/redpandaide.desktop", {prefixdir = "$(prefix)/share/applications"})
+    end
+
+    -- qt.conf
+
+    if is_os("windows") then
+        add_installfiles("platform/windows/qt.conf", {prefixdir = "bin"})
+    end


### PR DESCRIPTION
- xmake generating compilation database (`compile_commands.json`) makes it easier to work with various editors/IDEs.
- xmake makes feature matrix test much easier.
- Current status:
  - Compilation database generation: seems to work on all platforms.
  - Full build: only works with Linux system libs and Windows MSVC dynamic libs.