### PR TITLE
Move from command line to argv array

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,30 @@
+name: Unit
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu_makefile_escape:
+    name: Unix makefile escape
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: '2.8.6'
+
+      - name: Setup Qt
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libqt5svg5-dev qtbase5-dev qtbase5-dev-tools qttools5-dev-tools
+
+      - name: Build
+        run: |
+          xmake f --qt=/usr
+          xmake b test-escape
+
+      - name: Test
+        run: |
+          export QT_ASSUME_STDERR_HAS_CONSOLE=1
+          xmake r test-escape

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Red Panda C++ Version 2.27
   - enhancement: Limit the minimum font size in options dialog to 5. (by XY0797@github.com)
   - enhancement: After a new file is created in filesystem panel, auto select and rename it. (by XY0797@github.com)
   - enhancement: Select file basename when rename in the filesystem panel. (by XY0797@github.com)
+  - enhancement: Migrate external calls from command string to argv array to improve safety and security.
+  - enhancement: Support POSIX shell-like escaping in user inputs for compiler arguments.
+  - fix: (Hopefully) properly escape filenames and arguments in makefile generation.
 
 Red Panda C++ Version 2.26
   - enhancement: Code suggestion for embedded std::vectors.

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -177,6 +177,7 @@ SOURCES += \
     debugger.cpp \
     editor.cpp \
     editorlist.cpp \
+    escape.cpp \
     iconsmanager.cpp \
     main.cpp \
     mainwindow.cpp \
@@ -305,6 +306,7 @@ HEADERS += \
     debugger.h \
     editor.h \
     editorlist.h \
+    escape.h \
     iconsmanager.h \
     mainwindow.h \
     settingsdialog/compilersetdirectorieswidget.h \

--- a/RedPandaIDE/compiler/compiler.h
+++ b/RedPandaIDE/compiler/compiler.h
@@ -70,14 +70,14 @@ protected:
     virtual QByteArray pipedText();
     virtual bool prepareForRebuild() = 0;
     virtual bool beforeRunExtraCommand(int idx);
-    virtual QString getCharsetArgument(const QByteArray& encoding, FileType fileType, bool onlyCheckSyntax);
-    virtual QString getCCompileArguments(bool checkSyntax);
-    virtual QString getCppCompileArguments(bool checkSyntax);
-    virtual QString getCIncludeArguments();
-    virtual QString getProjectIncludeArguments();
-    virtual QString getCppIncludeArguments();
-    virtual QString getLibraryArguments(FileType fileType);
-    virtual QString parseFileIncludesForAutolink(
+    virtual QStringList getCharsetArgument(const QByteArray& encoding, FileType fileType, bool onlyCheckSyntax);
+    virtual QStringList getCCompileArguments(bool checkSyntax);
+    virtual QStringList getCppCompileArguments(bool checkSyntax);
+    virtual QStringList getCIncludeArguments();
+    virtual QStringList getProjectIncludeArguments();
+    virtual QStringList getCppIncludeArguments();
+    virtual QStringList getLibraryArguments(FileType fileType);
+    virtual QStringList parseFileIncludesForAutolink(
             const QString& filename,
             QSet<QString>& parsedFiles);
     virtual bool parseForceUTF8ForAutolink(
@@ -85,15 +85,16 @@ protected:
             QSet<QString>& parsedFiles);
     void log(const QString& msg);
     void error(const QString& msg);
-    void runCommand(const QString& cmd, const QString& arguments, const QString& workingDir, const QByteArray& inputText=QByteArray(), const QString& outputFile=QString());
+    void runCommand(const QString& cmd, const QStringList& arguments, const QString& workingDir, const QByteArray& inputText=QByteArray(), const QString& outputFile=QString());
+    QString dumpCommandForLog(const QString &cmd, const QStringList &arguments);
 
 protected:
     bool mOnlyCheckSyntax;
     QString mCompiler;
-    QString mArguments;
-    QStringList mExtraCompilersList;
-    QStringList mExtraArgumentsList;
-    QStringList mExtraOutputFilesList;
+    QStringList mArguments;
+    QList<QString> mExtraCompilersList;
+    QList<QStringList> mExtraArgumentsList;
+    QList<QString> mExtraOutputFilesList;
     QString mOutputFile;
     int mErrorCount;
     int mWarningCount;

--- a/RedPandaIDE/compiler/compilermanager.cpp
+++ b/RedPandaIDE/compiler/compilermanager.cpp
@@ -267,7 +267,7 @@ void CompilerManager::run(
                 QString::number(consoleFlag),
                 sharedMemoryId,
                 localizePath(filename)
-            } + splitProcessCommand(arguments);
+            } + parseArgumentsWithoutVariables(arguments);
             if (pSettings->environment().useCustomTerminal()) {
                 auto [filename, args, fileOwner] = wrapCommandForTerminalEmulator(
                     pSettings->environment().terminalPath(),
@@ -285,7 +285,7 @@ void CompilerManager::run(
             }
         } else {
             //delete when thread finished
-            execRunner = new ExecutableRunner(filename,splitProcessCommand(arguments),workDir);
+            execRunner = new ExecutableRunner(filename, parseArgumentsWithoutVariables(arguments), workDir);
         }
 #else
         QStringList execArgs;
@@ -310,19 +310,19 @@ void CompilerManager::run(
                     sharedMemoryId,
                     redirectInputFilename,
                     localizePath(filename),
-                } + splitProcessCommand(arguments);
+                } + parseArgumentsWithoutVariables(arguments);
             } else {
                 execArgs = QStringList{
                     consolePauserPath,
                     QString::number(consoleFlag),
                     sharedMemoryId,
                     localizePath(filename),
-                } + splitProcessCommand(arguments);
+                } + parseArgumentsWithoutVariables(arguments);
             }
         } else {
             execArgs = QStringList{
                 localizePath(filename),
-            } + splitProcessCommand(arguments);
+            } + parseArgumentsWithoutVariables(arguments);
         }
         auto [filename, args, fileOwner] = wrapCommandForTerminalEmulator(
             pSettings->environment().terminalPath(),
@@ -336,7 +336,7 @@ void CompilerManager::run(
         execRunner->setStartConsole(true);
     } else {
         //delete when thread finished
-        execRunner = new ExecutableRunner(filename,splitProcessCommand(arguments),workDir);
+        execRunner = new ExecutableRunner(filename, parseArgumentsWithoutVariables(arguments), workDir);
     }
     if (redirectInput) {
         execRunner->setRedirectInput(true);
@@ -380,7 +380,7 @@ void CompilerManager::doRunProblem(const QString &filename, const QString &argum
     if (mRunner!=nullptr) {
         return;
     }
-    OJProblemCasesRunner * execRunner = new OJProblemCasesRunner(filename,splitProcessCommand(arguments),workDir,problemCases);
+    OJProblemCasesRunner * execRunner = new OJProblemCasesRunner(filename, parseArgumentsWithoutVariables(arguments), workDir, problemCases);
     mRunner = execRunner;
     if (pSettings->executor().enableCaseLimit()) {
         execRunner->setExecTimeout(pSettings->executor().caseTimeout());

--- a/RedPandaIDE/compiler/filecompiler.cpp
+++ b/RedPandaIDE/compiler/filecompiler.cpp
@@ -66,20 +66,20 @@ bool FileCompiler::prepareForCompile()
     log(tr("- Compiler Set Name: %1").arg(compilerSet()->name()));
     log("");
     FileType fileType = getFileType(mFilename);
-    mArguments = QString(" \"%1\"").arg(mFilename);
+    mArguments = QStringList{mFilename};
     if (!mOnlyCheckSyntax) {
         switch(compilerSet()->compilationStage()) {
         case Settings::CompilerSet::CompilationStage::PreprocessingOnly:
             mOutputFile=changeFileExt(mFilename,compilerSet()->preprocessingSuffix());
-            mArguments+=" -E";
+            mArguments << "-E";
             break;
         case Settings::CompilerSet::CompilationStage::CompilationProperOnly:
             mOutputFile=changeFileExt(mFilename,compilerSet()->compilationProperSuffix());
-            mArguments+=" -S -fverbose-asm";
+            mArguments += {"-S", "-fverbose-asm"};
             break;
         case Settings::CompilerSet::CompilationStage::AssemblingOnly:
             mOutputFile=changeFileExt(mFilename,compilerSet()->assemblingSuffix());
-            mArguments+=" -c";
+            mArguments << "-c";
             break;
         case Settings::CompilerSet::CompilationStage::GenerateExecutable:
             mOutputFile = changeFileExt(mFilename,compilerSet()->executableSuffix());
@@ -91,14 +91,14 @@ bool FileCompiler::prepareForCompile()
             }
         }
 #endif
-        mArguments+=QString(" -o \"%1\"").arg(mOutputFile);
+        mArguments += {"-o", mOutputFile};
 
 #if defined(ARCH_X86_64) || defined(ARCH_X86)
         if (mCompileType == CppCompileType::GenerateAssemblyOnly) {
             if (pSettings->languages().noSEHDirectivesWhenGenerateASM())
-                mArguments+=" -fno-asynchronous-unwind-tables";
+                mArguments << "-fno-asynchronous-unwind-tables";
             if (pSettings->languages().x86DialectOfASMGenerated()==Settings::Languages::X86ASMDialect::Intel)
-                mArguments+=" -masm=intel";
+                mArguments << "-masm=intel";
         }
 #endif
         //remove the old file if it exists
@@ -171,7 +171,7 @@ bool FileCompiler::prepareForCompile()
                 break;
         }
         if (hasStart) {
-            mArguments+=" -nostartfiles";
+            mArguments << "-nostartfiles";
         }
     }
 
@@ -185,7 +185,8 @@ bool FileCompiler::prepareForCompile()
     log(tr("Processing %1 source file:").arg(strFileType));
     log("------------------");
     log(tr("%1 Compiler: %2").arg(strFileType).arg(mCompiler));
-    log(tr("Command: %1 %2").arg(extractFileName(mCompiler)).arg(mArguments));
+    QString command = dumpCommandForLog(mCompiler, mArguments);
+    log(tr("Command: %1").arg(command));
     mDirectory = extractFileDir(mFilename);
     return true;
 }

--- a/RedPandaIDE/compiler/sdccprojectcompiler.cpp
+++ b/RedPandaIDE/compiler/sdccprojectcompiler.cpp
@@ -18,6 +18,9 @@
 #include "../project.h"
 #include "compilermanager.h"
 #include "../systemconsts.h"
+#include "qt_utils/utils.h"
+#include "utils.h"
+#include "escape.h"
 
 #include <QDir>
 
@@ -40,17 +43,17 @@ void SDCCProjectCompiler::createStandardMakeFile()
     newMakeFile(file);
     QString suffix = compilerSet()->executableSuffix();
     if (suffix == SDCC_IHX_SUFFIX) {
-        writeln(file,"$(BIN): $(OBJ)");
-        writeln(file,"\t$(CC) $(LIBS) -o $(BIN) $(LINKOBJ)");
+        writeln(file,"$(BIN_TAR): $(OBJ)");
+        writeln(file,"\t$(CC) $(LIBS) -o $(BIN_ARG) $(LINKOBJ)");
     } else {
-        writeln(file,"$(IHX): $(OBJ)\n");
-        writeln(file,"\t$(CC) $(LIBS) -o $(IHX) $(LINKOBJ)");
+        writeln(file,"$(IHX_TAR): $(OBJ)\n");
+        writeln(file,"\t$(CC) $(LIBS) -o $(IHX_ARG) $(LINKOBJ)");
         if (suffix == SDCC_HEX_SUFFIX) {
-            writeln(file,"$(BIN): $(IHX)");
-            writeln(file,"\t$(PACKIHX) $(IHX) > $(BIN)");
+            writeln(file,"$(BIN_TAR): $(IHX_DEP)");
+            writeln(file,"\t$(PACKIHX) $(IHX_ARG) > $(BIN_ARG)");
         } else {
-            writeln(file,"$(BIN): $(IHX)");
-            writeln(file,"\t$(MAKEBIN) $(IHX) $(BIN)");
+            writeln(file,"$(BIN_TAR): $(IHX_DEP)");
+            writeln(file,"\t$(MAKEBIN) $(IHX_ARG) $(BIN_ARG)");
         }
     }
     writeMakeObjFilesRules(file);
@@ -102,9 +105,9 @@ void SDCCProjectCompiler::writeMakeHeader(QFile &file)
 void SDCCProjectCompiler::writeMakeDefines(QFile &file)
 {
     // Get list of object files
-    QString Objects;
-    QString LinkObjects;
-    QString cleanObjects;
+    QStringList Objects;
+    QStringList LinkObjects;
+    QStringList cleanObjects;
 
     // Create a list of object files
     foreach(const PProjectUnit &unit, mProject->unitList()) {
@@ -122,67 +125,52 @@ void SDCCProjectCompiler::writeMakeDefines(QFile &file)
                 QString fullObjFile = includeTrailingPathDelimiter(mProject->options().objectOutput)
                         + extractFileName(unit->fileName());
                 QString relativeObjFile = extractRelativePath(mProject->directory(), changeFileExt(fullObjFile, SDCC_REL_SUFFIX));
-                QString objFile = genMakePath2(relativeObjFile);
-                Objects += ' ' + objFile;
-#ifdef Q_OS_WIN
-                cleanObjects += ' ' + genMakePath1(relativeObjFile).replace("/",QDir::separator());
-#else
-                cleanObjects += ' ' + genMakePath1(relativeObjFile);
-#endif
+                Objects << relativeObjFile;
+                cleanObjects << localizePath(relativeObjFile);
                 if (unit->link()) {
-                    LinkObjects += ' ' + genMakePath1(relativeObjFile);
+                    LinkObjects << relativeObjFile;
                 }
             } else {
-                Objects += ' ' + genMakePath2(changeFileExt(RelativeName, SDCC_REL_SUFFIX));
-#ifdef Q_OS_WIN
-                cleanObjects += ' ' + genMakePath1(changeFileExt(RelativeName, SDCC_REL_SUFFIX)).replace("/",QDir::separator());
-#else
-                cleanObjects += ' ' + genMakePath1(changeFileExt(RelativeName, SDCC_REL_SUFFIX));
-#endif
+                Objects << changeFileExt(RelativeName, SDCC_REL_SUFFIX);
+                cleanObjects << localizePath(changeFileExt(RelativeName, SDCC_REL_SUFFIX));
                 if (unit->link())
-                    LinkObjects = LinkObjects + ' ' + genMakePath1(changeFileExt(RelativeName, SDCC_REL_SUFFIX));
+                    LinkObjects << changeFileExt(RelativeName, SDCC_REL_SUFFIX);
             }
         }
     }
 
