### PR TITLE
Remake color scheme One Dark

### DIFF
--- a/RedPandaIDE/resources/colorschemes/One_Dark.scheme
+++ b/RedPandaIDE/resources/colorschemes/One_Dark.scheme
@@ -15,7 +15,7 @@
     },
     "Assembler": {
         "bold": false,
-        "foreground": "#ffff00ff",
+        "foreground": "#ff0000ff",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -48,7 +48,7 @@
         "underlined": false
     },
     "Current Highlighted Word": {
-        "background": "#504a505f",
+        "background": "#ff353840",
         "bold": false,
         "italic": false,
         "strikeout": false,
@@ -57,14 +57,15 @@
     "Editor Text": {
         "background": "#ff282c34",
         "bold": false,
-        "foreground": "#ffabb2bf",
+        "foreground": "#ff528bff",
         "italic": false,
         "strikeout": false,
         "underlined": false
     },
     "Error": {
+        "background": "#ff800000",
         "bold": false,
-        "foreground": "#fff44747",
+        "foreground": "#ffc24038",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -85,13 +86,13 @@
     },
     "Fold Line": {
         "bold": false,
-        "foreground": "#ff3b4048",
+        "foreground": "#ff495162",
         "italic": false,
         "strikeout": false,
         "underlined": false
     },
     "Function": {
-        "bold": true,
+        "bold": false,
         "foreground": "#ff61afef",
         "italic": false,
         "strikeout": false,
@@ -135,7 +136,7 @@
     },
     "Illegal Char": {
         "bold": false,
-        "foreground": "#ffff0000",
+        "foreground": "#ffc24038",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -156,7 +157,7 @@
     },
     "Number": {
         "bold": false,
-        "foreground": "#ffd18f52",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -170,8 +171,8 @@
     },
     "Preprocessor": {
         "bold": false,
-        "foreground": "#ffc678dd",
-        "italic": true,
+        "foreground": "#ffd19a66",
+        "italic": false,
         "strikeout": false,
         "underlined": false
     },
@@ -185,12 +186,12 @@
     "Reserved Word": {
         "bold": false,
         "foreground": "#ffc678dd",
-        "italic": true,
+        "italic": false,
         "strikeout": false,
         "underlined": false
     },
     "Selected text": {
-        "background": "#ff4a505f",
+        "background": "#ff404859",
         "bold": false,
         "italic": false,
         "strikeout": false,
@@ -198,7 +199,7 @@
     },
     "Space": {
         "bold": false,
-        "foreground": "#ff4a505f",
+        "foreground": "#1dffffff",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -226,7 +227,7 @@
     },
     "Warning": {
         "bold": false,
-        "foreground": "#fff0a45d",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -240,7 +241,7 @@
     },
     "brace/parenthesis/bracket level 2": {
         "bold": false,
-        "foreground": "#ffd18f52",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false


### PR DESCRIPTION
根据VS Code One Dark Pro和少量天依蓝的喜好重制One Dark配色。

（该PR暂时仅作演示，无需merge。）

相对天依蓝版One Dark，具体改变如下：
1.修复选中的空格字符不可见（取原版色）
2.更改光标颜色为蓝色（原版如此）
3.适当调亮代码折叠线（取原版类似元素色）
4.取消预处理指令、关键字斜体（原版如此）
5.取消函数加粗（原版如此，Flat版为加粗）
6.调亮整数、2级括号橙色（原版如此）
7.调暗错误、警告、非法字符颜色（取原版色）
8.更改预处理指令为橙色（取原版宏定义色）

旧：
![屏幕截图 2024-05-10 192325](https://github.com/royqh1979/RedPanda-CPP/assets/111294086/f7eb76c1-4efd-41d2-846c-2c513f502493)

新：
![屏幕截图 2024-05-10 192345](https://github.com/royqh1979/RedPanda-CPP/assets/111294086/78751508-ec33-4402-916a-f5409a5450e5)

