### PR TITLE
修复一些BUG，改良用户体验

### DIFF
--- a/RedPandaIDE/FileNameDelegate.cpp
+++ b/RedPandaIDE/FileNameDelegate.cpp
@@ -1,0 +1,106 @@
+/* by XY0797 2024.2.21 */
+
+#include "FileNameDelegate.h"
+#include <QLineEdit>
+#include <QFileInfo>
+
+// 自定义编辑框控件。之所以要这样子，是因为QLineEdit获取焦点后的默认行为是全选，如果在获取焦点前设置选区，会被获取焦点后的全选给覆盖
+// Custom edit box control. This is necessary because the default behavior of a QLineEdit when it gains focus is to select all its text, and if a selection is set before gaining focus, it will be overridden by the select-all action upon focusing.
+class MyLineEdit : public QLineEdit
+{
+public:
+    explicit MyLineEdit(QWidget *parent = nullptr) : QLineEdit(parent) {}
+
+    // 添加自定义方法设置焦点获取时的选区
+    // Add a custom method to set the selection on focus gain.
+    void setFocusSelectState(int index, int length)
+    {
+        m_focusSelectionStart = index;
+        m_focusSelectionLength = length;
+    }
+
+protected:
+    int m_focusSelectionStart = -1;
+    int m_focusSelectionLength = -1;
+
+    // 覆写焦点获取事件，在执行默认操作前重置选区
+    // Override the focus-in event, resetting the selection before executing the default operation.
+    void focusInEvent(QFocusEvent *event) override
+    {
+        if (m_focusSelectionStart != -1 && m_focusSelectionLength > 0)
+        {
+            deselect();
+            setSelection(m_focusSelectionStart, m_focusSelectionLength);
+        }
+        QLineEdit::focusInEvent(event);
+    }
+};
+
+// 返回'.'在字符串里最后一次出现的位置，如果找不到就返回字符串的长度
+// Return the last occurrence index of '.' in the string; if not found, return the length of the string.
+int findDotPosition(const QString &fileName)
+{
+    int dotPosition = fileName.lastIndexOf('.');
+    if (dotPosition != -1)
+    {
+        return dotPosition;
+    }
+    else
+    {
+        return fileName.length();
+    }
+}
+
+// 下面是委托类的实现
+// Below follows the implementation of the delegate class.
+
+FileNameDelegate::FileNameDelegate(QObject *parent) : QStyledItemDelegate(parent) {}
+
+// 创建编辑器时使用我们的自定义组件
+// Use our custom component when creating the editor.
+QWidget *FileNameDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    MyLineEdit *editor = new MyLineEdit(parent);
+    return editor;
+}
+
+// 设置内容，如果是文件就设置获取焦点后的选区为非后缀内容
+// Set the content, and if the item is a file, set the selection on focus gain to exclude the file extension.
+void FileNameDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    MyLineEdit *lineEdit = (MyLineEdit *)editor;
+    QString fileName = index.data().toString();
+    lineEdit->setText(fileName);
+    // 判断目前待编辑的是目录还是文件，如果是目录就没必要设置选区
+    // Determine whether the currently edited item is a directory or a file; if it's a directory, there's no need to set a selection.
+    Qt::ItemFlags flags = index.flags();
+    if (flags & Qt::ItemNeverHasChildren) {
+        lineEdit->setFocusSelectState(0, findDotPosition(fileName));
+    }
+}
+
+// 把编辑后的数据返回到QTreeView
+// Return the edited data back to the QTreeView.
+void FileNameDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+    MyLineEdit *lineEdit = (MyLineEdit *)editor;
+    model->setData(index, lineEdit->text());
+}
+
+// 重新计算矩形的左边和宽度，避开图标显示
+// Recalculate the rectangle's left side and width to avoid overlapping with the icon display.
+QRect adjustForIcon(const QRect &originalRect)
+{
+    // 避让图标显示
+    // Adjust the position to accommodate the icon display.
+    int theiconWidth = 20;
+    return QRect(originalRect.x() + theiconWidth, originalRect.y(), originalRect.width() - theiconWidth, originalRect.height());
+}
+
+// 重写位置更新方法
+// Override the method for updating the editor's position.
+void FileNameDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    MyLineEdit *lineEdit = (MyLineEdit *)editor;
+    lineEdit->setGeometry(adjustForIcon(option.rect));
+}