-    Objects = Objects.trimmed();
-    LinkObjects = LinkObjects.trimmed();
+    QString cc = extractFileName(compilerSet()->CCompiler());
 
+    QStringList cCompileArguments = getCCompileArguments(mOnlyCheckSyntax);
+    if (cCompileArguments.contains("-g3"))
+        cCompileArguments << "-D__DEBUG__";
+    QStringList libraryArguments = getLibraryArguments(FileType::Project);
+    QStringList cIncludeArguments = getCIncludeArguments() + getProjectIncludeArguments();
 
-    // Get list of applicable flags
-    QString cCompileArguments = getCCompileArguments(mOnlyCheckSyntax);
-    QString libraryArguments = getLibraryArguments(FileType::Project);
-    QString cIncludeArguments = getCIncludeArguments() + " " + getProjectIncludeArguments();
+    QString executable = extractRelativePath(mProject->makeFileName(), mProject->executable());
+    QString cleanExe = localizePath(executable);
+    QString ihx = extractRelativePath(mProject->makeFileName(), changeFileExt(mProject->executable(), SDCC_IHX_SUFFIX));
+    QString cleanIhx = localizePath(ihx);
 
-    if (cCompileArguments.indexOf(" -g3")>=0
-            || cCompileArguments.startsWith("-g3")) {
-        cCompileArguments += " -D__DEBUG__";
-    }
+    writeln(file, "CC       = " + escapeArgumentForMakefileVariableValue(cc, true));
+    writeln(file, "PACKIHX  = " PACKIHX_PROGRAM);
+    writeln(file, "MAKEBIN  = " MAKEBIN_PROGRAM);
 
