### PR TITLE
Update Windows legacy packaging script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
           name: Windows MSYS2 - msystem=${{ matrix.msystem }}
           path: dist/
 
-  windows_legacy:
-    name: Windows NT 5.x
+  windows_legacy_native:
+    name: Windows NT 5.x native
     strategy:
       fail-fast: false
       matrix:
@@ -78,46 +78,65 @@ jobs:
           - 32-ucrt
           - 64-msvcrt
           - 32-msvcrt
-          - 32-win2000
         include:
           - isUcrt: 0
           - profile: 64-ucrt
             isUcrt: 1
           - profile: 32-ucrt
             isUcrt: 1
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}
-    env:
-      _REDPANDA_QT_BUILD: "5.15.13+redpanda1"
-      _QT_NAME: mingw141_${{ matrix.profile }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup
+      - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
           update: true
-          install: mingw-w64-x86_64-7zip mingw-w64-x86_64-cmake mingw-w64-i686-nsis curl git
-
-      - name: Setup Qt
-        run: |
-          curl -LO https://github.com/redpanda-cpp/qtbase-xp/releases/download/$_REDPANDA_QT_BUILD/$_QT_NAME.7z
-          /mingw64/bin/7z x $_QT_NAME.7z -oC:/Qt
 
       - name: Build
         run: |
-          ./packages/msys/build-xp.sh -p ${{ matrix.profile }} $( [[ ${{ matrix.isUcrt }} -eq 1 ]] && echo --ucrt 22621 )
+          ./packages/msys/build-xp.sh -p ${{ matrix.profile }} \
+            $( [[ ${{ matrix.isUcrt }} -eq 1 ]] && echo --ucrt 22621 )
+          ./packages/msys/build-xp.sh -p ${{ matrix.profile }} --mingw \
+            $( [[ ${{ matrix.isUcrt }} -eq 1 ]] && echo --ucrt 22621 )
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: Windows NT 5.x - profile=${{ matrix.profile }}
+          name: Windows NT 5.x native - profile=${{ matrix.profile }}
+          path: dist/*
+
+  windows_legacy_cross:
+    name: Windows NT 5.x cross
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - 64-msvcrt
+          - 32-msvcrt
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: |
+          sudo ./packages/xmingw/build-xp.sh -p ${{ matrix.profile }}
+          sudo ./packages/xmingw/build-xp.sh -p ${{ matrix.profile }} --mingw
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows NT 5.x cross - profile=${{ matrix.profile }}
           path: dist/*
 
   windows_msvc_x64:

--- a/BUILD.md
+++ b/BUILD.md
@@ -87,62 +87,29 @@ Extra arguments for `build-mingw.sh`:
 
 ## Windows NT 5.x Qt Library with MinGW Lite Toolchain
 
-The script `build-xp.sh` is alike `build-mingw.sh`, but the toolchain is provided by Qt library.
+The scripts `build-xp.sh` are alike `build-mingw.sh`, but the toolchain is provided by Qt library.
 
-Prerequisites:
+Prerequisites for native build:
 
 0. Windows 10 x64 or later.
 1. Install MSYS2.
-2. Install required utils:
-   ```bash
-   pacman -S \
-     mingw-w64-x86_64-{7zip,cmake} \
-     mingw-w64-i686-nsis \
-     git curl
-   ```
-3. Download [Windows XP Qt Library](https://github.com/redpanda-cpp/qtbase-xp) and extract to `C:/Qt`.
-   - The directory structure should be like
-     ```
-     C:
-     └─ Qt
-        └─ 5.15.13+redpanda1
-           ├─ mingw141_32-msvcrt
-           │  ├─ bin
-           │  │  ├─ gcc.exe
-           │  │  ├─ mingw32-make.exe
-           │  │  └─ qmake.exe
-           │  ├─ include
-           │  ├─ lib
-           │  └─ ...
-           └─ mingw141_64-msvcrt
-              ├─ bin
-              │  ├─ gcc.exe
-              │  ├─ mingw32-make.exe
-              │  └─ qmake.exe
-              ├─ include
-              ├─ lib
-              └─ ...
-     ```
-   - Or you can build from source and specify the path with `--qt` argument.
 
-To build, launch MSYS2 environment, run:
+For native build, launch MSYS2 environment, run:
 ```bash
 ./packages/msys/build-xp.sh -p 32-msvcrt
 ```
 
-This script accepts the same arguments as `build-mingw.sh`, plus:
-- `-p|--profile <profile>`: (REQUIRED) the profile of MinGW Lite as well as Qt library. Available profiles are `64-ucrt`, `64-msvcrt`, `32-ucrt`, `32-msvcrt`, `32-win2000`.
-- `--qt <dir>`: set Qt directory. e.g. `--qt /d/myqt-32`.
+For cross build, run:
+```bash
+podman run -it --rm -v $PWD:/mnt -w /mnt docker.io/amd64/ubuntu:24.04
 
-  The directory structure should be like
-  ```
-  D:
-  └─ myqt-32
-     ├─ bin
-     ├─ include
-     ├─ lib
-     └─ ...
-  ```
+# in container
+export MIRROR=mirrors.kernel.org  # optionally set mirror site
+./packages/xmingw/build-xp.sh -p 32-msvcrt
+```
+
+These scripts accepts the same arguments as `build-mingw.sh`, plus:
+- `-p|--profile <profile>`: (REQUIRED) the profile of MinGW Lite as well as Qt library. Available profiles are `64-ucrt`, `64-msvcrt`, `32-ucrt`, `32-msvcrt`.
 
 # Linux
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -89,60 +89,27 @@
 
 `build-xp.sh` 脚本和 `build-mingw.sh` 类似，但是工具链由 Qt 库提供。
 
-前置条件：
+本机构建前置条件：
 
 0. Windows 10 x64 或更高版本。
 1. 安装 MSYS2。
-2. 安装所需工具：
-   ```bash
-   pacman -S \
-     mingw-w64-x86_64-{7zip,cmake} \
-     mingw-w64-i686-nsis \
-     git curl
-   ```
-3. 下载 [Windows XP 的 Qt 库](https://github.com/redpanda-cpp/qtbase-xp)并解压到 `C:/Qt`。
-   - 目录结构应该如下：
-     ```
-     C:
-     └─ Qt
-        └─ 5.15.13+redpanda1
-           ├─ mingw141_32-msvcrt
-           │  ├─ bin
-           │  │  ├─ gcc.exe
-           │  │  ├─ mingw32-make.exe
-           │  │  └─ qmake.exe
-           │  ├─ include
-           │  ├─ lib
-           │  └─ ...
-           └─ mingw141_64-msvcrt
-              ├─ bin
-              │  ├─ gcc.exe
-              │  ├─ mingw32-make.exe
-              │  └─ qmake.exe
-              ├─ include
-              ├─ lib
-              └─ ...
-     ```
-   - 也可以从源代码自行构建 Qt 并在构建时指定 `--qt` 参数。
 
-要构建此项目，启动 MSYS2 环境，然后运行
+要进行本机构建，启动 MSYS2 环境，然后运行
 ```bash
 ./packages/msys/build-xp.sh -p 32-msvcrt
 ```
 
-此脚本除了接受 `build-mingw.sh` 的参数外，还接受以下参数：
-- `-p|--profile <profile>`：（必需）MinGW Lite 和 Qt 库的编译配置。可用的配置有 `64-ucrt`、`32-ucrt`、`64-msvcrt`、`32-msvcrt`、`32-win2000`。
-- `--qt <dir>`：指定 Qt 库目录。例如 `--qt /d/myqt-32`。
+要进行交叉构建，运行
+```bash
+podman run -it --rm -v $PWD:/mnt -w /mnt docker.io/amd64/ubuntu:24.04
 
-  目录结构应该如下：
-  ```
-  D:
-  └─ myqt-32
-     ├─ bin
-     ├─ include
-     ├─ lib
-     └─ ...
-  ```
+# 在容器内
+export MIRROR=mirrors.ustc.edu.cn  # 根据需要设置镜像站
+./packages/xmingw/build-xp.sh -p 32-msvcrt
+```
+
+此脚本除了接受 `build-mingw.sh` 的参数外，还接受以下参数：
+- `-p|--profile <profile>`：（必需）MinGW Lite 和 Qt 库的编译配置。可用的配置有 `64-ucrt`、`32-ucrt`、`64-msvcrt`、`32-msvcrt`。
 
 # Linux
 

--- a/packages/msys/build-xp.sh
+++ b/packages/msys/build-xp.sh
@@ -16,9 +16,6 @@ Options:
   --mingw64                Build mingw64 integrated compiler.
   --ucrt <build>           Include UCRT in the package. Windows SDK required.
                            e.g. '--ucrt 22621' for Windows 11 SDK 22H2.
-  --qt <dir>               Path to Qt library.
-                           Default: /c/Qt/${QT_VERSION}/mingw141_\${PROFILE}-redpanda.
-  -nd, --no-deps           Skip dependency check.
   -t, --target-dir <dir>   Set target directory for the packages.
 EOF
 }
@@ -39,37 +36,33 @@ fi
 PROFILE=$2
 shift 2
 
-QT_VERSION="5.15.13+redpanda1"
-QT_NAME="mingw141_${PROFILE}"
+QT_VERSION="5.15.15+redpanda0"
 case "${PROFILE}" in
   64-ucrt|64-msvcrt)
     NSIS_ARCH=x64
     PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-ws2003_x64"
     ;;
-  32-ucrt|32-msvcrt)
+  32-ucrt)
     NSIS_ARCH=x86
     PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-winxp_x86"
     ;;
-  32-win2000)
+  32-msvcrt)
     NSIS_ARCH=x86
     PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-win2000_x86"
     ;;
   *)
     echo "Invalid profile: ${PROFILE}"
-    echo "Available profiles: 64-ucrt, 32-ucrt, 64-msvcrt, 32-msvcrt, 32-win2000"
+    echo "Available profiles: 64-ucrt, 64-msvcrt, 32-ucrt, 32-msvcrt"
     exit 1
     ;;
 esac
 
 CLEAN=0
-CHECK_DEPS=1
 compilers=()
 COMPILER_MINGW32=0
 COMPILER_MINGW64=0
-COMPILER_MINGW32_WIN2000=0
 TARGET_DIR="$(pwd)/dist"
 UCRT=""
-QT_DIR="/c/Qt/${QT_VERSION}/${QT_NAME}"
 while [[ $# -gt 0 ]]; do
   case $1 in
     -h|--help)
@@ -92,26 +85,12 @@ while [[ $# -gt 0 ]]; do
           COMPILER_MINGW32=1
           shift
           ;;
-        32-win2000)
-          compilers+=("mingw32-win2000")
-          COMPILER_MINGW32_WIN2000=1
-          shift
-          ;;
       esac
       ;;
     --mingw32)
-      case "${PROFILE}" in
-        64-ucrt|32-ucrt|64-msvcrt|32-msvcrt)
-          compilers+=("mingw32")
-          COMPILER_MINGW32=1
-          shift
-          ;;
-        32-win2000)
-          compilers+=("mingw32-win2000")
-          COMPILER_MINGW32_WIN2000=1
-          shift
-          ;;
-      esac
+      compilers+=("mingw32")
+      COMPILER_MINGW32=1
+      shift
       ;;
     --mingw64)
       compilers+=("mingw64")
@@ -130,14 +109,6 @@ while [[ $# -gt 0 ]]; do
           ;;
       esac
       ;;
-    --qt)
-      QT_DIR="$2"
-      shift 2
-      ;;
-    -nd|--no-deps)
-      CHECK_DEPS=0
-      shift
-      ;;
     -t|--target-dir)
       TARGET_DIR="$2"
       shift 2
@@ -149,11 +120,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-ASTYLE_VERSION_TAG="3.4.14"
+ASTYLE_VERSION_TAG="3.6.2"
 BUILD_DIR="${TEMP}/redpanda-xp-${PROFILE}-build"
 ASTYLE_BUILD_DIR="${BUILD_DIR}/astyle"
 PACKAGE_DIR="${TEMP}/redpanda-xp-${PROFILE}-pkg"
-QMAKE="${QT_DIR}/bin/qmake.exe"
 NSIS="/mingw32/bin/makensis"
 _7Z="/mingw64/bin/7z"
 CMAKE="/mingw64/bin/cmake"
@@ -161,7 +131,10 @@ SOURCE_DIR="$(pwd)"
 ASSETS_DIR="${SOURCE_DIR}/assets"
 UCRT_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/10.0.${UCRT}.0/ucrt/DLLs/${NSIS_ARCH}"
 
-REDPANDA_MINGW_RELEASE="11.4.0-r0"
+QT_ARCHIVE="qt-$QT_VERSION-$PROFILE.tar.zst"
+QT_DIR="/c/Qt/${QT_VERSION}/${PROFILE}"
+
+REDPANDA_MINGW_RELEASE="11.5.0-r0"
 MINGW32_ARCHIVE="mingw32-${REDPANDA_MINGW_RELEASE}.7z"
 MINGW32_COMPILER_NAME="MinGW-w64 i686 GCC"
 MINGW32_PACKAGE_SUFFIX="mingw32"
@@ -170,13 +143,10 @@ MINGW64_ARCHIVE="mingw64-${REDPANDA_MINGW_RELEASE}.7z"
 MINGW64_COMPILER_NAME="MinGW-w64 x86_64 GCC"
 MINGW64_PACKAGE_SUFFIX="mingw64"
 
-MINGW_LITE_RELEASE="14.1.0-r2"
-MINGW32_WIN2000_ARCHIVE="mingw32-win2000-${MINGW_LITE_RELEASE}.7z"
-
 if [[ ${#compilers[@]} -eq 0 ]]; then
   PACKAGE_BASENAME="${PACKAGE_BASENAME}-none"
 else
-  [[ ${COMPILER_MINGW32} -eq 1 || ${COMPILER_MINGW32_WIN2000} -eq 1 ]] && PACKAGE_BASENAME="${PACKAGE_BASENAME}-${MINGW32_PACKAGE_SUFFIX}"
+  [[ ${COMPILER_MINGW32} -eq 1 ]] && PACKAGE_BASENAME="${PACKAGE_BASENAME}-${MINGW32_PACKAGE_SUFFIX}"
   [[ ${COMPILER_MINGW64} -eq 1 ]] && PACKAGE_BASENAME="${PACKAGE_BASENAME}-${MINGW64_PACKAGE_SUFFIX}"
 fi
 
@@ -186,31 +156,10 @@ function fn_print_progress() {
 
 ## check deps
 
-if [[ ${CHECK_DEPS} -eq 1 ]]; then
-  if [[ ! -x "${QMAKE}" ]]; then
-    echo "Qt library not found at ${QT_DIR}."
-    echo "Please download from https://github.com/redpanda-cpp/qtbase-xp and extract to C:/Qt."
-    exit 1
-  fi
-  deps=(
-    mingw-w64-x86_64-7zip
-    mingw-w64-x86_64-cmake
-    mingw-w64-i686-nsis
-    curl git
-  )
-  for dep in ${deps[@]}; do
-    pacman -Q ${dep} &>/dev/null || {
-      echo "Missing dependency: ${dep}"
-      exit 1
-    }
-  done
-fi
 if [[ -n "${UCRT}" && ! -f "${UCRT_DIR}/ucrtbase.dll" ]]; then
   echo "Missing Windows SDK, UCRT cannot be included."
   exit 1
 fi
-
-export PATH="${QT_DIR}/bin:${PATH}"
 
 ## prepare dirs
 
@@ -218,7 +167,22 @@ if [[ ${CLEAN} -eq 1 ]]; then
   rm -rf "${BUILD_DIR}"
   rm -rf "${PACKAGE_DIR}"
 fi
-mkdir -p "${BUILD_DIR}" "${PACKAGE_DIR}" "${TARGET_DIR}" "${ASTYLE_BUILD_DIR}" "${ASSETS_DIR}"
+mkdir -p /c/Qt "${BUILD_DIR}" "${PACKAGE_DIR}" "${TARGET_DIR}" "${ASTYLE_BUILD_DIR}" "${ASSETS_DIR}"
+
+## install deps
+
+pacman -S --noconfirm --needed \
+  mingw-w64-x86_64-7zip mingw-w64-x86_64-cmake \
+  mingw-w64-i686-nsis \
+  curl git
+
+if [[ ! -f "$ASSETS_DIR/$QT_ARCHIVE" ]]; then
+  fn_print_progress "Downloading Qt"
+  curl -L "https://github.com/redpanda-cpp/qtbase-xp/releases/download/$QT_VERSION/$QT_ARCHIVE" -o "$ASSETS_DIR/$QT_ARCHIVE"
+fi
+zstdcat "$ASSETS_DIR/$QT_ARCHIVE" | tar -x -C /c/Qt
+
+export PATH="${QT_DIR}/bin:${PATH}"
 
 ## prepare assets
 
@@ -237,9 +201,6 @@ if [[ ${COMPILER_MINGW32} -eq 1 && ! -f "${ASSETS_DIR}/${MINGW32_ARCHIVE}" ]]; t
 fi
 if [[ ${COMPILER_MINGW64} -eq 1 && ! -f "${ASSETS_DIR}/${MINGW64_ARCHIVE}" ]]; then
   curl -L "https://github.com/redpanda-cpp/toolchain-win32-mingw-xp/releases/download/${REDPANDA_MINGW_RELEASE}/${MINGW64_ARCHIVE}" -o "${ASSETS_DIR}/${MINGW64_ARCHIVE}"
-fi
-if [[ ${COMPILER_MINGW32_WIN2000} -eq 1 && ! -f "${ASSETS_DIR}/${MINGW32_WIN2000_ARCHIVE}" ]]; then
-  curl -L "https://github.com/redpanda-cpp/mingw-lite/releases/download/${MINGW_LITE_RELEASE}/${MINGW32_WIN2000_ARCHIVE}" -o "${ASSETS_DIR}/${MINGW32_WIN2000_ARCHIVE}"
 fi
 
 ## build
@@ -260,7 +221,7 @@ pushd .
 cd "${BUILD_DIR}"
 qmake_flags=()
 [[ ${NSIS_ARCH} == x64 ]] && qmake_flags+=("X86_64=ON")
-"$QMAKE" PREFIX="${PACKAGE_DIR}" ${qmake_flags[@]} -o Makefile "${SOURCE_DIR}/Red_Panda_Cpp.pro" -r
+qmake PREFIX="${PACKAGE_DIR}" ${qmake_flags[@]} -o Makefile "${SOURCE_DIR}/Red_Panda_CPP.pro" -r
 mingw32-make -j$(nproc)
 mingw32-make install
 popd
@@ -300,30 +261,26 @@ case "${PROFILE}" in
       -DREQUIRED_WINDOWS_NAME="Windows Server 2003"
     )
     ;;
-  32-ucrt|32-msvcrt)
+  32-ucrt)
     nsis_flags+=(
       -DREQUIRED_WINDOWS_BUILD=2600
       -DREQUIRED_WINDOWS_NAME="Windows XP"
     )
     ;;
-  32-win2000)
+  32-msvcrt)
     nsis_flags+=(
       -DREQUIRED_WINDOWS_BUILD=2195
-      -DREQUIRED_WINDOWS_NAME="Windows XP"
+      -DREQUIRED_WINDOWS_NAME="Windows 2000"
     )
     ;;
 esac
 if [[ ${COMPILER_MINGW32} -eq 1 ]]; then
   nsis_flags+=(-DHAVE_MINGW32)
-  [[ -d "mingw32" ]] || "${_7Z}" x "${SOURCE_DIR}/assets/${MINGW32_ARCHIVE}" -o"${PACKAGE_DIR}"
+  [[ -d "mingw32" ]] || "${_7Z}" x "$ASSETS_DIR/${MINGW32_ARCHIVE}" -o"${PACKAGE_DIR}"
 fi
 if [[ ${COMPILER_MINGW64} -eq 1 ]]; then
   nsis_flags+=(-DHAVE_MINGW64)
-  [[ -d "mingw64" ]] || "${_7Z}" x "${SOURCE_DIR}/assets/${MINGW64_ARCHIVE}" -o"${PACKAGE_DIR}"
-fi
-if [[ ${COMPILER_MINGW32_WIN2000} -eq 1 ]]; then
-  nsis_flags+=(-DHAVE_MINGW32)
-  [[ -d "mingw32" ]] || "${_7Z}" x "${SOURCE_DIR}/assets/${MINGW32_WIN2000_ARCHIVE}" -o"${PACKAGE_DIR}"
+  [[ -d "mingw64" ]] || "${_7Z}" x "$ASSETS_DIR/${MINGW64_ARCHIVE}" -o"${PACKAGE_DIR}"
 fi
 if [[ -n "${UCRT}" ]]; then
   nsis_flags+=(-DHAVE_UCRT)

--- a/packages/xmingw/build-xp.sh
+++ b/packages/xmingw/build-xp.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+function fn_print_help() {
+  cat <<EOF
+Usage:
+  packages/msys/build-xp.sh -p|--profile <profile> [-c|--clean] [-nd|--no-deps] [-t|--target-dir <dir>]
+Options:
+  -h, --help               Display this information.
+  -p, --profile <profile>  MinGW Lite profile.
+                           MUST be used before other options.
+  -c, --clean              Clean build and package directories.
+  --mingw                  Alias for --mingw32 (x86 app) or --mingw64 (x64 app).
+  --mingw32                Build mingw32 integrated compiler.
+  --mingw64                Build mingw64 integrated compiler.
+EOF
+}
+
+source version.inc
+if [[ -n "$APP_VERSION_SUFFIX" ]]; then
+  APP_VERSION="$APP_VERSION$APP_VERSION_SUFFIX"
+fi
+
+if [[ $# -lt 2 || ($1 != "-p" && $1 != "--profile") ]]; then
+  echo "Missing profile argument."
+  exit 1
+fi
+
+PROFILE=$2
+shift 2
+
+case "${PROFILE}" in
+  64-ucrt|64-msvcrt)
+    NSIS_ARCH=x64
+    TARGET=x86_64-w64-mingw32
+    PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-ws2003_x64"
+    ;;
+  32-ucrt)
+    NSIS_ARCH=x86
+    TARGET=i686-w64-mingw32
+    PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-winxp_x86"
+    ;;
+  32-msvcrt)
+    NSIS_ARCH=x86
+    TARGET=i686-w64-mingw32
+    PACKAGE_BASENAME="redpanda-cpp-${APP_VERSION}-win2000_x86"
+    ;;
+  *)
+    echo "Invalid profile: ${PROFILE}"
+    echo "Available profiles: 64-ucrt, 64-msvcrt, 32-ucrt, 32-msvcrt"
+    exit 1
+    ;;
+esac
+
+CLEAN=0
+compilers=()
+COMPILER_MINGW32=0
+COMPILER_MINGW64=0
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      fn_print_help
+      exit 0
+      ;;
+    -c|--clean)
+      CLEAN=1
+      shift
+      ;;
+    --mingw)
+      case "$PROFILE" in
+        64-ucrt|64-msvcrt)
+          compilers+=("mingw64")
+          COMPILER_MINGW64=1
+          shift
+          ;;
+        32-ucrt|32-msvcrt)
+          compilers+=("mingw32")
+          COMPILER_MINGW32=1
+          shift
+          ;;
+      esac
+      ;;
+    --mingw32)
+      compilers+=("mingw32")
+      COMPILER_MINGW32=1
+      shift
+      ;;
+    --mingw64)
+      compilers+=("mingw64")
+      COMPILER_MINGW64=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+QT_VERSION=5.15.15+redpanda0
+MINGW_LITE_BRANCH=14
+
+ASTYLE_VERSION_TAG="3.6.2"
+TARGET_DIR="$PWD/dist"
+BUILD_DIR="/tmp/build/redpanda-xp-$PROFILE-build"
+ASTYLE_BUILD_DIR="$BUILD_DIR/astyle"
+PACKAGE_DIR="/tmp/build/redpanda-xp-$PROFILE-pkg"
+SOURCE_DIR="$PWD"
+ASSETS_DIR="$PWD/assets"
+
+QT_ARCHIVE="x-qt-$QT_VERSION-$PROFILE.tar.zst"
+QT_DIR="/opt/x-mingw$PROFILE-$MINGW_LITE_BRANCH"
+
+REDPANDA_MINGW_RELEASE="11.5.0-r0"
+MINGW32_ARCHIVE="mingw32-$REDPANDA_MINGW_RELEASE.7z"
+MINGW32_COMPILER_NAME="MinGW-w64 i686 GCC"
+MINGW32_PACKAGE_SUFFIX="mingw32"
+
+MINGW64_ARCHIVE="mingw64-$REDPANDA_MINGW_RELEASE.7z"
+MINGW64_COMPILER_NAME="MinGW-w64 x86_64 GCC"
+MINGW64_PACKAGE_SUFFIX="mingw64"
+
+if [[ ${#compilers[@]} -eq 0 ]]; then
+  PACKAGE_BASENAME="$PACKAGE_BASENAME-none"
+else
+  [[ "$COMPILER_MINGW32" -eq 1 ]] && PACKAGE_BASENAME="$PACKAGE_BASENAME-$MINGW32_PACKAGE_SUFFIX"
+  [[ "$COMPILER_MINGW64" -eq 1 ]] && PACKAGE_BASENAME="$PACKAGE_BASENAME-$MINGW64_PACKAGE_SUFFIX"
+fi
+
+function fn_print_progress() {
+  echo -e "\e[1;32;44m$1\e[0m"
+}
+
+## prepare dirs
+
+if [[ "$CLEAN" -eq 1 ]]; then
+  rm -rf "$BUILD_DIR"
+  rm -rf "$PACKAGE_DIR"
+fi
+mkdir -p "$BUILD_DIR" "$PACKAGE_DIR" "$TARGET_DIR" "$ASTYLE_BUILD_DIR" "$ASSETS_DIR"
+
+## install deps
+
+if [[ -v MIRROR && -n $MIRROR ]]
+then
+  sed -i "s|archive.ubuntu.com|$MIRROR|; s|security.ubuntu.com|$MIRROR|" /etc/apt/sources.list.d/ubuntu.sources
+fi
+
+apt update
+env DEBIAN_FRONTEND=noninteractive \
+  apt install -y --no-install-recommends \
+    7zip ca-certificates cmake curl git make nsis qttools5-dev-tools zstd
+
+if [[ ! -f "$ASSETS_DIR/$QT_ARCHIVE" ]]; then
+  fn_print_progress "Downloading Qt"
+  curl -L "https://github.com/redpanda-cpp/qtbase-xp/releases/download/$QT_VERSION/$QT_ARCHIVE" -o "$ASSETS_DIR/$QT_ARCHIVE"
+fi
+zstdcat "$ASSETS_DIR/$QT_ARCHIVE" | tar -x -C /
+
+export PATH="$QT_DIR/bin:$PATH"
+
+## prepare assets
+
+fn_print_progress "Updating astyle repo..."
+if [[ ! -d "$ASSETS_DIR/astyle" ]]; then
+  git clone --bare "https://gitlab.com/saalen/astyle" "$ASSETS_DIR/astyle"
+fi
+pushd "$ASSETS_DIR/astyle"
+if [[ -z "$(git tag -l "$ASTYLE_VERSION_TAG")" ]]; then
+  git fetch --all --tags
+fi
+popd
+
+if [[ "$COMPILER_MINGW32" -eq 1 && ! -f "$ASSETS_DIR/$MINGW32_ARCHIVE" ]]; then
+  fn_print_progress "Downloading MinGW32..."
+  curl -L "https://github.com/redpanda-cpp/toolchain-win32-mingw-xp/releases/download/$REDPANDA_MINGW_RELEASE/$MINGW32_ARCHIVE" -o "$ASSETS_DIR/$MINGW32_ARCHIVE"
+fi
+if [[ "$COMPILER_MINGW64" -eq 1 && ! -f "$ASSETS_DIR/$MINGW64_ARCHIVE" ]]; then
+  fn_print_progress "Downloading MinGW64..."
+  curl -L "https://github.com/redpanda-cpp/toolchain-win32-mingw-xp/releases/download/$REDPANDA_MINGW_RELEASE/$MINGW64_ARCHIVE" -o "$ASSETS_DIR/$MINGW64_ARCHIVE"
+fi
+
+## build
+
+fn_print_progress "Building astyle..."
+pushd "$ASSETS_DIR/astyle"
+git --work-tree="$ASTYLE_BUILD_DIR" checkout -f "$ASTYLE_VERSION_TAG"
+popd
+
+pushd "$ASTYLE_BUILD_DIR"
+sed -i "s|<Windows.h>|<windows.h>|" AStyle/src/*.cpp
+
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_CC_COMPILER="$TARGET-gcc" -DCMAKE_CXX_COMPILER="$TARGET-g++" -DCMAKE_EXE_LINKER_FLAGS="-static"
+make -j$(nproc)
+cp AStyle/AStyle.exe "$PACKAGE_DIR/astyle.exe"
+popd
+
+fn_print_progress "Building..."
+pushd "$BUILD_DIR"
+qmake_flags=()
+if [[ "$NSIS_ARCH" == x64 ]]; then
+  qmake_flags+=("X86_64=ON")
+fi
+qmake PREFIX="$PACKAGE_DIR" "${qmake_flags[@]}" -o Makefile "$SOURCE_DIR/Red_Panda_CPP.pro" -r
+make -j$(nproc)
+make install
+popd
+
+## prepare packaging resources
+
+pushd "$PACKAGE_DIR"
+
+cp "$SOURCE_DIR/platform/windows/qt.conf" .
+
+cp "$SOURCE_DIR"/platform/windows/installer-scripts/{lang.nsh,utils.nsh,redpanda.nsi} .
+popd
+
+## make package
+
+pushd "$PACKAGE_DIR"
+SETUP_NAME="$PACKAGE_BASENAME.exe"
+PORTABLE_NAME="$PACKAGE_BASENAME.7z"
+
+fn_print_progress "Making installer..."
+
+nsis_flags=(
+  -DAPP_VERSION="$APP_VERSION"
+  -DARCH="$NSIS_ARCH"
+  -DFINALNAME="$SETUP_NAME"
+  -DMINGW32_COMPILER_NAME="$MINGW32_COMPILER_NAME"
+  -DMINGW64_COMPILER_NAME="$MINGW64_COMPILER_NAME"
+)
+case "$PROFILE" in
+  64-ucrt|64-msvcrt)
+    nsis_flags+=(
+      -DREQUIRED_WINDOWS_BUILD=3790
+      -DREQUIRED_WINDOWS_NAME="Windows Server 2003"
+    )
+    ;;
+  32-ucrt)
+    nsis_flags+=(
+      -DREQUIRED_WINDOWS_BUILD=2600
+      -DREQUIRED_WINDOWS_NAME="Windows XP"
+    )
+    ;;
+  32-msvcrt)
+    nsis_flags+=(
+      -DREQUIRED_WINDOWS_BUILD=2195
+      -DREQUIRED_WINDOWS_NAME="Windows 2000"
+    )
+    ;;
+esac
+if [[ "$COMPILER_MINGW32" -eq 1 ]]; then
+  nsis_flags+=(-DHAVE_MINGW32)
+  if [[ ! -d mingw32 ]]; then
+    7z x "$ASSETS_DIR/$MINGW32_ARCHIVE" -o"$PACKAGE_DIR"
+  fi
+fi
+if [[ "$COMPILER_MINGW64" -eq 1 ]]; then
+  nsis_flags+=(-DHAVE_MINGW64)
+  if [[ ! -d mingw64 ]]; then
+    7z x "$ASSETS_DIR/$MINGW64_ARCHIVE" -o"$PACKAGE_DIR"
+  fi
+fi
+makensis "${nsis_flags[@]}" redpanda.nsi
+
+fn_print_progress "Making Portable Package..."
+7z x "$SETUP_NAME" -o"RedPanda-CPP" -xr'!$PLUGINSDIR' -x"!uninstall.exe"
+7z a -mmt -mx9 -ms=on -mqs=on -mf=BCJ2 "$PORTABLE_NAME" RedPanda-CPP
+rm -rf RedPanda-CPP
+
+mv "$SETUP_NAME" "$TARGET_DIR"
+mv "$PORTABLE_NAME" "$TARGET_DIR"
+popd


### PR DESCRIPTION
- upgrade to Qt 5.15.15, mingw-lite 14.2.0
- port bundled mingw-builds to Windows 2000
  - previous winxp build now becomes win2000 build, replacing old win2000 build
- automatic dependency download & install
- add cross build script