### PR TITLE
Simplify compiler version check in about dialog

### DIFF
--- a/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
@@ -55,39 +55,14 @@
         <translation>Versão:</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>Non-GCC Compiler</source>
-        <translation>Compilador não GCC</translation>
+        <location line="+38"/>
+        <source>unknown compiler</source>
+        <translation>compilador desconhecido</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>Website: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
         <translation>Website: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location line="-27"/>
-        <source>Next Generation Microsoft Visual C++</source>
-        <translation>Microsoft Visual C++ de Próxima Geração</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2022</source>
-        <translation>Microsoft Visual C++ 2022</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2019</source>
-        <translation>Microsoft Visual C++ 2019</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2017</source>
-        <translation>Microsoft Visual C++ 2017</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Legacy Microsoft Visual C++</source>
-        <translation>Microsoft Visual C++ Legado</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="-61"/>
@@ -498,7 +473,7 @@
 <context>
     <name>CompetitiveCompanionThread</name>
     <message>
-        <location filename="../problems/competitivecompenionhandler.cpp" line="+134"/>
+        <location filename="../problems/competitivecompenionhandler.cpp" line="+131"/>
         <source>Problem Case %1</source>
         <translation type="unfinished">Caso do problema %1</translation>
     </message>
@@ -563,7 +538,7 @@
         <translation>[Nota] </translation>
     </message>
     <message>
-        <location line="+578"/>
+        <location line="+588"/>
         <source>The compiler process for &apos;%1&apos; failed to start.</source>
         <translation>Falha ao iniciar a compilação para &apos;%1&apos;.</translation>
     </message>
@@ -598,7 +573,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-663"/>
+        <location line="-673"/>
         <source> - Command: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1814,7 +1789,7 @@
         <translation>Remover ...</translation>
     </message>
     <message>
-        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+327"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+337"/>
         <location line="+53"/>
         <location line="+9"/>
         <location line="+13"/>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
@@ -129,34 +129,9 @@ p, li { white-space: pre-wrap; }
         <translation>版本：</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <source>Next Generation Microsoft Visual C++</source>
-        <translation>下一代 Microsoft Visual C++</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2022</source>
-        <translation>Microsoft Visual C++ 2022</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2019</source>
-        <translation>Microsoft Visual C++ 2019</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2017</source>
-        <translation>Microsoft Visual C++ 2017</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Legacy Microsoft Visual C++</source>
-        <translation>旧版 Microsoft Visual C++</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Non-GCC Compiler</source>
-        <translation>非GCC编译器</translation>
+        <location line="+38"/>
+        <source>unknown compiler</source>
+        <translation>未知编译器</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -566,7 +541,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>CompetitiveCompanionThread</name>
     <message>
-        <location filename="../problems/competitivecompenionhandler.cpp" line="+134"/>
+        <location filename="../problems/competitivecompenionhandler.cpp" line="+131"/>
         <source>Problem Case %1</source>
         <translation>试题案例%1</translation>
     </message>
@@ -700,7 +675,7 @@ p, li { white-space: pre-wrap; }
         <translation>警告：</translation>
     </message>
     <message>
-        <location line="+550"/>
+        <location line="+560"/>
         <source>Can&apos;t open file &quot;%1&quot; for write!</source>
         <translation>无法写入文件“%1”。</translation>
     </message>
@@ -2064,7 +2039,7 @@ p, li { white-space: pre-wrap; }
         <translation>背景色</translation>
     </message>
     <message>
-        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+327"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+337"/>
         <location line="+53"/>
         <location line="+9"/>
         <location line="+13"/>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
@@ -48,39 +48,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>Non-GCC Compiler</source>
-        <translation type="unfinished"></translation>
+        <location line="+38"/>
+        <source>unknown compiler</source>
+        <translation>未知編譯器</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>Website: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-27"/>
-        <source>Next Generation Microsoft Visual C++</source>
-        <translation>下一代 Microsoft Visual C++</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2022</source>
-        <translation>Microsoft Visual C++ 2022</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2019</source>
-        <translation>Microsoft Visual C++ 2019</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Microsoft Visual C++ 2017</source>
-        <translation>Microsoft Visual C++ 2017</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Legacy Microsoft Visual C++</source>
-        <translation>舊版 Microsoft Visual C++</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="-37"/>
@@ -399,7 +374,7 @@
 <context>
     <name>CompetitiveCompanionThread</name>
     <message>
-        <location filename="../problems/competitivecompenionhandler.cpp" line="+134"/>
+        <location filename="../problems/competitivecompenionhandler.cpp" line="+131"/>
         <source>Problem Case %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -464,7 +439,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+578"/>
+        <location line="+588"/>
         <source>The compiler process for &apos;%1&apos; failed to start.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -499,7 +474,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-663"/>
+        <location line="-673"/>
         <source> - Command: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1615,7 +1590,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+327"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="+337"/>
         <location line="+53"/>
         <location line="+9"/>
         <location line="+13"/>

--- a/RedPandaIDE/widgets/aboutdialog.cpp
+++ b/RedPandaIDE/widgets/aboutdialog.cpp
@@ -55,25 +55,17 @@ AboutDialog::AboutDialog(QWidget *parent) :
                  .arg(appArch()))
             .arg(osArch()));
 #elif defined(_MSC_VER)
-# if (_MSC_VER >= 1940)
-    QString name = tr("Next Generation Microsoft Visual C++");
-# elif (_MSC_VER >= 1930)
-    QString name = tr("Microsoft Visual C++ 2022");
-# elif (_MSC_VER >= 1920)
-    QString name = tr("Microsoft Visual C++ 2019");
-# elif (_MSC_VER >= 1910)
-    QString name = tr("Microsoft Visual C++ 2017");
-# else
-    QString name = tr("Legacy Microsoft Visual C++");
-# endif
     ui->lblQt->setText(ui->lblQt->text()
             .arg(qVersion())
-            .arg(name + " " + appArch())
+            .arg(QStringLiteral("MSVC %1.%2 %3")
+                .arg(_MSC_VER / 100)
+                .arg(_MSC_VER % 100)
+                .arg(appArch()))
             .arg(osArch()));
 #else
     ui->lblQt->setText(ui->lblQt->text()
             .arg(qVersion())
-            .arg(tr("Non-GCC Compiler"))
+            .arg(tr("unknown compiler"))
             .arg(osArch()));
 #endif
     ui->lblCompileTime->setText(ui->lblCompileTime->text()


### PR DESCRIPTION
Visual Studio 2022 17.10 came out with MSVC v14.40 (1940), violating versioning rules described in [the document](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170).

> Visual Studio 2017 and later
> - For major releases, the minor version increases by 10.
> - For minor releases, the minor version increases by 1 starting with Visual Studio 2017 version 15.3.