-    writeln(file,"CC       = " + extractFileName(compilerSet()->CCompiler()));
-    writeln(file,QString("PACKIHX  = ") + PACKIHX_PROGRAM);
-    writeln(file,QString("MAKEBIN  = ") + MAKEBIN_PROGRAM);
-
-    writeln(file,"OBJ      = " + Objects);
-    writeln(file,"LINKOBJ  = " + LinkObjects);
-#ifdef Q_OS_WIN
-    writeln(file,"CLEANOBJ  = " + cleanObjects +
-            + " " + genMakePath1(extractRelativePath(mProject->makeFileName(), changeFileExt(mProject->executable(),SDCC_IHX_SUFFIX))).replace("/",QDir::separator())
-            + " " + genMakePath1(extractRelativePath(mProject->makeFileName(), mProject->executable())).replace("/",QDir::separator()) );
-#else
-    writeln(file,"CLEANOBJ  = " + cleanObjects +
-              + " " + genMakePath1(extractRelativePath(mProject->makeFileName(), mProject->executable())));
-#endif
-    libraryArguments.replace('\\', '/');
-    writeln(file,"LIBS     = " + libraryArguments);
-    cIncludeArguments.replace('\\', '/');
-    writeln(file,"INCS     = " + cIncludeArguments);
-    writeln(file,"IHX      = " + genMakePath1(extractRelativePath(mProject->makeFileName(), changeFileExt(mProject->executable(), SDCC_IHX_SUFFIX))));
-    writeln(file,"BIN      = " + genMakePath1(extractRelativePath(mProject->makeFileName(), mProject->executable())));
-    //writeln(file,"ENCODINGS = -finput-charset=utf-8 -fexec-charset='+GetSystemCharsetName);
-    cCompileArguments.replace('\\', '/');
-    writeln(file,"CFLAGS   = $(INCS) " + cCompileArguments);
-    writeln(file, QString("RM       = ") + CLEAN_PROGRAM );
+    writeln(file, "OBJ      = " + dumpFilenamesForMakefilePrerequisites(Objects));
+    writeln(file, "LINKOBJ  = " + dumpArgumentsForMakefileVariableValue(LinkObjects));
+    writeln(file,"CLEANOBJ = " + dumpArgumentsForMakefileVariableValue(cleanObjects) + ' ' +
+        escapeArgumentForMakefileVariableValue(cleanIhx, false) + ' ' +
+        escapeArgumentForMakefileVariableValue(cleanExe, false));
+    writeln(file, "LIBS     = " + dumpArgumentsForMakefileVariableValue(libraryArguments));
+    writeln(file, "INCS     = " + dumpArgumentsForMakefileVariableValue(cIncludeArguments));
+    writeln(file, "IHX_TAR  = " + escapeFilenameForMakefileTarget(ihx));
+    writeln(file, "IHX_DEP  = " + escapeFilenameForMakefilePrerequisite(ihx));
+    writeln(file, "IHX_ARG  = " + escapeArgumentForMakefileVariableValue(ihx, false));
+    writeln(file, "BIN_TAR  = " + escapeFilenameForMakefileTarget(executable));
+    writeln(file, "BIN_DEP  = " + escapeFilenameForMakefilePrerequisite(executable));
+    writeln(file, "BIN_ARG  = " + escapeArgumentForMakefileVariableValue(executable, false));
+    writeln(file, "CFLAGS   = $(INCS) " + dumpArgumentsForMakefileVariableValue(cCompileArguments));
+    writeln(file, "RM       = " CLEAN_PROGRAM);
 
     writeln(file);
 }
@@ -191,7 +179,7 @@ void SDCCProjectCompiler::writeMakeTarget(QFile &file)
 {
     writeln(file, ".PHONY: all all-before all-after clean clean-custom");
     writeln(file);
-    writeln(file, "all: all-before $(BIN) all-after");
+    writeln(file, "all: all-before $(BIN_DEP) all-after");
     writeln(file);
 
 }
