### PR TITLE
Disable openSUSE CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,6 +252,7 @@ jobs:
   rpm_opensuse:
     name: RPM on openSUSE Tumbleweed
     runs-on: ubuntu-latest
+    if: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It seems broken due to an upstream or environment issue.