### PR TITLE
enhancement: 限制字体大小不得小于5

### DIFF
--- a/RedPandaIDE/settingsdialog/environmentappearancewidget.ui
+++ b/RedPandaIDE/settingsdialog/environmentappearancewidget.ui
@@ -95,7 +95,11 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QSpinBox" name="spinFontSize"/>
+       <widget class="QSpinBox" name="spinFontSize">
+        <property name="minimum">
+         <number>5</number>
+        </property>
+       </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer_3">


### PR DESCRIPTION
# 本PR的主要内容

修改`EnvironmentAppearanceWidget`的UI，限制“字体大小”最小设置为5。

这么做是因为这种情况下往往是用户设置错了，然后用户会因为文字过小看不见界面而无法撤销更改(主要是我自己遇到过)

# 具体实现

修改`RedPandaIDE/settingsdialog/environmentappearancewidget.ui`，为QSpinBox添加minimum属性