@@ -199,7 +187,7 @@ void SDCCProjectCompiler::writeMakeTarget(QFile &file)
 void SDCCProjectCompiler::writeMakeIncludes(QFile &file)
 {
     foreach(const QString& s, mProject->options().makeIncludes) {
-        writeln(file, "include " + genMakePath1(s));
+        writeln(file, "include " + escapeFilenameForMakefileInclude(s));
     }
     if (!mProject->options().makeIncludes.isEmpty()) {
         writeln(file);
@@ -209,16 +197,13 @@ void SDCCProjectCompiler::writeMakeIncludes(QFile &file)
 void SDCCProjectCompiler::writeMakeClean(QFile &file)
 {
     writeln(file, "clean: clean-custom");
-    QString target="$(CLEANOBJ)";
-
-    writeln(file, QString("\t-$(RM) %1 > %2 2>&1").arg(target,NULL_FILE));
+    writeln(file, QString("\t-$(RM) $(CLEANOBJ) > %1 2>&1").arg(NULL_FILE));
     writeln(file);
 }
 
 void SDCCProjectCompiler::writeMakeObjFilesRules(QFile &file)
 {
     PCppParser parser = mProject->cppParser();
-    QString precompileStr;
 
     QList<PProjectUnit> projectUnits=mProject->unitList();
     foreach(const PProjectUnit &unit, projectUnits) {
@@ -233,7 +218,7 @@ void SDCCProjectCompiler::writeMakeObjFilesRules(QFile &file)
         QString shortFileName = extractRelativePath(mProject->makeFileName(),unit->fileName());
 
         writeln(file);
-        QString objStr=genMakePath2(shortFileName);
+        QString objStr = escapeFilenameForMakefilePrerequisite(shortFileName);
         // if we have scanned it, use scanned info
         if (parser && parser->fileScanned(unit->fileName())) {
             QSet<QString> fileIncludes = parser->getIncludedFiles(unit->fileName());
@@ -241,34 +226,36 @@ void SDCCProjectCompiler::writeMakeObjFilesRules(QFile &file)
                 if (unit2==unit)
                     continue;
                 if (fileIncludes.contains(unit2->fileName())) {
-                    objStr = objStr + ' ' + genMakePath2(extractRelativePath(mProject->makeFileName(),unit2->fileName()));
+                    QString header = extractRelativePath(mProject->makeFileName(),unit2->fileName());
+                    objStr = objStr + ' ' + escapeFilenameForMakefilePrerequisite(header);
                 }
             }
         } else {
             foreach(const PProjectUnit &unit2, projectUnits) {
                 FileType fileType = getFileType(unit2->fileName());
-                if (fileType == FileType::CHeader || fileType==FileType::CppHeader)
-                    objStr = objStr + ' ' + genMakePath2(extractRelativePath(mProject->makeFileName(),unit2->fileName()));
+                if (fileType == FileType::CHeader || fileType==FileType::CppHeader) {
+                    QString header = extractRelativePath(mProject->makeFileName(),unit2->fileName());
+                    objStr = objStr + ' ' + escapeFilenameForMakefilePrerequisite(header);
+                }
             }
         }
-        QString objFileName;
-        QString objFileName2;
+        QString objFileNameTarget;
+        QString objFileNameCommand;
         if (!mProject->options().objectOutput.isEmpty()) {
             QString fullObjname = includeTrailingPathDelimiter(mProject->options().objectOutput) +
                     extractFileName(unit->fileName());
-            objFileName = genMakePath2(extractRelativePath(mProject->makeFileName(), changeFileExt(fullObjname, SDCC_REL_SUFFIX)));
-            objFileName2 = genMakePath1(extractRelativePath(mProject->makeFileName(), changeFileExt(fullObjname, SDCC_REL_SUFFIX)));
-//            if (!extractFileDir(ObjFileName).isEmpty()) {
-//                objStr = genMakePath2(includeTrailingPathDelimiter(extractFileDir(ObjFileName))) + objStr;
-//            }
+            QString objFile = extractRelativePath(mProject->makeFileName(), changeFileExt(fullObjname, SDCC_REL_SUFFIX));
+            objFileNameTarget = escapeFilenameForMakefileTarget(objFile);
+            objFileNameCommand = escapeArgumentForMakefileRecipe(objFile, false);
         } else {
-            objFileName = genMakePath2(changeFileExt(shortFileName, SDCC_REL_SUFFIX));
-            objFileName2 = genMakePath1(changeFileExt(shortFileName, SDCC_REL_SUFFIX));
+            QString objFile = changeFileExt(shortFileName, SDCC_REL_SUFFIX);
+            objFileNameTarget = escapeFilenameForMakefileTarget(objFile);
+            objFileNameCommand = escapeArgumentForMakefileRecipe(objFile, false);
         }
 
-        objStr = objFileName + ": "+objStr+precompileStr;
+        objStr = objFileNameTarget + ": " + objStr;
 
-        writeln(file,objStr);
+        writeln(file, objStr);
 
         // Write custom build command
         if (unit->overrideBuildCmd() && !unit->buildCmd().isEmpty()) {
@@ -278,7 +265,7 @@ void SDCCProjectCompiler::writeMakeObjFilesRules(QFile &file)
             // Or roll our own
         } else {
             if (fileType==FileType::CSource) {
-                writeln(file, "\t$(CC) $(CFLAGS) -c " + genMakePath1(shortFileName));
+                writeln(file, "\t$(CC) $(CFLAGS) -c " + escapeArgumentForMakefileRecipe(shortFileName, false));
             }
         }
     }
@@ -323,39 +310,44 @@ bool SDCCProjectCompiler::prepareForCompile()
     QString parallelParam;
     if (mProject->options().allowParallelBuilding) {
         if (mProject->options().parellelBuildingJobs==0) {
-            parallelParam = " --jobs";
+            parallelParam = "--jobs";
         } else {
-            parallelParam = QString(" -j%1").arg(mProject->options().parellelBuildingJobs);
+            parallelParam = QString("-j%1").arg(mProject->options().parellelBuildingJobs);
         }
+    } else {
+        parallelParam = "-j1";
     }
 
+    QString makefile = 
+            extractRelativePath(mProject->directory(), mProject->makeFileName());
+    QStringList cleanArgs{
+        "-f",
+        makefile,
+        "clean",
+    };
+    QStringList makeAllArgs{
+        parallelParam,
+        "-f",
+        makefile,
+        "all",
+    };
     if (onlyClean()) {
-        mArguments = QString(" %1 -f \"%2\" clean").arg(parallelParam,
-                                                        extractRelativePath(
-                                                            mProject->directory(),
-                                                            mProject->makeFileName()));
+        mArguments = cleanArgs;
     } else if (mRebuild) {
-        mArguments = QString("  -f \"%1\" clean").arg(extractRelativePath(
-                                                            mProject->directory(),
-                                                            mProject->makeFileName()));
-        mExtraCompilersList.append(mCompiler);
-        mExtraOutputFilesList.append("");
-        mExtraArgumentsList.append(QString(" %1 -f \"%2\" all").arg(parallelParam,
-                                                            extractRelativePath(
-                                                            mProject->directory(),
-                                                            mProject->makeFileName())));
+        mArguments = cleanArgs;
+        mExtraCompilersList << mCompiler;
+        mExtraOutputFilesList << "";
+        mExtraArgumentsList << makeAllArgs;
     } else {
-        mArguments = QString(" %1 -f \"%2\" all").arg(parallelParam,
-                                                      extractRelativePath(
-                                                      mProject->directory(),
-                                                      mProject->makeFileName()));
+        mArguments = makeAllArgs;
     }
     mDirectory = mProject->directory();
 
     log(tr("Processing makefile:"));
     log("--------");
     log(tr("- makefile processer: %1").arg(mCompiler));
-    log(tr("- Command: %1 %2").arg(extractFileName(mCompiler)).arg(mArguments));
+    QString command = dumpCommandForLog(mCompiler, mArguments);
+    log(tr("- Command: %1").arg(command));
     log("");
 
     return true;

--- a/RedPandaIDE/compiler/stdincompiler.cpp
+++ b/RedPandaIDE/compiler/stdincompiler.cpp
@@ -46,7 +46,7 @@ bool StdinCompiler::prepareForCompile()
     }
     switch(fileType) {
     case FileType::CSource:
-        mArguments += " -x c - ";
+        mArguments += {"-x", "c", "-"};
         mArguments += getCCompileArguments(mOnlyCheckSyntax);
         mArguments += getCIncludeArguments();
         mArguments += getProjectIncludeArguments();
@@ -54,7 +54,7 @@ bool StdinCompiler::prepareForCompile()
         mCompiler = compilerSet()->CCompiler();
         break;
     case FileType::GAS:
-        mArguments += " -x assembler - ";
+        mArguments += {"-x", "assembler", "-"};
         mArguments += getCCompileArguments(mOnlyCheckSyntax);
         mArguments += getCIncludeArguments();
         mArguments += getProjectIncludeArguments();
@@ -64,7 +64,7 @@ bool StdinCompiler::prepareForCompile()
     case FileType::CppSource:
     case FileType::CppHeader:
     case FileType::CHeader:
-        mArguments += " -x c++ - ";
+        mArguments += {"-x", "c++", "-"};
         mArguments += getCppCompileArguments(mOnlyCheckSyntax);
         mArguments += getCppIncludeArguments();
         mArguments += getProjectIncludeArguments();
@@ -87,7 +87,8 @@ bool StdinCompiler::prepareForCompile()
     log(tr("Processing %1 source file:").arg(strFileType));
     log("------------------");
     log(tr("%1 Compiler: %2").arg(strFileType).arg(mCompiler));
-    log(tr("Command: %1 %2").arg(extractFileName(mCompiler)).arg(mArguments));
+    QString command = dumpCommandForLog(mCompiler, mArguments);
+    log(tr("Command: %1").arg(command));
     mDirectory = extractFileDir(mFilename);
     return true;
 }

--- a/RedPandaIDE/debugger.cpp
+++ b/RedPandaIDE/debugger.cpp
@@ -140,7 +140,7 @@ bool Debugger::start(int compilerSetIndex, const QString& inferior, const QStrin
         //deleted when thread finished
         QStringList params;
         if (pSettings->executor().useParams())
-            params = splitProcessCommand(pSettings->executor().params());
+            params = parseArgumentsWithoutVariables(pSettings->executor().params());
         mTarget = new DebugTarget(inferior,compilerSet->debugServer(),pSettings->debugger().GDBServerPort(),params);
         if (pSettings->executor().redirectInput())
             mTarget->setInputFile(pSettings->executor().inputFilename());

--- a/RedPandaIDE/escape.cpp
+++ b/RedPandaIDE/escape.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2020-2022 Roy Qu (royqh1979@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "escape.h"
+
+#include <QSet>
+#include <QRegularExpression>
+
+#ifdef _MSC_VER
+#define __builtin_unreachable() (__assume(0))
+#endif
+
+static QString contextualBackslashEscaping(const QString &arg, const QSet<QChar> &needsEscaping, bool escapeFinal = true)
+{
+    QString result;
+    for (auto it = arg.begin(); ; ++it) {
+        int nBackSlash = 0;
+        while (it != arg.end() && *it == '\\') {
+            ++it;
+            ++nBackSlash;
+        }
+        if (it == arg.end()) {
+            if (escapeFinal) {
+                // escape all backslashes, but leave following character unescaped
+                // (terminating double quote for CreateProcess, or LF or space in makefile)
+                result.append(QString('\\').repeated(nBackSlash * 2));
+            } else {
+                // leave all backslashes unescaped, and add a space to protect LF
+                result.append(QString('\\').repeated(nBackSlash));
+                if (nBackSlash > 0)
+                    result.push_back(' ');
+            }
+            break;
+        } else if (needsEscaping.contains(*it)) {
+            // escape all backslashes and the following character
+            result.append(QString('\\').repeated(nBackSlash * 2 + 1));
+            result.push_back(*it);
+        } else {
+            // backslashes aren't special here
+            result.append(QString('\\').repeated(nBackSlash));
+            result.push_back(*it);
+        }
+    }
+    return result;
+}
+
+QString escapeArgumentImplBourneAgainShellPretty(const QString &arg, bool isFirstArg)
+{
+    // ref. https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html
+
+    if (arg.isEmpty())
+        return R"("")";
+
+    /* POSIX say the following reserved words (may) have special meaning:
+     *   !, {, }, case, do, done, elif, else, esac, fi, for, if, in, then, until, while,
+     *   [[, ]], function, select,
+     * only if used as the _first word_ of a command (or somewhere we dot not care).
+     */
+    const static QSet<QString> reservedWord{
+        "!", "{", "}", "case", "do", "done", "elif", "else", "esac", "fi", "for", "if", "in", "then", "until", "while",
+        "[[", "]]", "function", "select",
+    };
+    if (isFirstArg && reservedWord.contains(arg))
+        return QString(R"("%1")").arg(arg);
+
+    /* POSIX say “shall quote”:
+     *   '|', '&', ';', '<', '>', '(', ')', '$', '`', '\\', '"', '\'', ' ', '\t', '\n';
+     * and “may need to be quoted”:
+     *   '*', '?', '[', '#', '~', '=', '%'.
+     * among which “may need to be quoted” there are 4 kinds:
+     *   - wildcards '*', '?', '[' are “danger anywhere” (handle it as if “shall quote”);
+     *   - comment '#', home '~', is “danger at first char in any word”;
+     *   - (environment) variable '=' is “danger at any char in first word”;
+     *   - foreground '%' is “danger at first char in first word”.
+     * although not mentioned by POSIX, bash’s brace expansion '{', '}' are also “danger anywhere”.
+     */
+
+    static QRegularExpression doubleQuotingDangerChars(R"([`$\\"])");
+    static QRegularExpression otherDangerChars(R"([|&;<>() \t\n*?\[\{\}])");
+    bool isDoubleQuotingDanger = arg.contains(doubleQuotingDangerChars);
+    bool isSingleQuotingDanger = arg.contains('\'');
+    bool isDangerAnyChar = isDoubleQuotingDanger || isSingleQuotingDanger || arg.contains(otherDangerChars);
+    bool isDangerFirstChar = (arg[0] == '#') || (arg[0] == '~');
+    if (isFirstArg) {
+        isDangerAnyChar = isDangerAnyChar || arg.contains('=');
+        isDangerFirstChar = isDangerFirstChar || (arg[0] == '%');
+    }
+
+    // a “safe” string
+    if (!isDangerAnyChar && !isDangerFirstChar)
+        return arg;
+
+    // prefer more-common double quoting
+    if (!isDoubleQuotingDanger)
+        return QString(R"("%1")").arg(arg);
+
+    // and then check the opportunity of single quoting
+    if (!isSingleQuotingDanger)
+        return QString("'%1'").arg(arg);
+
+    // escaping is necessary
+    // use double quoting since it’s less tricky
+    QString result = "\"";
+    for (auto ch : arg) {
+        if (ch == '$' || ch == '`' || ch == '\\' || ch == '"')
+            result.push_back('\\');
+        result.push_back(ch);
+    }
+    result.push_back('"');
+    return result;
+}
+
+QString escapeArgumentImplBourneAgainShellFast(QString arg)
+{
+    /* 1. replace each single quote with `'\''`, which contains
+     *    - a single quote to close quoting,
+     *    - an escaped single quote representing the single quote itself, and
+     *    - a single quote to open quoting again. */
+    arg.replace('\'', R"('\'')");
+    /* 2. enclose the string with a pair of single quotes. */
+    return '\'' + arg + '\'';
+}
+
+QString escapeArgumentImplWindowsCreateProcess(const QString &arg, bool forceQuote)
+{
+    // See https://stackoverflow.com/questions/31838469/how-do-i-convert-argv-to-lpcommandline-parameter-of-createprocess ,
+    // and https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way .
+
+    static QRegularExpression needQuoting(R"([ \t\n\v"])");
+    if (!arg.isEmpty() && !forceQuote && !arg.contains(needQuoting))
+        return arg;
+
+    return '"' + contextualBackslashEscaping(arg, {'"'}) + '"';
+}
+
+QString escapeArgumentImplWindowsCommandPrompt(const QString &arg)
+{
+    static QRegularExpression metaChars(R"([()%!^"<>&|])");
+    bool containsMeta = arg.contains(metaChars);
+    if (containsMeta) {
+        QString quoted = escapeArgumentImplWindowsCreateProcess(arg, false);
+        quoted.replace('^', "^^"); // handle itself first
+        quoted.replace('(', "^(");
+        quoted.replace(')', "^)");
+        quoted.replace('%', "^%");
+        quoted.replace('!', "^!");
+        quoted.replace('"', "^\"");
+        quoted.replace('<', "^<");
+        quoted.replace('>', "^>");
+        quoted.replace('&', "^&");
+        quoted.replace('|', "^|");
+        return quoted;
+    } else
+        return escapeArgumentImplWindowsCreateProcess(arg, false);
+}
+
+QString escapeArgument(const QString &arg, bool isFirstArg, EscapeArgumentRule rule)
+{
+    switch (rule) {
+    case EscapeArgumentRule::BourneAgainShellPretty:
+        return escapeArgumentImplBourneAgainShellPretty(arg, isFirstArg);
+    case EscapeArgumentRule::BourneAgainShellFast:
+        return escapeArgumentImplBourneAgainShellFast(arg);
+    case EscapeArgumentRule::WindowsCreateProcess:
+        return escapeArgumentImplWindowsCreateProcess(arg, false);
+    case EscapeArgumentRule::WindowsCreateProcessForceQuote:
+        return escapeArgumentImplWindowsCreateProcess(arg, true);
+    case EscapeArgumentRule::WindowsCommandPrompt:
+        return escapeArgumentImplWindowsCommandPrompt(arg);
+    default:
+        __builtin_unreachable();
+    }
+}
+
+EscapeArgumentRule platformShellEscapeArgumentRule()
+{
+#ifdef Q_OS_WIN
+    return EscapeArgumentRule::WindowsCommandPrompt;
+#else
+    return EscapeArgumentRule::BourneAgainShellPretty;
+#endif
+}
+
+QString escapeArgumentForPlatformShell(const QString &arg, bool isFirstArg)
+{
+    return escapeArgument(arg, isFirstArg, platformShellEscapeArgumentRule());
+}
+
+QString dumpCommandForPlatformShell(const QString &prog, const QStringList &args)
+{
+    QStringList escapedArgs{escapeArgumentForPlatformShell(prog, true)};
+    for (int i = 0; i < args.size(); ++i)
+        escapedArgs << escapeArgumentForPlatformShell(args[i], false);
+    return escapedArgs.join(' ');
+}
+
+EscapeArgumentRule makefileCommandEscapeArgumentRule()
+{
+#ifdef Q_OS_WIN
+    /* Lord knows why.
+
+      standard CreateProcess or CMD escaping:
+        child.exe -c main'.c -o main'.o
+      yielding:
+        0: [child.exe]
+        1: [-c]
+        2: [main.c -o main.o]
+      that's not what we want.
+
+      however, if CMD escaping a malformed argument
+        child.exe -c main'.c -o main'.o ^"mal \^" ^& calc^"
+      yielding:
+        0: [child.exe]
+        1: [-c]
+        2: [main'.c]
+        3: [-o]
+        4: [main'.o]
+        5: [mal " & calc]
+      it works?!?!?!
+
+      force-quoted CreateProcess escaping seems work on most cases.
+    */
+    return EscapeArgumentRule::WindowsCreateProcessForceQuote;
+#else
+    return EscapeArgumentRule::BourneAgainShellPretty;
+#endif
+}
+
+QString escapeArgumentForMakefileVariableValue(const QString &arg, bool isFirstArg)
+{
+    static QSet<QChar> needsMfEscaping = {'#'};
+    QString recipeEscaped = escapeArgument(arg, isFirstArg, makefileCommandEscapeArgumentRule());
+    QString mfEscaped = contextualBackslashEscaping(recipeEscaped, needsMfEscaping);
+    return mfEscaped.replace('$', "$$");
+}
+
+QString dumpArgumentsForMakefileVariableValue(const QStringList &args)
+{
+    QStringList escapedArgs;
+    for (int i = 0; i < args.size(); ++i)
+        escapedArgs << escapeArgumentForMakefileVariableValue(args[i], false);
+    return escapedArgs.join(' ');
+}
+
+QString escapeFilenameForMakefileInclude(const QString &filename)
+{
+    static QSet<QChar> needsEscaping{'#', ' '};
+    QString result = contextualBackslashEscaping(filename, needsEscaping);
+    return result.replace('$', "$$");
+}
+
+QString escapeFilenameForMakefileTarget(const QString &filename)
+{
+    static QSet<QChar> needsEscaping{'#', ' ', ':', '%'};
+    QString result = contextualBackslashEscaping(filename, needsEscaping);
+    return result.replace('$', "$$");
+}
+
+QString escapeFilenameForMakefilePrerequisite(const QString &filename)
+{
+    static QSet<QChar> needsEscaping{'#', ' ', ':', '?', '*'};
+    QString result = contextualBackslashEscaping(filename, needsEscaping, false);
+    return result.replace('$', "$$");
+}
+
+QString dumpFilenamesForMakefilePrerequisites(const QStringList &filenames)
+{
+    QStringList escapedFilenames;
+    for (int i = 0; i < filenames.size(); ++i)
+        escapedFilenames << escapeFilenameForMakefilePrerequisite(filenames[i]);
+    return escapedFilenames.join(' ');
+}
+
+QString escapeArgumentForMakefileRecipe(const QString &arg, bool isFirstArg)
+{
+    QString shellEscaped = escapeArgument(arg, isFirstArg, makefileCommandEscapeArgumentRule());
+    return shellEscaped.replace('$', "$$");
+}
+
+QString escapeArgumentForInputField(const QString &arg, bool isFirstArg)
+{
+    return escapeArgument(arg, isFirstArg, EscapeArgumentRule::BourneAgainShellPretty);
+}
+
+QString dumpArgumentsForInputField(const QStringList &args)
+{
+    QStringList escapedArgs;
+    for (int i = 0; i < args.size(); ++i)
+        escapedArgs << escapeArgumentForInputField(args[i], false);
+    return escapedArgs.join(' ');
+}

