### PR TITLE
Adjust color scheme One Dark

### DIFF
--- a/RedPandaIDE/resources/colorschemes/One_Dark.scheme
+++ b/RedPandaIDE/resources/colorschemes/One_Dark.scheme
@@ -1,6 +1,6 @@
 {
     "Active Breakpoint": {
-        "background": "#ff565a30",
+        "background": "#33ffff00",
         "bold": false,
         "italic": false,
         "strikeout": false,
@@ -15,7 +15,7 @@
     },
     "Assembler": {
         "bold": false,
-        "foreground": "#ffff00ff",
+        "foreground": "#ff0000ff",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -48,7 +48,7 @@
         "underlined": false
     },
     "Current Highlighted Word": {
-        "background": "#504a505f",
+        "background": "#0fffffff",
         "bold": false,
         "italic": false,
         "strikeout": false,
@@ -63,8 +63,9 @@
         "underlined": false
     },
     "Error": {
+        "background": "#ff800000",
         "bold": false,
-        "foreground": "#fff44747",
+        "foreground": "#ffc24038",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -91,7 +92,7 @@
         "underlined": false
     },
     "Function": {
-        "bold": true,
+        "bold": false,
         "foreground": "#ff61afef",
         "italic": false,
         "strikeout": false,
@@ -135,7 +136,7 @@
     },
     "Illegal Char": {
         "bold": false,
-        "foreground": "#ffff0000",
+        "foreground": "#fff44747",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -156,7 +157,7 @@
     },
     "Number": {
         "bold": false,
-        "foreground": "#ffd18f52",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -171,7 +172,7 @@
     "Preprocessor": {
         "bold": false,
         "foreground": "#ffc678dd",
-        "italic": true,
+        "italic": false,
         "strikeout": false,
         "underlined": false
     },
@@ -185,12 +186,12 @@
     "Reserved Word": {
         "bold": false,
         "foreground": "#ffc678dd",
-        "italic": true,
+        "italic": false,
         "strikeout": false,
         "underlined": false
     },
     "Selected text": {
-        "background": "#ff4a505f",
+        "background": "#61677696",
         "bold": false,
         "italic": false,
         "strikeout": false,
@@ -198,7 +199,7 @@
     },
     "Space": {
         "bold": false,
-        "foreground": "#ff4a505f",
+        "foreground": "#1dffffff",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -226,7 +227,7 @@
     },
     "Warning": {
         "bold": false,
-        "foreground": "#fff0a45d",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false
@@ -240,7 +241,7 @@
     },
     "brace/parenthesis/bracket level 2": {
         "bold": false,
-        "foreground": "#ffd18f52",
+        "foreground": "#ffd19a66",
         "italic": false,
         "strikeout": false,
         "underlined": false


### PR DESCRIPTION
按照VSCode原版One Dark Pro调整当前高亮单词、活动断点、选中文字、空格字符、整数、2级括号，错误、警告下划线，取消函数加粗和预处理指令、关键字斜体。实现所有元素全面复刻原版One Dark Pro（对于代码折叠线、1级括号等模棱两可部分仍保留天依蓝设计）。
旧版：
![屏幕截图 2024-05-31 094222](https://github.com/royqh1979/RedPanda-CPP/assets/111294086/d72f0660-41e9-4edc-995d-17a6aef98bf4)

新版：
![屏幕截图 2024-05-31 094236](https://github.com/royqh1979/RedPanda-CPP/assets/111294086/456745ad-fd69-43f5-af67-b88b94a88c39)

至于为什么天依蓝处会显示预处理指令和关键字斜体，这其实是One Dark Theme的一个bug，只要曾经安装过One Dark Theme，所有配色的预处理指令和关键字都会变成斜体，可见https://github.com/one-dark/vscode-one-dark-theme/issues/50