### PR TITLE
fix: 修复了新建文件无法进入选择状态和重命名状态的BUG

### DIFF
--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4521,8 +4521,12 @@ void MainWindow::onFilesViewCreateFile()
     // workaround: try create but do not truncate
     file.open(QFile::ReadWrite);
 #endif
-    QModelIndex newIndex = mFileSystemModel.index(fileName);
+    file.close();
+    // Refresh, otherwise it cannot be selected
+    mFileSystemModel.setRootPath(mFileSystemModel.rootPath());
+    QModelIndex newIndex = mFileSystemModel.index(dir.filePath(fileName));
     ui->treeFiles->setCurrentIndex(newIndex);
+    ui->treeFiles->edit(newIndex);
 }
 
 

--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -4433,15 +4433,17 @@ void MainWindow::onShowInsertCodeSnippetMenu()
 void MainWindow::onFilesViewCreateFolderFolderLoaded(const QString& path)
 {
 
-    if (mFilesViewNewCreatedFolder.isEmpty())
+    if (mFilesViewNewCreatedFolder.isEmpty() && mFilesViewNewCreatedFile.isEmpty())
         return;
 
-    if (path!=extractFilePath(mFilesViewNewCreatedFolder))
+    if (path!=extractFilePath(mFilesViewNewCreatedFolder) && path!=extractFilePath(mFilesViewNewCreatedFile))
         return;
 
     disconnect(&mFileSystemModel,&QFileSystemModel::directoryLoaded,
             this,&MainWindow::onFilesViewCreateFolderFolderLoaded);
-    QModelIndex newIndex = mFileSystemModel.index(mFilesViewNewCreatedFolder);
+
+    QModelIndex newIndex = mFileSystemModel.index(mFilesViewNewCreatedFolder.isEmpty() ? mFilesViewNewCreatedFile : mFilesViewNewCreatedFolder);
+
     if (newIndex.isValid()) {
         ui->treeFiles->setCurrentIndex(newIndex);
         ui->treeFiles->edit(newIndex);
@@ -4499,7 +4501,6 @@ void MainWindow::onFilesViewCreateFile()
             dir = QDir(mFileSystemModel.fileInfo(index).absoluteFilePath());
         else
             dir = mFileSystemModel.fileInfo(index).absoluteDir();
-        ui->treeFiles->expand(index);
     } else {
         dir = mFileSystemModel.rootDirectory();
     }
@@ -4522,11 +4523,11 @@ void MainWindow::onFilesViewCreateFile()
     file.open(QFile::ReadWrite);
 #endif
     file.close();
-    // Refresh, otherwise it cannot be selected
-    mFileSystemModel.setRootPath(mFileSystemModel.rootPath());
     QModelIndex newIndex = mFileSystemModel.index(dir.filePath(fileName));
-    ui->treeFiles->setCurrentIndex(newIndex);
-    ui->treeFiles->edit(newIndex);
+    connect(&mFileSystemModel,&QFileSystemModel::directoryLoaded,
+            this,&MainWindow::onFilesViewCreateFolderFolderLoaded);
+    ui->treeFiles->expand(index);
+    mFilesViewNewCreatedFile=mFileSystemModel.filePath(newIndex);
 }
 
 

--- a/RedPandaIDE/mainwindow.h
+++ b/RedPandaIDE/mainwindow.h
@@ -906,6 +906,7 @@ private:
 
     QString mClassBrowserCurrentStatement;
     QString mFilesViewNewCreatedFolder;
+    QString mFilesViewNewCreatedFile;
 
     bool mCheckSyntaxInBack;
     bool mShouldRemoveAllSettings;


### PR DESCRIPTION
# 本PR的主要内容

修复新建文件后，不会自动选中并且进入重命名状态的BUG

# 具体实现

在`RedPandaIDE/mainwindow.cpp:4524`

```cpp
    file.close();
    QModelIndex newIndex = mFileSystemModel.index(dir.filePath(fileName));
    connect(&mFileSystemModel,&QFileSystemModel::directoryLoaded,
            this,&MainWindow::onFilesViewCreateFolderFolderLoaded);
    ui->treeFiles->expand(index);
    mFilesViewNewCreatedFile=mFileSystemModel.filePath(newIndex);
```

在`RedPandaIDE/mainwindow.h`新定义`QString mFilesViewNewCreatedFile;`

并且在`onFilesViewCreateFolderFolderLoaded`添加了对`mFilesViewNewCreatedFile`的判断

也就是采用了和新建文件夹一样的等待刷新方法

(如果采用`mFileSystemModel.setRootPath(mFileSystemModel.rootPath());`的方法大部分情况下也能正常刷新，但是如果用户创建了一个文件夹，并且这个文件夹是第一次创建，并且文件夹处于未展开状态，那么就会导致新建的文件无法被选中。如果采用和新建文件夹一样的方法就不会有这个问题)