--- a/RedPandaIDE/escape.h
+++ b/RedPandaIDE/escape.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020-2022 Roy Qu (royqh1979@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef ESCAPE_H
+#define ESCAPE_H
+
+#include <QString>
+
+enum class EscapeArgumentRule {
+    BourneAgainShellPretty,
+    BourneAgainShellFast,
+    WindowsCreateProcess,
+    WindowsCreateProcessForceQuote,
+    WindowsCommandPrompt,
+};
+
+QString escapeArgument(const QString &arg, bool isFirstArg, EscapeArgumentRule rule);
+
+EscapeArgumentRule platformShellEscapeArgumentRule();
+QString escapeArgumentForPlatformShell(const QString &arg, bool isFirstArg);
+QString dumpCommandForPlatformShell(const QString &prog, const QStringList &args);
+
+EscapeArgumentRule makefileCommandEscapeArgumentRule();
+QString escapeArgumentForMakefileVariableValue(const QString &arg, bool isFirstArg);
+QString dumpArgumentsForMakefileVariableValue(const QStringList &args);
+QString escapeFilenameForMakefileInclude(const QString &filename);
+QString escapeFilenameForMakefileTarget(const QString &filename);
+QString escapeFilenameForMakefilePrerequisite(const QString &filename);
+QString dumpFilenamesForMakefilePrerequisites(const QStringList &filenames);
+QString escapeArgumentForMakefileRecipe(const QString &arg, bool isFirstArg);
+
+QString escapeArgumentForInputField(const QString &arg, bool isFirstArg);
+QString dumpArgumentsForInputField(const QStringList &args);
+
+#endif // ESCAPE_H

--- a/RedPandaIDE/project.cpp
+++ b/RedPandaIDE/project.cpp
@@ -1423,11 +1423,7 @@ void Project::buildPrivateResource()
         if (
                 (getFileType(unit->fileName()) == FileType::WindowsResourceSource)
                 && unit->compile() )
-            contents.append("#include \"" +
-                           genMakePath(
-                               extractRelativePath(directory(), unit->fileName()),
-                               false,
-                               false) + "\"");
+            contents.append("#include \"" + extractRelativePath(directory(), unit->fileName()) + "\"");
     }
 
     if (!mOptions.icon.isEmpty()) {
@@ -1450,11 +1446,8 @@ void Project::buildPrivateResource()
       contents.append("//");
       if (!mOptions.exeOutput.isEmpty())
           contents.append(
-                    "1 24 \"" +
-                       genMakePath2(
-                           includeTrailingPathDelimiter(mOptions.exeOutput)
-                           + extractFileName(executable()))
-                + ".Manifest\"");
+                    "1 24 \"" + includeTrailingPathDelimiter(mOptions.exeOutput)
+                           + extractFileName(executable()) + ".Manifest\"");
       else
           contents.append("1 24 \"" + extractFileName(executable()) + ".Manifest\"");
     }