--- a/RedPandaIDE/FileNameDelegate.h
+++ b/RedPandaIDE/FileNameDelegate.h
@@ -1,0 +1,19 @@
+#ifndef FILENAMEDELEGATE_H
+#define FILENAMEDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class FileNameDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    FileNameDelegate(QObject *parent = nullptr);
+
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+};
+
+#endif // FILENAMEDELEGATE_H

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -176,6 +176,7 @@ SOURCES += \
     widgets/cpudialog.cpp \
     debugger.cpp \
     editor.cpp \
+    FileNameDelegate.cpp \
     editorlist.cpp \
     iconsmanager.cpp \
     main.cpp \
@@ -303,6 +304,7 @@ HEADERS += \
     widgets/cpudialog.h \
     debugger.h \
     editor.h \
+    FileNameDelegate.h \
     editorlist.h \
     iconsmanager.h \
     mainwindow.h \

--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4524,7 +4524,10 @@ void MainWindow::onFilesViewCreateFile()
     // workaround: try create but do not truncate
     file.open(QFile::ReadWrite);
 #endif
-    QModelIndex newIndex = mFileSystemModel.index(fileName);
+    file.close();
+    // Refresh
+    mFileSystemModel.setRootPath(mFileSystemModel.rootPath());
+    QModelIndex newIndex = mFileSystemModel.index(dir.filePath(fileName));
     ui->treeFiles->setCurrentIndex(newIndex);
     ui->treeFiles->edit(newIndex);
 }

--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -18,6 +18,7 @@
 #include "ui_mainwindow.h"
 #include "editorlist.h"
 #include "editor.h"
+#include "FileNameDelegate.h"
 #include "systemconsts.h"
 #include "settings.h"
 #include "qsynedit/constants.h"
@@ -396,6 +397,8 @@ MainWindow::MainWindow(QWidget *parent)
     for (int i=1;i<mFileSystemModel.columnCount();i++) {
         ui->treeFiles->hideColumn(i);
     }
+    FileNameDelegate *fileNameDelegate = new FileNameDelegate(this);
+    ui->treeFiles->setItemDelegate(fileNameDelegate);
     connect(ui->cbFilesPath->lineEdit(),&QLineEdit::returnPressed,
             this,&MainWindow::onFilesViewPathChanged);
     connect(ui->cbFilesPath, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -4523,6 +4526,7 @@ void MainWindow::onFilesViewCreateFile()
 #endif
     QModelIndex newIndex = mFileSystemModel.index(fileName);
     ui->treeFiles->setCurrentIndex(newIndex);
+    ui->treeFiles->edit(newIndex);
 }
 
 

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -4109,6 +4109,10 @@ void Settings::Environment::doSave()
     //Appearance
     saveValue("theme", mTheme);
     saveValue("interface_font", mInterfaceFont);
+    if (mInterfaceFontSize < 5){
+        // Prevent users from being unable to undo settings due to interface visibility issues after making incorrect adjustments.
+        mInterfaceFontSize = 5;
+    }
     saveValue("interface_font_size", mInterfaceFontSize);
     saveValue("icon_zoom_factor",mIconZoomFactor);
     saveValue("language", mLanguage);

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -55,6 +55,7 @@ target("RedPandaIDE")
         "cpprefacter",
         "debugger",
         "editor",
+        "FileNameDelegate",
         "editorlist",
         "iconsmanager",
         "project",


### PR DESCRIPTION
# 本PR的主要内容

1. 新建文件后，将自动进入编辑状态
2. 进入文件重命名状态后，默认将仅选中文件名，不选中后缀
3. 当用户设置的“字体大小”小于5时，强制设置为5。这么做是因为这种情况下往往是用户设置错了，然后用户会因为文字过小看不见界面而无法撤销更改(主要是我自己遇到过)

