### PR TITLE
Enable OEM codepages in charsetinfo.cpp

### DIFF
--- a/libs/redpanda_qt_utils/qt_utils/charsetinfo.cpp
+++ b/libs/redpanda_qt_utils/qt_utils/charsetinfo.cpp
@@ -106,26 +106,26 @@ CharsetInfoManager::CharsetInfoManager(const QString& localeName):
     mLocaleName(localeName)
 {
     mCodePages.append(std::make_shared<CharsetInfo>(37,"IBM037","","",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(437,"IBM437","","",false));
+    mCodePages.append(std::make_shared<CharsetInfo>(437,"IBM437","","",true));
     mCodePages.append(std::make_shared<CharsetInfo>(500,"IBM500","","",false));
     mCodePages.append(std::make_shared<CharsetInfo>(708,"ASMO-708","","",false));
     mCodePages.append(std::make_shared<CharsetInfo>(709,"","","",false));
     mCodePages.append(std::make_shared<CharsetInfo>(710,"","","",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(720,"DOS-720",tr("Arabic"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(737,"ibm737",tr("Greek"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(775,"ibm775",tr("Baltic"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(850,"ibm850",tr("Western Europe"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(852,"ibm852",tr("Central Europe"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(855,"IBM855",tr("Cyrillic"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(857,"ibm857",tr("Turkish"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(858,"ibm858",tr("Western Europe"),"",false));
+    mCodePages.append(std::make_shared<CharsetInfo>(720,"DOS-720",tr("Arabic"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(737,"ibm737",tr("Greek"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(775,"ibm775",tr("Baltic"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(850,"ibm850",tr("Western Europe"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(852,"ibm852",tr("Central Europe"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(855,"IBM855",tr("Cyrillic"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(857,"ibm857",tr("Turkish"),"",true));
+    mCodePages.append(std::make_shared<CharsetInfo>(858,"ibm858",tr("Western Europe"),"",true));
     mCodePages.append(std::make_shared<CharsetInfo>(860,"IBM860",tr("Western Europe"),"",false));
     mCodePages.append(std::make_shared<CharsetInfo>(861,"ibm861",tr("Northern Europe"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(862,"DOS-862",tr("Hebrew"),"",false));
+    mCodePages.append(std::make_shared<CharsetInfo>(862,"DOS-862",tr("Hebrew"),"",true));
     mCodePages.append(std::make_shared<CharsetInfo>(863,"IBM863",tr("Western Europe"),"",false));
     mCodePages.append(std::make_shared<CharsetInfo>(864,"IBM864","","",false));
     mCodePages.append(std::make_shared<CharsetInfo>(865,"IBM865",tr("Northern Europe"),"",false));
-    mCodePages.append(std::make_shared<CharsetInfo>(866,"cp866",tr("Cyrillic"),"",false));
+    mCodePages.append(std::make_shared<CharsetInfo>(866,"cp866",tr("Cyrillic"),"",true));
     mCodePages.append(std::make_shared<CharsetInfo>(869,"ibm869",tr("Greek"),"",false));
     mCodePages.append(std::make_shared<CharsetInfo>(870,"IBM870","","",false));
     mCodePages.append(std::make_shared<CharsetInfo>(874,"tis-620",tr("Thai"),"",true));


### PR DESCRIPTION
The OEM code pages are used by Windows console applications.