--- a/RedPandaIDE/resources/terminal-unix.json
+++ b/RedPandaIDE/resources/terminal-unix.json
@@ -15,8 +15,8 @@
             {
                 "name": "CoreTerminal",
                 "path": "coreterminal",
-                "argsPattern": "$term -e \"$command\"",
-                "comment": "The pair of quotation mark around `$command` is only a visual symbol, not actually required."
+                "argsPattern": "$term -e \"$unix_command\"",
+                "comment": "The pair of quotation mark around `$unix_command` is only a visual symbol, not actually required."
             },
             {
                 "name": "iTerm2",
@@ -26,7 +26,7 @@
             {
                 "name": "kermit",
                 "path": "kermit",
-                "argsPattern": "$term -e \"$command\""
+                "argsPattern": "$term -e \"$unix_command\""
             },
             {
                 "name": "Kitty",
@@ -36,12 +36,12 @@
             {
                 "name": "ROXTerm",
                 "path": "roxterm",
-                "argsPattern": "$term -e \"$command\""
+                "argsPattern": "$term -e \"$unix_command\""
             },
             {
                 "name": "sakura",
                 "path": "sakura",
-                "argsPattern": "$term -e \"$command\""
+                "argsPattern": "$term -e \"$unix_command\""
             },
             {
                 "name": "Termit",
@@ -51,7 +51,7 @@
             {
                 "name": "Termite",
                 "path": "termite",
-                "argsPattern": "$term -e \"$command\""
+                "argsPattern": "$term -e \"$unix_command\""
             },
             {
                 "name": "Tilix",
@@ -116,7 +116,7 @@
             {
                 "name": "Terminology (Enlightenment)",
                 "path": "terminology",
-                "argsPattern": "$term -e \"$command\""
+                "argsPattern": "$term -e \"$unix_command\""
             },
             {
                 "name": "Xfce Terminal",
@@ -131,7 +131,7 @@
             {
                 "name": "Elementary Terminal",
                 "path": "io.elementary.terminal",
-                "argsPattern": "$term -e \"$command\"",
+                "argsPattern": "$term -e \"$unix_command\"",
                 "comment": "confirm to quit"
             },
             {

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -19,6 +19,7 @@
 #include <QTextCodec>
 #include <algorithm>
 #include "utils.h"
+#include "escape.h"
 #include <QDir>
 #include "systemconsts.h"
 #include <QDebug>
@@ -1850,14 +1851,14 @@ Settings::CompilerSet::CompilerSet(const QJsonObject &set) :
         mFullLoaded = false;
     }
 
-    QStringList escapedCompileParams;
+    QStringList compileParams;
     for (const QJsonValue &param : set["customCompileParams"].toArray())
-        escapedCompileParams.append(escapeArgument(param.toString(), false));
-    mCustomCompileParams = escapedCompileParams.join(' ');
-    QStringList escapedLinkParams;
+        compileParams << param.toString();
+    mCustomCompileParams = dumpArgumentsForInputField(compileParams);
+    QStringList linkParams;
     for (const QJsonValue &param : set["customLinkParams"].toArray())
-        escapedLinkParams.append(escapeArgument(param.toString(), false));
-    mCustomLinkParams = escapedLinkParams.join(' ');
+        linkParams << param.toString();
+    mCustomLinkParams = dumpArgumentsForInputField(linkParams);
 
     if (!mAutoAddCharsetParams)
         mExecCharset = "UTF-8";
@@ -2513,7 +2514,7 @@ QStringList Settings::CompilerSet::defines(bool isCpp) {
 #endif
 
     if (mUseCustomCompileParams) {
-        QStringList extraParams = splitProcessCommand(mCustomCompileParams);
+        QStringList extraParams = parseArgumentsWithoutVariables(mCustomCompileParams);
         arguments.append(extraParams);
     }
     arguments.append(NULL_FILE);
@@ -4038,7 +4039,12 @@ void Settings::Environment::checkAndSetTerminal()
     QMessageBox::critical(
                 nullptr,
                 QCoreApplication::translate("Settings","Error"),
-                QCoreApplication::translate("Settings","Can't find terminal program!"));
+        QCoreApplication::translate("Settings","Can't find terminal program!"));
+}
+
+QMap<QString, QString> Settings::Environment::terminalArgsPatternMagicVariables()
+{
+    return mTerminalArgsPatternMagicVariables;
 }
 
 QList<Settings::Environment::TerminalItem> Settings::Environment::loadTerminalList() const
@@ -4081,7 +4087,7 @@ bool Settings::Environment::isTerminalValid()
     // terminal patter is empty
     if (mTerminalArgumentsPattern.isEmpty()) return false;
 
-    QStringList patternItems = splitProcessCommand(mTerminalArgumentsPattern);
+    QStringList patternItems = parseArguments(mTerminalArgumentsPattern, mTerminalArgsPatternMagicVariables, false);
 
     if (!(patternItems.contains("$argv")
           || patternItems.contains("$command")
@@ -4157,6 +4163,17 @@ void Settings::Environment::setTheme(const QString &theme)
 {
     mTheme = theme;
 }
+
+const QMap<QString, QString> Settings::Environment::mTerminalArgsPatternMagicVariables = {
+    {"term", "$term"},
+    {"integrated_term", "$integrated_term"},
+    {"argv", "$argv"},
+    {"command", "$command"},
+    {"unix_command", "$unix_command"},
+    {"dos_command", "$dos_command"},
+    {"lpCommandLine", "$lpCommandLine"},
+    {"tmpfile", "$tmpfile"},
+};
 
 Settings::Executor::Executor(Settings *settings):_Base(settings, SETTING_EXECUTOR)
 {
@@ -6624,25 +6641,58 @@ std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>> wrapCommandFor
             wrappedArgs.append(includeTrailingPathDelimiter(pSettings->dirs().appDir())+terminal);
         else if (patternItem == "$argv")
             wrappedArgs.append(payloadArgsWithArgv0);
-        else if (patternItem == "$command") {
+        else if (patternItem == "$command" || patternItem == "$unix_command") {
+            // “$command” is for compatibility; previously used on multiple Unix terms
             QStringList escapedArgs;
             for (int i = 0; i < payloadArgsWithArgv0.length(); i++) {
                 auto &arg = payloadArgsWithArgv0[i];
-                auto escaped = escapeArgument(arg, i == 0);
+                auto escaped = escapeArgument(arg, i == 0, EscapeArgumentRule::BourneAgainShellPretty);
                 escapedArgs.append(escaped);
             }
             wrappedArgs.push_back(escapedArgs.join(' '));
-        } else if (patternItem == "$tmpfile") {
+        } else if (patternItem == "$dos_command") {
+            QStringList escapedArgs;
+            for (int i = 0; i < payloadArgsWithArgv0.length(); i++) {
+                auto &arg = payloadArgsWithArgv0[i];
+                auto escaped = escapeArgument(arg, i == 0, EscapeArgumentRule::WindowsCommandPrompt);
+                escapedArgs.append(escaped);
+            }
+            wrappedArgs.push_back(escapedArgs.join(' '));
+        } else if (patternItem == "$lpCommandLine") {
+            QStringList escapedArgs;
+            for (int i = 0; i < payloadArgsWithArgv0.length(); i++) {
+                auto &arg = payloadArgsWithArgv0[i];
+                auto escaped = escapeArgument(arg, i == 0, EscapeArgumentRule::WindowsCreateProcess);
+                escapedArgs.append(escaped);
+            }
+            wrappedArgs.push_back(escapedArgs.join(' '));
+        } else if (patternItem == "$tmpfile" || patternItem == "$tmpfile.command") {
+            // “$tmpfile” is for compatibility; previously used on macOS Terminal.app
             temproryFile = std::make_unique<QTemporaryFile>(QDir::tempPath() + "/redpanda_XXXXXX.command");
             if (temproryFile->open()) {
                 QStringList escapedArgs;
                 for (int i = 0; i < payloadArgsWithArgv0.length(); i++) {
                     auto &arg = payloadArgsWithArgv0[i];
-                    auto escaped = escapeArgument(arg, i == 0);
+                    auto escaped = escapeArgument(arg, i == 0, EscapeArgumentRule::BourneAgainShellPretty);
                     escapedArgs.append(escaped);
                 }
                 temproryFile->write(escapedArgs.join(' ').toUtf8());
                 temproryFile->write("\n");
+                temproryFile->flush();
+                QFile(temproryFile->fileName()).setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+            }
+            wrappedArgs.push_back(temproryFile->fileName());
+        } else if (patternItem == "$tmpfile.bat") {
+            temproryFile = std::make_unique<QTemporaryFile>(QDir::tempPath() + "/redpanda_XXXXXX.bat");
+            if (temproryFile->open()) {
+                QStringList escapedArgs;
+                for (int i = 0; i < payloadArgsWithArgv0.length(); i++) {
+                    auto &arg = payloadArgsWithArgv0[i];
+                    auto escaped = escapeArgument(arg, i == 0, EscapeArgumentRule::WindowsCommandPrompt);
+                    escapedArgs.append(escaped);
+                }
+                temproryFile->write(escapedArgs.join(' ').toLocal8Bit());
+                temproryFile->write("\r\n");
                 temproryFile->flush();
                 QFile(temproryFile->fileName()).setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
             }
@@ -6657,5 +6707,5 @@ std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>> wrapCommandFor
 
 std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>> wrapCommandForTerminalEmulator(const QString &terminal, const QString &argsPattern, const QStringList &payloadArgsWithArgv0)
 {
-    return wrapCommandForTerminalEmulator(terminal, splitProcessCommand(argsPattern), payloadArgsWithArgv0);
+    return wrapCommandForTerminalEmulator(terminal, parseArguments(argsPattern, Settings::Environment::terminalArgsPatternMagicVariables(), false), payloadArgsWithArgv0);
 }

--- a/RedPandaIDE/settings.h
+++ b/RedPandaIDE/settings.h
@@ -609,6 +609,8 @@ public:
 
         QList<TerminalItem> loadTerminalList() const;
 
+        static QMap<QString, QString> terminalArgsPatternMagicVariables();
+
     private:
         bool isTerminalValid();
         void checkAndSetTerminal();
@@ -631,6 +633,8 @@ public:
         bool mUseCustomTerminal;
         bool mHideNonSupportFilesInFileView;
         bool mOpenFilesInSingleInstance;
+
+        static const QMap<QString, QString> mTerminalArgsPatternMagicVariables;
         // _Base interface
     protected:
         void doSave() override;

--- a/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentprogramswidget.cpp
@@ -20,6 +20,7 @@
 #include "../iconsmanager.h"
 #include "../systemconsts.h"
 #include "../compiler/executablerunner.h"
+#include "escape.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -43,18 +44,16 @@ EnvironmentProgramsWidget::~EnvironmentProgramsWidget()
 auto EnvironmentProgramsWidget::resolveExecArguments(const QString &terminalPath, const QString &argsPattern)
     -> std::tuple<QString, QStringList, std::unique_ptr<QTemporaryFile>>
 {
-    QString shell = defaultShell();
-    QStringList payloadArgs{shell, "-c", "echo hello; sleep 3"};
-    return wrapCommandForTerminalEmulator(terminalPath, argsPattern, payloadArgs);
+    return wrapCommandForTerminalEmulator(terminalPath, argsPattern, platformCommandForTerminalArgsPreview());
 }
 
 void EnvironmentProgramsWidget::updateCommandPreview(const QString &terminalPath, const QString &argsPattern)
 {
     auto [filename, arguments, fileOwner] = resolveExecArguments(terminalPath, argsPattern);
     for (auto &arg : arguments)
-        arg = escapeArgument(arg, false);
+        arg = escapeArgument(arg, false, platformShellEscapeArgumentRule());
 
-    ui->labelCmdPreviewResult->setPlainText(escapeArgument(filename, true) + " " + arguments.join(' '));
+    ui->labelCmdPreviewResult->setPlainText(escapeArgument(filename, true, platformShellEscapeArgumentRule()) + " " + arguments.join(' '));
 }
 
 void EnvironmentProgramsWidget::autoDetectAndUpdateArgumentsPattern(const QString &terminalPath)

--- a/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
+++ b/RedPandaIDE/settingsdialog/executorgeneralwidget.cpp
@@ -90,7 +90,7 @@ void ExecutorGeneralWidget::updateIcons(const QSize &/*size*/)
 
 void ExecutorGeneralWidget::on_txtExecuteParamaters_textChanged(const QString &commandLine)
 {
-    QStringList parsed = splitProcessCommand(commandLine);
+    QStringList parsed = parseArgumentsWithoutVariables(commandLine);
     QJsonArray obj = QJsonArray::fromStringList(parsed);
     ui->txtParsedArgsInJson->setText(QJsonDocument{obj}.toJson());
 }

--- a/RedPandaIDE/settingsdialog/projectcompileparamaterswidget.cpp
+++ b/RedPandaIDE/settingsdialog/projectcompileparamaterswidget.cpp
@@ -19,6 +19,8 @@
 #include "../mainwindow.h"
 #include "../project.h"
 #include "../iconsmanager.h"
+#include "utils.h"
+#include "escape.h"
 
 #ifdef Q_OS_WIN
 #include <sysinfoapi.h>
@@ -83,7 +85,7 @@ void ProjectCompileParamatersWidget::on_btnChooseLib_clicked()
                 );
     if (!files.isEmpty()) {
         foreach (const QString& file,files) {
-            ui->txtLinker->appendPlainText(" "+genMakePath1(file));
+            ui->txtLinker->appendPlainText(" " + escapeArgument(file, false, EscapeArgumentRule::BourneAgainShellPretty));
         }
     }
 }

--- a/RedPandaIDE/settingsdialog/toolsgeneralwidget.cpp
+++ b/RedPandaIDE/settingsdialog/toolsgeneralwidget.cpp
@@ -19,6 +19,8 @@
 #include "../mainwindow.h"
 #include "../settings.h"
 #include "../iconsmanager.h"
+#include "utils.h"
+#include "escape.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -132,9 +134,11 @@ void ToolsGeneralWidget::onEdited()
 
 void ToolsGeneralWidget::updateDemo()
 {
-    ui->txtDemo->setText(
-                parseMacros(ui->txtProgram->text())+ " " +
-                parseMacros(ui->txtParameters->text()));
+    QMap<QString,QString> macros = devCppMacroVariables();
+    ui->txtDemo->setText(dumpCommandForPlatformShell(
+                parseMacros(ui->txtProgram->text(), macros),
+                parseArguments(ui->txtParameters->text(), macros, true)
+    ));
 }
 
 ToolsModel::ToolsModel(QObject *parent):QAbstractListModel(parent)

--- a/RedPandaIDE/test-escape.cpp
+++ b/RedPandaIDE/test-escape.cpp
@@ -1,0 +1,157 @@
+#include <cstdlib>
+
+#include <QByteArray>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
+#include <QString>
+
+#include "escape.h"
+
+int testIndex = 0;
+
+QByteArray content = "main(){}";
+
+void testMake(QString name)
+{
+    ++testIndex;
+    auto dir = QString("test-escape-%1").arg(testIndex);
+    auto srcName = name + ".c";
+    auto objName = name + ".o";
+#ifdef Q_OS_WIN
+    auto binName = name + ".exe";
+#else
+    auto binName = name;
+#endif 
+    auto includeMfName = name + ".mf";
+
+    auto fail = [&name](const QString& msg) {
+        qDebug() << "Error in test" << testIndex << name << ":" << msg;
+        exit(1);
+    };
+
+    // create directory
+    {
+        auto cwd = QDir();
+        if (cwd.exists(dir)) {
+            if (!QDir(dir).removeRecursively())
+                fail("cannot remove directory");
+        }
+        if (!cwd.mkdir(dir))
+            fail("cannot create directory");
+    }
+
+    // create source file
+    {
+        auto srcPath = QString("%1/%2").arg(dir, srcName);
+        QFile f(srcPath);
+        if (!f.open(QIODevice::WriteOnly))
+            fail("cannot create source file");
+        if (f.write(content) != content.size())
+            fail("cannot write to source file");
+        f.close();
+    }
+
+    // create included makefile
+    {
+        auto file = QString("%1/%2").arg(dir, includeMfName);
+        QFile f(file);
+        if (!f.open(QIODevice::WriteOnly))
+            fail("cannot create included makefile");
+        f.close();
+    }
+
+    // create makefile
+    {
+        QStringList mf;
+        mf << "BIN_DEP = " + escapeFilenameForMakefilePrerequisite(binName);
+        mf << "BIN_TAR = " + escapeFilenameForMakefileTarget(binName);
+        mf << "BIN_ARG = " + escapeArgumentForMakefileVariableValue(binName, false);
+        mf << "OBJS_DEP = " + escapeFilenameForMakefilePrerequisite(objName);
+        mf << "OBJS_ARG = " + escapeArgumentForMakefileVariableValue(objName, false);
+        mf << "include " + escapeFilenameForMakefileInclude(includeMfName);
+        mf << ".PHONY: all clean";
+        mf << "all: $(BIN_DEP)";
+        mf << "$(BIN_TAR): $(OBJS_DEP)";
+        mf << "\tgcc -o $(BIN_ARG) $(OBJS_ARG)";
+        mf << escapeFilenameForMakefileTarget(objName) + ": " + escapeFilenameForMakefilePrerequisite(srcName);
+        mf << "\tgcc -o " + escapeArgumentForMakefileRecipe(objName, false) + " -c " + escapeArgumentForMakefileRecipe(srcName, false);
+        mf << "clean:";
+        mf << "\trm -f $(BIN_ARG) $(OBJS_ARG)";
+
+        auto file = QString("%1/makefile").arg(dir);
+        QFile f(file);
+        if (!f.open(QIODevice::WriteOnly))
+            fail("cannot create makefile");
+        f.write(mf.join("\n").toUtf8());
+    }
+
+    // run make
+    {
+        QProcess p;
+        p.setWorkingDirectory(dir);
+#ifdef Q_OS_WIN
+        p.setProgram("mingw32-make.exe");
+#else
+        p.setProgram("make");
+#endif
+        p.start();
+        p.waitForFinished();
+        if (p.exitCode() != 0) {
+            qDebug() << "Error in test" << testIndex << name << ": make failed";
+            exit(1);
+        }
+        auto binFile = QString("%1/%2").arg(dir, binName);
+        if (!QFile(binFile).exists()) {
+            qDebug() << "Error in test" << testIndex << name << ": executable not properly created";
+            exit(1);
+        }
+    }
+}
+
+int main()
+{
+    testMake("simple");
+    testMake("dollar$dollar");
+    testMake("paren(paren");
+    testMake("paren)paren");
+    testMake("pair(of)paren");
+    testMake("bracket[bracket");
+    testMake("bracket]bracket");
+    testMake("pair[of]brackets");
+    testMake("brace{brace");
+    testMake("brace}brace");
+    testMake("pair{of}braces");
+    testMake("hash#hash");
+    testMake("percent%percent");
+    testMake("ampersand&ampersand");
+    testMake("space space");
+    testMake("quote'quote");
+    testMake("complex$(complex)complex");
+    testMake("complex${complex}complex");
+
+#ifndef Q_OS_WIN
+    testMake("colon:colon");
+    testMake("less<less");
+    testMake("greater>greater");
+    testMake("pair<of>angle");
+    testMake("asterisk*asterisk");
+    testMake("question?question");
+    testMake("escape\033escape");
+    testMake(R"(quote"quote)");
+    testMake(R"(backslash\backslash)");
+    testMake(R"(complex\#complex)");
+    testMake(R"(complex\ complex)");
+    testMake(R"(weird\)");
+    testMake(R"(weird\\)");
+    testMake(R"(weird\\\)");
+    testMake(R"(weird\\\\)");
+#endif
+
+    // seems impossible:
+    // testMake("tab\ttab");
+    // testMake("newline\nnewline");
+
+    return 0;
+}

--- a/RedPandaIDE/utils.h
+++ b/RedPandaIDE/utils.h
@@ -116,14 +116,12 @@ enum class ProblemCaseValidateType {
 };
 
 FileType getFileType(const QString& filename);
-QStringList splitProcessCommand(const QString& cmd);
 
-QString genMakePath(const QString& fileName,bool escapeSpaces, bool encloseInQuotes);
-QString genMakePath1(const QString& fileName);
-QString genMakePath2(const QString& fileName);
 bool programHasConsole(const QString& filename);
 
 QString parseMacros(const QString& s);
+QString parseMacros(const QString& s, const QMap<QString, QString>& variables);
+QMap<QString, QString> devCppMacroVariables();
 
 class CppParser;
 void resetCppParser(std::shared_ptr<CppParser> parser, int compilerSetIndex=-1);
@@ -138,7 +136,7 @@ QByteArray runAndGetOutput(const QString& cmd, const QString& workingDir, const 
 void openFileFolderInExplorer(const QString& path);
 
 void executeFile(const QString& fileName,
-                 const QString& params,
+                 const QStringList& params,
                  const QString& workingDir,
                  const QString& tempFile);
 
@@ -169,9 +167,10 @@ QColor alphaBlend(const QColor &lower, const QColor &upper);
 
 QStringList getExecutableSearchPaths();
 
-QString escapeArgument(const QString &arg, bool isFirstArg);
+QStringList parseArguments(const QString &command, const QMap<QString, QString> &variables, bool enableDevCppVariableExpansion);
+QStringList parseArgumentsWithoutVariables(const QString &command);
 
-QString defaultShell();
+QStringList platformCommandForTerminalArgsPreview();
 
 QString appArch();
 QString osArch();

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -30,6 +30,7 @@ target("RedPandaIDE")
         "autolinkmanager.cpp",
         "colorscheme.cpp",
         "customfileiconprovider.cpp",
+        "escape.cpp",
         "gdbmiresultparser.cpp",
         "main.cpp",
         "projectoptions.cpp",
@@ -236,3 +237,12 @@ target("RedPandaIDE")
     if is_xdg() then
         on_install(install_bin)
     end
+
+target("test-escape")
+    set_kind("binary")
+    add_rules("qt.console")
+
+    set_default(false)
+    add_tests("test-escape")
+
+    add_files("escape.cpp", "test-escape.cpp")

--- a/libs/redpanda_qt_utils/qt_utils/utils.cpp
+++ b/libs/redpanda_qt_utils/qt_utils/utils.cpp
@@ -539,7 +539,7 @@ QString changeFileExt(const QString& filename, QString ext)
         path = includeTrailingPathDelimiter(fileInfo.path());
     }
     if (suffix.isEmpty()) {
-        return path+filename+ext;
+        return path+name+ext;
     } else {
         return path+fileInfo.completeBaseName()+ext;
     }


### PR DESCRIPTION
- Migrate external calls from command string to argv array to improve safety and security.
- Support POSIX shell-like escaping in user inputs for compiler arguments.
- (Hopefully) properly escape filenames and arguments in makefile generation.