# 具体实现

## 1. 新建文件后，将自动进入编辑状态

在`RedPandaIDE/mainwindow.cpp:4524`

先关闭文件，然后通过`mFileSystemModel.setRootPath(mFileSystemModel.rootPath());`来刷新

最后再获取newIndex并且进入修改状态

## 2. 进入文件重命名状态后，默认将仅选中文件名，不选中后缀

`RedPandaIDE/FileNameDelegate.cpp`和`RedPandaIDE/FileNameDelegate.h`定义了委托类和相关辅助函数

对于`ui->treeFiles`，使用`setItemDelegate`方法设置委托，从而覆写默认创建的`QLineEdit`组件

```cpp
    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
```

函数的解释：

`createEditor`：创建编辑框组件

`setEditorData`：从`treeFiles`读取内容到编辑框

`setModelData`：输入完成，把编辑框内容写入`treeFiles`

`updateEditorGeometry`：更新编辑框的位置

但是不能直接使用`QLineEdit`组件然后在`setEditorData`使用`setSelection`方法

这是因为`QLineEdit`组件在获取焦点后默认会全选文本，导致我们之前设置的选区被覆盖掉

所以说自定义了`MyLineEdit`类继承`QLineEdit`，提供`setFocusSelectState`方法，让我们可以存下设定的选区位置

```cpp
class MyLineEdit : public QLineEdit
{
public:
    explicit MyLineEdit(QWidget *parent = nullptr) : QLineEdit(parent) {}
```

然后覆写`QLineEdit.focusInEvent`，在调用默认的`focusInEvent`前执行`setSelection`

```cpp
    void focusInEvent(QFocusEvent *event) override
    {
        if (m_focusSelectionStart != -1 && m_focusSelectionLength > 0)
        {
            deselect();
            setSelection(m_focusSelectionStart, m_focusSelectionLength);
        }
        QLineEdit::focusInEvent(event);
    }
```

这样子就能避免`QLineEdit`的默认行为带来的副作用

然后在`setEditorData`里面不能直接找后缀`setFocusSelectState`。因为如果被重命名的文件夹，就不能只选最后一个'.'前面的内容

通过`index.flags()`判断有没有`Qt::ItemNeverHasChildren`属性，如果有就说明是文件(也就是判断是否可展开)

```cpp
// 设置内容，如果是文件就设置获取焦点后的选区为非后缀内容
void FileNameDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
{
    MyLineEdit *lineEdit = (MyLineEdit *)editor;
    QString fileName = index.data().toString();
    lineEdit->setText(fileName);
    // 判断目前待编辑的是目录还是文件，如果是目录就没必要设置选区
    Qt::ItemFlags flags = index.flags();
    if (flags & Qt::ItemNeverHasChildren) {
        lineEdit->setFocusSelectState(0, findDotPosition(fileName));
    }
}
```

在`updateEditorGeometry`里面不能直接`lineEdit->setGeometry(option.rect);`设置提供的宽高

这是因为`ui->treeFiles`有一个宽度20的图标，所以说需要右移20并且减少20的宽度：

```cpp
QRect adjustForIcon(const QRect &originalRect)
{
    // 避让图标显示
    int theiconWidth = 20;
    return QRect(originalRect.x() + theiconWidth, originalRect.y(), originalRect.width() - theiconWidth, originalRect.height());
}
void FileNameDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
{
    MyLineEdit *lineEdit = (MyLineEdit *)editor;
    lineEdit->setGeometry(adjustForIcon(option.rect));
}
```

然后为了能编译，得在`RedPandaIDE/RedPandaIDE.pro`和`RedPandaIDE/xmake.lua`加一下头文件和源文件

## 3. 当用户设置的“字体大小”小于5时，强制设置为5。

在`RedPandaIDE/settings.cpp`添加个判断：

```cpp
    if (mInterfaceFontSize < 5){
        mInterfaceFontSize = 5;
    }
```