### PR TITLE
fix: 修复了新建文件无法进入选择状态和重命名状态的BUG

### DIFF
--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4521,7 +4521,10 @@ void MainWindow::onFilesViewCreateFile()
     // workaround: try create but do not truncate
     file.open(QFile::ReadWrite);
 #endif
-    QModelIndex newIndex = mFileSystemModel.index(fileName);
+    file.close();
+    // Refresh, otherwise it cannot be selected
+    mFileSystemModel.setRootPath(mFileSystemModel.rootPath());
+    QModelIndex newIndex = mFileSystemModel.index(dir.filePath(fileName));
     ui->treeFiles->setCurrentIndex(newIndex);
 }
 


### PR DESCRIPTION
# 本PR的主要内容

修复新建文件后，不会自动选中并且进入编辑状态的BUG

# 具体实现

在`RedPandaIDE/mainwindow.cpp:4524`

先关闭文件，然后通过`mFileSystemModel.setRootPath(mFileSystemModel.rootPath());`来刷新文件树

最后再获取newIndex并且进入修改状态