### PR TITLE
Updated the Chinese translation for "Goto Page Start and Select"

### DIFF
--- a/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
@@ -5534,7 +5534,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../mainwindow.ui" line="3098"/>
         <source>Goto Page Start and Select</source>
-        <translation>跳转到行首并选中</translation>
+        <translation>跳转到页首并选中</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3106"/>


### PR DESCRIPTION
This PR updates the Chinese translation for "Goto Page Start and Select" to accurately reflect the functionality of the feature. 

本次PR更新了“Goto Page Start and Select”的中文翻译，以准确反映该功能的操作。