### PR TITLE
Fix debian-static build script

### DIFF
--- a/packages/debian-static/builddeb.sh
+++ b/packages/debian-static/builddeb.sh
@@ -16,6 +16,6 @@ TMP_FOLDER="$(mktemp -d)"
 podman run -it --rm -v "$PWD:/mnt" -w /mnt -v "$TMP_FOLDER:/out" quay.io/redpanda-cpp/appimage-builder-x86_64:20240304.0 packages/debian-static/01-in-docker.sh
 
 mkdir -p dist
-mkdir -p "$TMP_FOLDER/DEBIAN"
+mkdir -m 755 -p "$TMP_FOLDER/DEBIAN"
 sed "s/__VERSION__/$VERSION/" packages/debian-static/control.in >"$TMP_FOLDER/DEBIAN/control"
 dpkg-deb --build "$TMP_FOLDER" "dist/$DEB_FILE"


### PR DESCRIPTION
Hello.

packages/debian-static/builddeb.sh returned this error:
```
dpkg-deb: error: control directory has bad permissions 777 (must be
> >=0755 and <=0775)
```
The fix is simple
`mkdir -m 755 -p "$TMP_FOLDER/DEBIAN"`

I built and installed the IDE
![Screenshot from 2024-05-27 12-30-06](https://github.com/royqh1979/RedPanda-CPP/assets/43163920/a1215ac0-0801-48f8-ac1d-2881cab27901)