### PR TITLE
Add russian interface localization

### DIFF
--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -582,7 +582,6 @@ qtConfig(static) {
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_pt_BR.qm
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_zh_CN.qm
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_zh_TW.qm
-    qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_ru_RU.qm
     qt_translation_files.base = $$[QT_INSTALL_TRANSLATIONS]
     qt_translation_files.prefix = /translations
 

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -542,6 +542,7 @@ linux: {
 TRANSLATIONS += \
     translations/RedPandaIDE_zh_CN.ts \
     translations/RedPandaIDE_zh_TW.ts \
+    translations/RedPandaIDE_ru_RU.ts \
     translations/RedPandaIDE_pt_BR.ts
 
 win32: {
@@ -581,6 +582,7 @@ qtConfig(static) {
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_pt_BR.qm
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_zh_CN.qm
     qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_zh_TW.qm
+    qt_translation_files.files += $$[QT_INSTALL_TRANSLATIONS]/qtbase_ru_RU.qm
     qt_translation_files.base = $$[QT_INSTALL_TRANSLATIONS]
     qt_translation_files.prefix = /translations
 

--- a/RedPandaIDE/settingsdialog/environmentappearancewidget.cpp
+++ b/RedPandaIDE/settingsdialog/environmentappearancewidget.cpp
@@ -107,6 +107,7 @@ void EnvironmentAppearanceWidget::init()
     ui->cbLanguage->addItem(tr("Portuguese"),"pt_BR");
     ui->cbLanguage->addItem(tr("Simplified Chinese"),"zh_CN");
     ui->cbLanguage->addItem(tr("Traditional Chinese"),"zh_TW");
+    ui->cbLanguage->addItem(tr("Russian"),"ru_RU");
     QList<PIconSet> iconSets = pIconsManager->listIconSets();
     foreach(const PIconSet& iconSet, iconSets) {
         ui->cbIconSet->addItem(iconSet->displayName,iconSet->name);

--- a/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
@@ -1,0 +1,10392 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="14"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="20"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:600;&quot;&gt;Red Panda C++&lt;/span&gt;&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="35"/>
+        <source>Based on Qt %1 (%2) running on %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="47"/>
+        <source>Build time: %1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="59"/>
+        <source>Copyright(C) 2021-2024 瞿华(royqh1979@gmail.com)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="71"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Homepage: &lt;a href=&quot;Homepage: https://sourceforge.net/projects/dev-cpp-2020/&quot;&gt;https://sourceforge.net/projects/dev-cpp-2020/&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="87"/>
+        <source>GNU General Public License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.ui" line="96"/>
+        <source>    This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="30"/>
+        <source>Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="68"/>
+        <source>unknown compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="78"/>
+        <source>Website: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AppTheme</name>
+    <message>
+        <location filename="../thememanager.cpp" line="199"/>
+        <source>Theme file &apos;%1&apos; doesn&apos;t exist!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../thememanager.cpp" line="215"/>
+        <source>Error in json file &apos;%1&apos;:%2 : %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../thememanager.cpp" line="270"/>
+        <source>Can&apos;t open the theme file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutolinkModel</name>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="93"/>
+        <source>Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="95"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="97"/>
+        <source>Link options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="156"/>
+        <source>Header exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="157"/>
+        <source>Header already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BacktraceModel</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1500"/>
+        <source>Function</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1502"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1504"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkModel</name>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="292"/>
+        <source>Save file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="296"/>
+        <source>Can&apos;t open file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="315"/>
+        <source>Error in json file &apos;%1&apos;:%2 : %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="341"/>
+        <source>Can&apos;t open file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="547"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="549"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/bookmarkmodel.cpp" line="551"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BreakpointModel</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1267"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1269"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1271"/>
+        <source>Condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CPUDialog</name>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="14"/>
+        <source>CPU Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="72"/>
+        <location filename="../widgets/cpudialog.ui" line="75"/>
+        <source>Step over one machine instruction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="85"/>
+        <location filename="../widgets/cpudialog.ui" line="88"/>
+        <source>Step into one machine instruction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="95"/>
+        <source>Callstack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="149"/>
+        <source>AT&amp;&amp;T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="159"/>
+        <source>Intel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/cpudialog.ui" line="169"/>
+        <source>Blend Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChooseThemeDialog</name>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="14"/>
+        <location filename="../widgets/choosethemedialog.ui" line="20"/>
+        <source>Choose Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="58"/>
+        <source>Dark Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="65"/>
+        <source>Light Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="72"/>
+        <source>System Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="85"/>
+        <source>Default Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="92"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="102"/>
+        <source>C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/choosethemedialog.ui" line="169"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CodeSnippetsManager</name>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="57"/>
+        <location filename="../codesnippetsmanager.cpp" line="66"/>
+        <source>Load default code snippets failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="58"/>
+        <location filename="../codesnippetsmanager.cpp" line="67"/>
+        <source>Can&apos;t copy default code snippets &apos;%1&apos; to &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="77"/>
+        <location filename="../codesnippetsmanager.cpp" line="90"/>
+        <source>Read code snippets failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="78"/>
+        <source>Can&apos;t open code snippet file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="91"/>
+        <source>Read code snippet file &apos;%1&apos; failed:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="115"/>
+        <location filename="../codesnippetsmanager.cpp" line="134"/>
+        <source>Save code snippets failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="116"/>
+        <source>Can&apos;t open code snippet file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="135"/>
+        <source>Write to code snippet file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="150"/>
+        <source>Load new file template failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="151"/>
+        <source>Can&apos;t open new file template file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="164"/>
+        <source>Save new file template failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="165"/>
+        <source>Can&apos;t open new file template file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CodeSnippetsModel</name>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="310"/>
+        <source>Caption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="312"/>
+        <source>Completion Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="314"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../codesnippetsmanager.cpp" line="316"/>
+        <source>Menu Section</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ColorEdit</name>
+    <message>
+        <location filename="../widgets/coloredit.cpp" line="73"/>
+        <location filename="../widgets/coloredit.cpp" line="105"/>
+        <source>NONE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/coloredit.cpp" line="111"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CompetitiveCompanionThread</name>
+    <message>
+        <location filename="../problems/competitivecompenionhandler.cpp" line="131"/>
+        <source>Problem Case %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Compiler</name>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="62"/>
+        <source>Clean before rebuild failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="74"/>
+        <source> - Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="76"/>
+        <source> - Command: %1 &gt; %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="81"/>
+        <source>Compile Result:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="83"/>
+        <source>- Errors: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="84"/>
+        <source>- Warnings: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="86"/>
+        <source>- Output Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="88"/>
+        <source>- Output Size: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="90"/>
+        <source>- Compilation Time: %1 secs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="181"/>
+        <location filename="../compiler/compiler.cpp" line="183"/>
+        <source>error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="183"/>
+        <location filename="../compiler/compiler.cpp" line="196"/>
+        <source>[Error] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="185"/>
+        <location filename="../compiler/compiler.cpp" line="187"/>
+        <source>warning:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="187"/>
+        <location filename="../compiler/compiler.cpp" line="201"/>
+        <source>[Warning] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="199"/>
+        <source>warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="204"/>
+        <source>info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="206"/>
+        <source>[Info] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="209"/>
+        <source>note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="211"/>
+        <source>[Note] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="747"/>
+        <source>Can&apos;t open file &quot;%1&quot; for write!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="799"/>
+        <source>The compiler process for &apos;%1&apos; failed to start.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="803"/>
+        <source>The compiler process crashed after starting successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="806"/>
+        <source>The last waitFor...() function timed out.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="809"/>
+        <source>An error occurred when attempting to write to the compiler process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="812"/>
+        <source>An error occurred when attempting to read from the compiler process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compiler.cpp" line="815"/>
+        <source>An unknown error occurred.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CompilerAutolinkWidget</name>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="20"/>
+        <source>Enable auto link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="44"/>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="47"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="54"/>
+        <location filename="../settingsdialog/compilerautolinkwidget.ui" line="57"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="65"/>
+        <source>Save failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CompilerManager</name>
+    <message>
+        <location filename="../compiler/compilermanager.cpp" line="84"/>
+        <location filename="../compiler/compilermanager.cpp" line="120"/>
+        <location filename="../compiler/compilermanager.cpp" line="152"/>
+        <location filename="../compiler/compilermanager.cpp" line="186"/>
+        <location filename="../compiler/compilermanager.cpp" line="205"/>
+        <source>No compiler set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilermanager.cpp" line="85"/>
+        <location filename="../compiler/compilermanager.cpp" line="121"/>
+        <location filename="../compiler/compilermanager.cpp" line="153"/>
+        <location filename="../compiler/compilermanager.cpp" line="187"/>
+        <location filename="../compiler/compilermanager.cpp" line="206"/>
+        <source>No compiler set is configured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilermanager.cpp" line="85"/>
+        <location filename="../compiler/compilermanager.cpp" line="121"/>
+        <location filename="../compiler/compilermanager.cpp" line="153"/>
+        <location filename="../compiler/compilermanager.cpp" line="187"/>
+        <location filename="../compiler/compilermanager.cpp" line="206"/>
+        <source>Can&apos;t start debugging.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilermanager.cpp" line="297"/>
+        <source>Can&apos;t find Console Pauser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilermanager.cpp" line="298"/>
+        <source>Console Pauser &quot;%1&quot; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CompilerSetDirectoriesWidget</name>
+    <message>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="41"/>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="44"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="54"/>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="57"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="67"/>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="70"/>
+        <source>Remove Invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetdirectorieswidget.cpp" line="77"/>
+        <source>Choose Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CompilerSetOptionWidget</name>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="20"/>
+        <source>Compiler set to config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="35"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="38"/>
+        <source>Auto Find Compilers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="45"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="48"/>
+        <source>Find Compiler in the Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="55"/>
+        <source>Specify the compiler executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="58"/>
+        <source>Add Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="65"/>
+        <source>Copy current compiler set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="68"/>
+        <source>Copy compiler set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="75"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="78"/>
+        <source>Add Blank Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="85"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="88"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="95"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="98"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="115"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="136"/>
+        <source>Convert Executable&apos;s Charset as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="165"/>
+        <source>Statically link libraries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="172"/>
+        <source>Don&apos;t localize compiler output messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="179"/>
+        <source>Survive auto-finds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="186"/>
+        <source>Add the following arguments when calling the compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="196"/>
+        <source>Add the following arguments when calling the linker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="207"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="233"/>
+        <source>Directories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="262"/>
+        <source>Programs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="277"/>
+        <source>Choose Debugger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="280"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="287"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="310"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="337"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="347"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="373"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="294"/>
+        <source>Resource Compiler（windres)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="307"/>
+        <source>Choose make</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="317"/>
+        <source>C Compiler(gcc)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="324"/>
+        <source>make</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="334"/>
+        <source>Choose C++ Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="344"/>
+        <source>Choose C Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="357"/>
+        <source>gdb server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="370"/>
+        <source>Choose Resource Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="380"/>
+        <source>C++ Compiler(g++)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="387"/>
+        <source>gdb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="411"/>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="430"/>
+        <source>Compiling output suffix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="437"/>
+        <source>Executable suffix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="444"/>
+        <source>Compilation Stages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="450"/>
+        <source>Stop after the preprocessing stage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="457"/>
+        <source>Stop after the compilation proper stage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="464"/>
+        <source>Link and generate the executable </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="480"/>
+        <source>Preprocessing output suffix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.ui" line="509"/>
+        <source>Binary suffix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="67"/>
+        <source>System Default(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="68"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="315"/>
+        <source>Red Panda C++ will clear previously found compiler list and search for compilers in the following locations:&lt;br /&gt; &apos;%1&apos;&lt;br /&gt; &apos;%2&apos;&lt;br /&gt;Do you really want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="320"/>
+        <source>Red Panda C++ will clear previously found compiler list and search for compilers in the the PATH. &lt;br /&gt;Do you really want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="323"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="327"/>
+        <source>Searching for compilers...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="328"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="335"/>
+        <source>Searching...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="342"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="370"/>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="342"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="370"/>
+        <source>Can&apos;t find any compiler.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="348"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="379"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="396"/>
+        <source>Compiler Set Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="348"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="361"/>
+        <source>Compiler Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="379"/>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="396"/>
+        <source>New name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="380"/>
+        <source>%1 Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="472"/>
+        <source>Locate C Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="484"/>
+        <source>Locate C++ Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="496"/>
+        <source>Locate Make</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="508"/>
+        <source>Locate GDB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="520"/>
+        <source>Locate GDB Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="532"/>
+        <source>Locate windres</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="542"/>
+        <source>Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CppRefacter</name>
+    <message>
+        <location filename="../cpprefacter.cpp" line="147"/>
+        <location filename="../cpprefacter.cpp" line="160"/>
+        <location filename="../cpprefacter.cpp" line="352"/>
+        <location filename="../cpprefacter.cpp" line="402"/>
+        <source>Rename Symbol Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../cpprefacter.cpp" line="148"/>
+        <source>Can&apos;t rename symbols not defined in this file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../cpprefacter.cpp" line="161"/>
+        <source>New symbol already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../cpprefacter.cpp" line="192"/>
+        <location filename="../cpprefacter.cpp" line="203"/>
+        <source>Searching...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../cpprefacter.cpp" line="193"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomMakefileInfoDialog</name>
+    <message>
+        <location filename="../widgets/custommakefileinfodialog.ui" line="14"/>
+        <source>Information for custom makefile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/custommakefileinfodialog.ui" line="20"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/custommakefileinfodialog.ui" line="53"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red Panda C++&apos;s Makefile has two important targets:&lt;/p&gt;&lt;p&gt;- all (which builds the executable)&lt;/p&gt;&lt;p&gt;- clean (which cleans up object files)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;all&amp;quot; depends on 2 targets: all-before and all-after. All-before&lt;/p&gt;&lt;p&gt;gets called before the compilation process, and all-after gets&lt;/p&gt;&lt;p&gt;called after the compilation process.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;clean&amp;quot; depends on the target clean-custom, which gets called&lt;/p&gt;&lt;p&gt;before the cleaning process.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;You can change the Makefile&apos;s behavior by defining the targets&lt;/p&gt;&lt;p&gt;that &amp;quot;all&amp;quot; and &amp;quot;clean&amp;quot; depend on.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebugGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="20"/>
+        <source>Autosave watches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="42"/>
+        <source>Max number of array elements displayed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="87"/>
+        <source>Max  characters of a string displayed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="117"/>
+        <source>Use GDB Server to debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="138"/>
+        <source>GDB Server Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="171"/>
+        <source>Skip header files when step into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="189"/>
+        <source>System library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="196"/>
+        <source>Project library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="203"/>
+        <source>Custom library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="226"/>
+        <source>Debug Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="262"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="272"/>
+        <source>Show only monospaced fonts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="310"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="340"/>
+        <source>Show detail debug logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="350"/>
+        <source>Memory View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="368"/>
+        <source>Rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="388"/>
+        <source>Columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="421"/>
+        <source>CPU Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="439"/>
+        <source>Show CPU Window when signal received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="446"/>
+        <source>Show disassembly code in blend mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="468"/>
+        <source>Disassembly Coding Style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="499"/>
+        <source>AT&amp;&amp;T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/debuggeneralwidget.ui" line="509"/>
+        <source>Intel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Debugger</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="97"/>
+        <source>No compiler set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="98"/>
+        <source>No compiler set is configured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="98"/>
+        <source>Can&apos;t start debugging.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="123"/>
+        <source>Debugger not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="124"/>
+        <source>Can&apos;&apos;t find debugger (gdb) in : &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="126"/>
+        <source>Please check the &quot;program&quot; page of compiler settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="132"/>
+        <source>GDB Server path error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="133"/>
+        <source>GDB Server&apos;s path &quot;%1&quot; contains non-ascii characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="136"/>
+        <source>This prevents it from executing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="141"/>
+        <source>GDB Server not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="142"/>
+        <source>Can&apos;&apos;t find gdb server in : &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="585"/>
+        <source>Execute to evaluate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="929"/>
+        <source>Save file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="933"/>
+        <source>Can&apos;t open file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="958"/>
+        <source>Error in json file &apos;%1&apos;:%2 : %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="977"/>
+        <source>Can&apos;t open file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1006"/>
+        <source>Compile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1007"/>
+        <source>Source file is more recent than executable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1007"/>
+        <source>Recompile?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1045"/>
+        <source>Signal &quot;%1&quot; Received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Editor</name>
+    <message>
+        <location filename="../editor.cpp" line="127"/>
+        <location filename="../editor.cpp" line="632"/>
+        <source>Error Load File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="382"/>
+        <location filename="../editor.cpp" line="453"/>
+        <location filename="../editor.cpp" line="482"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="418"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="454"/>
+        <source>File %1 already opened!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="2207"/>
+        <source>hex: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="2209"/>
+        <source>dec: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="3381"/>
+        <source>Print Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="4130"/>
+        <location filename="../editor.cpp" line="4155"/>
+        <location filename="../editor.cpp" line="4201"/>
+        <source>Ctrl+click for more info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5143"/>
+        <source>astyle not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5144"/>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="331"/>
+        <source>Can&apos;t find astyle in &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5152"/>
+        <source>Reformatting content using astyle...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5154"/>
+        <source>- Astyle: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5155"/>
+        <source>- Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5323"/>
+        <source>Break point condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5324"/>
+        <source>Enter the condition of the breakpoint:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editor.cpp" line="5584"/>
+        <source>Readonly</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorAutoSaveWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="20"/>
+        <source>Auto backup editing contents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="27"/>
+        <source>Enable auto save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="51"/>
+        <source>Time interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="58"/>
+        <source>minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="87"/>
+        <source>Objects to save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="93"/>
+        <source>Current File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="100"/>
+        <source>All files opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="107"/>
+        <source>Project files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="117"/>
+        <source>Save strategy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="123"/>
+        <source>Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="130"/>
+        <source>Append UNIX timestamp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="137"/>
+        <source>Append formatted timestamp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.ui" line="147"/>
+        <source>Demo file name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorautosavewidget.cpp" line="38"/>
+        <location filename="../settingsdialog/editorautosavewidget.cpp" line="40"/>
+        <location filename="../settingsdialog/editorautosavewidget.cpp" line="44"/>
+        <source>Demo file name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorClipboardWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="35"/>
+        <source>Copy with format as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="61"/>
+        <source>Copy &amp;&amp; Export As HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="70"/>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="151"/>
+        <source>Use background color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="77"/>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="158"/>
+        <source>Use editor&apos;s color scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="84"/>
+        <source>Copy with line number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="91"/>
+        <source>Recalc line number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="113"/>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="180"/>
+        <source>Color scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorclipboardwidget.ui" line="142"/>
+        <source>Export As RTF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorCodeCompletionWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="20"/>
+        <source>Enable code competion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="47"/>
+        <source>Minimum id length to show completion </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="80"/>
+        <source>Editors share one code parser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="87"/>
+        <source>Clear all parsed symbols when editor is hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="94"/>
+        <source>Show completion suggestions while typing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="101"/>
+        <source>Engine options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="107"/>
+        <source>Scan local header files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="114"/>
+        <source>Scan system header files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="124"/>
+        <source>Show keywords in suggestions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="131"/>
+        <source>Show code snippets in suggestions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="138"/>
+        <source>Append () when complete functions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="145"/>
+        <source>Ignore case when search suggestions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="152"/>
+        <source>Prefer local symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="159"/>
+        <source>Hide symbols start with underscore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="166"/>
+        <source>Hide symbols start with two underscores</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="188"/>
+        <source>Prefer symbols mostly used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="208"/>
+        <source>Clear usage data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="233"/>
+        <source>Completion suggestion window width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="263"/>
+        <source>Completion suggestion window height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorColorSchemeWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="44"/>
+        <source>Scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="54"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="188"/>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="195"/>
+        <source>Foreground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="265"/>
+        <source>Font Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="271"/>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="278"/>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="285"/>
+        <source>Strikeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="292"/>
+        <source>Underlined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="349"/>
+        <source>Rainbow parenthesis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="356"/>
+        <source>Duplicate...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="361"/>
+        <source>Rename...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="366"/>
+        <source>Restore to Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="371"/>
+        <source>Import Scheme...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="376"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.ui" line="381"/>
+        <source>Delete...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="345"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="398"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="407"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="420"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="433"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="450"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="465"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="488"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="387"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="387"/>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="458"/>
+        <source>Color Scheme Files (*.scheme)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="398"/>
+        <source>&apos;%1&apos; is not a valid name for color scheme file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="416"/>
+        <source>New scheme name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="420"/>
+        <source>&apos;%1&apos; is not a valid scheme name!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="458"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="474"/>
+        <source>Confirm Delete Scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="475"/>
+        <source>Scheme &apos;%1&apos; will be deleted!&lt;br /&gt;Do you really want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorFontDialog</name>
+    <message>
+        <location filename="../widgets/editorfontdialog.ui" line="14"/>
+        <source>Choose Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/editorfontdialog.ui" line="39"/>
+        <source>Show only monospaced fonts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorFontWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="20"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="31"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="41"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="44"/>
+        <source>Modify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="51"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="54"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="61"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="64"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="84"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="87"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="94"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="97"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="104"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="107"/>
+        <source>Move to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="114"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="117"/>
+        <source>Move to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="153"/>
+        <source>Enable ligatures support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="160"/>
+        <source>Force fixed width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="183"/>
+        <source>Line Spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="190"/>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="542"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="285"/>
+        <source>Show whitespaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="291"/>
+        <source>Leading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="298"/>
+        <source>Inner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="305"/>
+        <source>Trailing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="312"/>
+        <source>Line break</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="322"/>
+        <source>Gutter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="343"/>
+        <source>Gutter is visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="365"/>
+        <source>Left Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="382"/>
+        <source>Right Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="415"/>
+        <source>Show Line Numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="439"/>
+        <source>Add leading zeros to line numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="446"/>
+        <source>Line numbers starts at zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="453"/>
+        <source>Auto calculate the digit count of line number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="475"/>
+        <source>Digit count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="511"/>
+        <source>Use Custom Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="535"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorfontwidget.ui" line="630"/>
+        <source>Show only monospaced fonts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.cpp" line="30"/>
+        <source>Vertical Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.cpp" line="31"/>
+        <source>Horizontal Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.cpp" line="32"/>
+        <source>Half Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.cpp" line="33"/>
+        <source>Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorMiscWidget</name>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="20"/>
+        <source>Open system header files in read only mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="27"/>
+        <source>Auto load files being open when Red Panda C++ last exited.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="34"/>
+        <source>Parse TODOs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="77"/>
+        <source>Action before saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="83"/>
+        <source>Reformat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="90"/>
+        <source>Trim trailing spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="97"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="120"/>
+        <source>Auto detect encoding when openning files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="127"/>
+        <source>Default file encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="155"/>
+        <source>Default file type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="161"/>
+        <source>C files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.ui" line="168"/>
+        <source>C++ files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.cpp" line="102"/>
+        <source>System Default(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.cpp" line="103"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editormiscwidget.cpp" line="104"/>
+        <source>UTF-8 BOM</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorSnippetWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="24"/>
+        <source>Code Snippets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="83"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="90"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="126"/>
+        <source>New C File Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="143"/>
+        <source>New C++ File Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsnippetwidget.ui" line="160"/>
+        <source>New GAS File Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorSymbolCompletionWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="33"/>
+        <source>Complete Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="60"/>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="78"/>
+        <source>Complete Braces{}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="85"/>
+        <source>Complete Brackets []</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="92"/>
+        <source>Complete Parenthesis ()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="99"/>
+        <source>Complete Multiline Comments /**/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="106"/>
+        <source>Complete Single Quotations &apos;&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="113"/>
+        <source>Complete Double Quotations &quot;&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="120"/>
+        <source>Complete #include &lt;&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="130"/>
+        <source>Skip matching symbols while typing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="143"/>
+        <source>Remove symbol pairs when delete chars</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorSyntaxCheckWidget</name>
+    <message>
+        <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="33"/>
+        <source>Enable Auto Syntax Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="42"/>
+        <source>Check when save/load file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="49"/>
+        <source>Check when count of lines changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditorTooltipsWidget</name>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="20"/>
+        <source>Show function tips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="27"/>
+        <source>Enable mouse hover tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="36"/>
+        <source>Show syntax issue tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="43"/>
+        <source>Show full header filename tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="50"/>
+        <source>Show identifier definition tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="57"/>
+        <source>Show expression value tooltips when debugging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="82"/>
+        <source>Tool tips delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editortooltipswidget.ui" line="89"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentAppearanceWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="38"/>
+        <source>Use custom icon set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="79"/>
+        <source>*Needs restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="190"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="197"/>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="204"/>
+        <source>Icon Set:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="211"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="218"/>
+        <source>Font Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="243"/>
+        <source>Create a customized copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="246"/>
+        <source>Customize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="253"/>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="256"/>
+        <source>Remove custom theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="263"/>
+        <source>Open custom themes folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="266"/>
+        <source>Open Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.ui" line="289"/>
+        <source>Icon Zoom:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.cpp" line="106"/>
+        <source>English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.cpp" line="107"/>
+        <source>Portuguese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.cpp" line="108"/>
+        <source>Simplified Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.cpp" line="109"/>
+        <source>Traditional Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentFileAssociationWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="20"/>
+        <source>Open Each File In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="26"/>
+        <source>Independent Red Panda C++ applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="33"/>
+        <source>The same Red Panda C++ application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="43"/>
+        <source>File Types:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="59"/>
+        <source>Just check or uncheck for which file types Red Panda C++ wil be registered as the default application to open them ... </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentFoldersWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="20"/>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="23"/>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="83"/>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="86"/>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="120"/>
+        <source>Open in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="50"/>
+        <source>Custom icon sets folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="73"/>
+        <source>Remove all custom settings and exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="93"/>
+        <source>Configuration folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="107"/>
+        <source>Custom theme folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.ui" line="117"/>
+        <source>Open custom theme folder in file browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.cpp" line="66"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.cpp" line="67"/>
+        <source>Do you really want to delete all custom settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.cpp" line="73"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfolderswidget.cpp" line="74"/>
+        <source>Failed to delete custom settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentPerformanceWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentperformancewidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentperformancewidget.ui" line="20"/>
+        <source>Reduce Memory Usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentperformancewidget.ui" line="26"/>
+        <source>Editors share one code parser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentperformancewidget.ui" line="33"/>
+        <source>Auto clear parsed symbols when editor hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentProgramsWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="20"/>
+        <source>Use custom terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="46"/>
+        <source>Args. pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="53"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="63"/>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="87"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="60"/>
+        <source>Auto Detect Terminal Arguments Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="70"/>
+        <source>Terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="77"/>
+        <source>Cmd. preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.ui" line="84"/>
+        <source>Test Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="104"/>
+        <source>Choose Terminal Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="106"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentShortcutModel</name>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="86"/>
+        <source>action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="142"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="143"/>
+        <source>Shortcut &quot;%1&quot; is used by &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="163"/>
+        <source>Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="165"/>
+        <source>Shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentShortcutWidget</name>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentshortcutwidget.ui" line="35"/>
+        <source>Filter Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExecutableRunner</name>
+    <message>
+        <location filename="../compiler/executablerunner.cpp" line="262"/>
+        <source>The runner process &apos;%1&apos; failed to start.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/executablerunner.cpp" line="269"/>
+        <source>The last waitFor...() function timed out.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/executablerunner.cpp" line="272"/>
+        <source>An error occurred when attempting to write to the runner process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/executablerunner.cpp" line="275"/>
+        <source>An error occurred when attempting to read from the runner process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExecutorGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="23"/>
+        <source>Pause console programs after return</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="30"/>
+        <source>Enable ANSI Escape Sequences Support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="37"/>
+        <source>Minimize IDE when running programs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="60"/>
+        <source>Parameters to pass to your program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="72"/>
+        <source>Parsed argv array (represented in JSON):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="85"/>
+        <source>Redirect input to the following file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="99"/>
+        <source>Debugger doesn&apos;t support this feature in Linux.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="111"/>
+        <source>Note: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="123"/>
+        <source>Debugger only support this feature in gdb server mode in windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="130"/>
+        <location filename="../settingsdialog/executorgeneralwidget.ui" line="133"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.cpp" line="80"/>
+        <source>Choose input file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorgeneralwidget.cpp" line="82"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExecutorProblemSetWidget</name>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="20"/>
+        <source>Enable Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="29"/>
+        <source>Listen for Competitive Companion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="61"/>
+        <source>Port Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="83"/>
+        <source>Convert HTML for：</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="90"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="97"/>
+        <source>Expected Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="123"/>
+        <source>Redirect STDERR to Tools output panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="145"/>
+        <source>Problem Case Validate type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="171"/>
+        <source>Case Validation Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="180"/>
+        <source>Time Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="190"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="219"/>
+        <source>Memory Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="226"/>
+        <source>kb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="242"/>
+        <source>Display problem case input file less than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="249"/>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="278"/>
+        <source>Case Editor Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="296"/>
+        <source>Font Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="337"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.ui" line="382"/>
+        <source>Only Monospaced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="27"/>
+        <source>Exact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="28"/>
+        <source>Ignore leading/trailing spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="29"/>
+        <source>Ignore spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileAssociationModel</name>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="128"/>
+        <source>Register File Association Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="129"/>
+        <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="148"/>
+        <source>Don&apos;t have privilege to register file types!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="147"/>
+        <source>Register File Type Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileCompiler</name>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="60"/>
+        <source>Checking single file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="62"/>
+        <source>Compiling single file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="65"/>
+        <source>- Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="66"/>
+        <source>- Compiler Set Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="109"/>
+        <location filename="../compiler/filecompiler.cpp" line="202"/>
+        <source>Can&apos;t delete the old executable file &quot;%1&quot;.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="122"/>
+        <source>GNU Assembler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="140"/>
+        <source>Can&apos;t find the compiler for file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="180"/>
+        <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="182"/>
+        <source>Please check the &quot;program&quot; page of compiler settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="185"/>
+        <source>Processing %1 source file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="187"/>
+        <source>%1 Compiler: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/filecompiler.cpp" line="189"/>
+        <source>Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FilePropertiesDialog</name>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="14"/>
+        <source>File Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="29"/>
+        <source>File name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="53"/>
+        <source>Path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="60"/>
+        <source>Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="74"/>
+        <source>Relative to Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="100"/>
+        <source>Comment lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="126"/>
+        <source>Code lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="152"/>
+        <source>Total lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="178"/>
+        <source>Including files:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="204"/>
+        <source>Empty lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="250"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="282"/>
+        <source>File date:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="308"/>
+        <source>File size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/filepropertiesdialog.ui" line="334"/>
+        <source>Characters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatterGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="35"/>
+        <source>Predefined format style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="64"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note for the predefined format style&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="78"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="84"/>
+        <source>Brace modifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="90"/>
+        <source>Attach braces to namespace statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="97"/>
+        <source>Attach braces to classes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="104"/>
+        <source>Attach braces to class inline function definitions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="111"/>
+        <source>Attach braces to extern &quot;C&quot; statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="118"/>
+        <source>Attach the closing while of do-while to the close brace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="128"/>
+        <source>Convert tabs to the appropriate number of spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="136"/>
+        <source>Indentation 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="142"/>
+        <source>Indent with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="157"/>
+        <source>Indent using spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="160"/>
+        <source>Spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="167"/>
+        <source>Indent using tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="170"/>
+        <source>Tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="195"/>
+        <source>Tab Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="246"/>
+        <source>Indent for continuation lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="294"/>
+        <source>Minimal indent for a continuous conditional beloning to a conditional header:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="335"/>
+        <source>Maximal indent spaces for a continuation line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="382"/>
+        <source>Indentation 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="388"/>
+        <source>Indent line comments that start in column one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="395"/>
+        <source>Indent multi-line preprocessor #define statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="402"/>
+        <source>Indent switch blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="409"/>
+        <source>Indent labels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="416"/>
+        <source>Indent preprocessor conditional statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="423"/>
+        <source>Indent after parenthesis &apos;(&apos; or assignment &apos;=&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="430"/>
+        <source>Indent class access modifiers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="437"/>
+        <source>Indent cases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="444"/>
+        <source>Indent class blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="451"/>
+        <source>Indent namespaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="458"/>
+        <source>Indent preprocessor blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="479"/>
+        <source>Padding 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="485"/>
+        <source>Insert spaces after parenthesis headers (&apos;if&apos;,&apos;for&apos;,...)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="505"/>
+        <source>Insert spaces around parenthesis on the inside only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="512"/>
+        <source>Insert spaces around parenthesis on the outside only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="519"/>
+        <source>Insert spaces around first parenthesis in a series on the out side  only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="526"/>
+        <source>Insert spaces after commas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="533"/>
+        <source>Insert empty lines arround unrelated blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="555"/>
+        <source>Remove superfluous empty lines exceeding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="585"/>
+        <source>Insert spaces around operators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="592"/>
+        <source>Insert spaces around parenthesis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="599"/>
+        <source>Insert empty lines around all blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="606"/>
+        <source>Remove superfluous whitespace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="614"/>
+        <source>Padding 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="620"/>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="630"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="640"/>
+        <source>Remove unnecessary space adding around parenthesis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="647"/>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="684"/>
+        <source>type(left)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="657"/>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="694"/>
+        <source>name(right)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="667"/>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="718"/>
+        <source>middle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="677"/>
+        <source>Attach a pointer operator to its :</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="704"/>
+        <source>Remove all empty lines. It will NOT delete lines added by the padding options.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="711"/>
+        <source>Fill empty lines with the white space of the previous lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="741"/>
+        <source>Attach a reference operator to its :</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="762"/>
+        <source>Other 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="768"/>
+        <source>Add braces to unbraced one line conditional statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="775"/>
+        <source>Add one line braces to unbraced one line conditional statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="782"/>
+        <source>Break one line headers (&apos;if&apos;,&apos;while&apos;,&apos;else&apos;...) from the statement on the same line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="789"/>
+        <source>Remove braces from a braced one line conditional statements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="796"/>
+        <source>Break braces before close headers (&apos;else&apos;,&apos;catch&quot;...)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="803"/>
+        <source>Break &apos;else if&apos; statements into two lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="824"/>
+        <source>Other 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="830"/>
+        <source>Attach return type to the function name in its definition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="837"/>
+        <source>Don&apos;t break blocks residing completely on one line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="844"/>
+        <source>Break return type from the function name in its definition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="851"/>
+        <source>Don&apos;t break multiple statements residing on one line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="858"/>
+        <source>Break return type from the function name in its declaration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="865"/>
+        <source>Attach return type to the function name in its declaration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="886"/>
+        <source>Other 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="907"/>
+        <source>Break lines exceeds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="914"/>
+        <source>characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="959"/>
+        <source>Remove the leading &apos;*&apos; prefix on multi-line comments and indent the comment text one line indent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="966"/>
+        <source>Close ending angle brackets on template definitions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.ui" line="973"/>
+        <source>Place the logical conditional to the last on the previous line, when break lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="37"/>
+        <source>No minimal indent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="38"/>
+        <source>Indent at least one additional indent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="39"/>
+        <source>Indent at least two additional indents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="40"/>
+        <source>Indent at least one-half an additional indent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatterPathWidget</name>
+    <message>
+        <location filename="../settingsdialog/formatterpathwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formatterpathwidget.ui" line="20"/>
+        <location filename="../settingsdialog/formatterpathwidget.cpp" line="40"/>
+        <source>Path to astyle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formatterpathwidget.ui" line="27"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formatterpathwidget.cpp" line="42"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatterStyleModel</name>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="168"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="169"/>
+        <source>The opening braces will not be changed and closing braces will be broken from the preceding line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="174"/>
+        <source>Allman</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="175"/>
+        <source>Broken braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="180"/>
+        <source>Java</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="181"/>
+        <source>Attached braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="186"/>
+        <source>K&amp;R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="187"/>
+        <source>Linux braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="192"/>
+        <source>Stroustrup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="193"/>
+        <source>Linux braces, with broken closing headers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="198"/>
+        <source>Whitesmith</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="199"/>
+        <source>Broken, indented braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="201"/>
+        <source>Indented class blocks and switch blocks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="206"/>
+        <source>VTK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="207"/>
+        <source>Broken, indented braces except for the opening braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="212"/>
+        <source>Ratliff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="213"/>
+        <source>Attached, indented braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="218"/>
+        <source>GNU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="219"/>
+        <source>Broken braces, indented blocks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="224"/>
+        <source>Linux</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="225"/>
+        <source>Linux braces, minimum conditional indent is one-half indent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="230"/>
+        <source>Horstmann</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="231"/>
+        <source>Run-in braces, indented switches.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="236"/>
+        <source>One True Brace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="237"/>
+        <source>Linux braces, add braces to all conditionals.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="242"/>
+        <source>Google</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="243"/>
+        <source>Attached braces, indented class modifiers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="248"/>
+        <source>Mozilla</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="249"/>
+        <source>Linux braces, with broken braces for structs and enums, and attached braces for namespaces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="254"/>
+        <source>Webkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="255"/>
+        <source>Linux braces, with attached closing headers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="260"/>
+        <source>Pico</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="261"/>
+        <source>Run-in opening braces and attached closing braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="263"/>
+        <source>Uses keep one line blocks and keep one line statements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="268"/>
+        <source>Lisp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="269"/>
+        <source>Attached opening braces and attached closing braces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/formattergeneralwidget.cpp" line="271"/>
+        <source>Uses keep one line statements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitBranchDialog</name>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="14"/>
+        <source>Branch/Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="20"/>
+        <source>Switch To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="26"/>
+        <source>Branch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="46"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="52"/>
+        <source>Overwrite working tree changed(force)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="59"/>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="65"/>
+        <source>Pass --track to git</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="68"/>
+        <source>Force Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="75"/>
+        <source>Pass --no-track to git</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="78"/>
+        <source>Force No Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="85"/>
+        <source>Neither --track nor --no-track is passed to git</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="88"/>
+        <source>Not Specifiied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="101"/>
+        <source>Create New Branch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="108"/>
+        <source>Merge between original branch, working tree contents and the branch to switch to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="111"/>
+        <source>Merge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="121"/>
+        <source>Force Creation (Reset branch if exists)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="160"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitbranchdialog.ui" line="167"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitFetchDialog</name>
+    <message>
+        <location filename="../vcs/gitfetchdialog.ui" line="13"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitLogDialog</name>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="14"/>
+        <source>Git Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="70"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="80"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="85"/>
+        <source>Revert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="90"/>
+        <source>branch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.ui" line="95"/>
+        <source>Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="134"/>
+        <source>Reset &quot;%1&quot; to this...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="135"/>
+        <source>Revert &quot;%1&quot; to this...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="136"/>
+        <source>Create Branch at this version...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="137"/>
+        <source>Create Tag at this version...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitLogModel</name>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="79"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="81"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitlogdialog.cpp" line="83"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitManager</name>
+    <message>
+        <location filename="../vcs/gitmanager.cpp" line="18"/>
+        <source>Folder &quot;%1&quot; already has a repository!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitMergeDialog</name>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="14"/>
+        <source>Merge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="20"/>
+        <source>From</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="26"/>
+        <source>Branch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="46"/>
+        <source>Option</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="52"/>
+        <source>No Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="59"/>
+        <source>Squash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="66"/>
+        <source>No Fast Forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="73"/>
+        <source>Fast Forward Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="83"/>
+        <source>Merge Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="129"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmergedialog.ui" line="136"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitPullDialog</name>
+    <message>
+        <location filename="../vcs/gitpulldialog.ui" line="13"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitPushDialog</name>
+    <message>
+        <location filename="../vcs/gitpushdialog.ui" line="13"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitRemoteDialog</name>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="14"/>
+        <source>Git Remote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="93"/>
+        <source>Add Remote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="96"/>
+        <location filename="../vcs/gitremotedialog.ui" line="213"/>
+        <location filename="../vcs/gitremotedialog.cpp" line="79"/>
+        <location filename="../vcs/gitremotedialog.cpp" line="95"/>
+        <location filename="../vcs/gitremotedialog.cpp" line="135"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="103"/>
+        <source>Remove Remote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="106"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="146"/>
+        <source>Detail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="155"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="162"/>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.ui" line="258"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.cpp" line="36"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitremotedialog.cpp" line="63"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitResetDialog</name>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="14"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="20"/>
+        <location filename="../vcs/gitresetdialog.cpp" line="32"/>
+        <source>Reset current branch &quot;%1&quot; to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="26"/>
+        <source>Branch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="43"/>
+        <source>Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="53"/>
+        <source>Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="66"/>
+        <source>Reset Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="78"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Leave working tree and index untouched&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="88"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset working tree and index (discarding local changes)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="98"/>
+        <source>Soft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="105"/>
+        <source>Hard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="112"/>
+        <source>Leave working tree untouched, reset index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="122"/>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="179"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitresetdialog.ui" line="186"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GitUserConfigDialog</name>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="14"/>
+        <source>Fill User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="23"/>
+        <source>User Email:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="49"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="56"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="79"/>
+        <source>User Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gituserconfigdialog.ui" line="86"/>
+        <source>Git needs the following info to commit：</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InfoMessageBox</name>
+    <message>
+        <location filename="../widgets/infomessagebox.ui" line="14"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/infomessagebox.ui" line="61"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>IssuesModel</name>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="259"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="261"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="263"/>
+        <source>Col</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="265"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>IssuesTable</name>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="63"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="64"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="65"/>
+        <source>Col</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/issuestable.cpp" line="66"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LanguageAsmGenerationWidget</name>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="20"/>
+        <source>Don&apos;t generate debug directives</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="27"/>
+        <source>Don&apos;t generate SEH directives </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="34"/>
+        <source>Instruction syntax:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="40"/>
+        <source>AT&amp;&amp;T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="47"/>
+        <source>Intel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/languageasmgenerationwidget.cpp" line="11"/>
+        <source>Don&apos;t generate cli directives.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MacroInfoModel</name>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="21"/>
+        <source>The default directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="22"/>
+        <source>Path to the Red Panda C++&apos;s executable file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="23"/>
+        <source>Version of the Red Panda C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="24"/>
+        <source>PATH to the Red Panda C++&apos;s installation folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="25"/>
+        <source>Current date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="26"/>
+        <source>Current date and time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="27"/>
+        <source>The first include directory of the working compiler set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="28"/>
+        <source>The first lib directory of the working compiler set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="29"/>
+        <source>The compiled filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="30"/>
+        <source>Full path to the compiled file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="31"/>
+        <source>Filename of the current source file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="32"/>
+        <source>Full path to the current source file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="33"/>
+        <source>Path to the current source file&apos;s parent folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="34"/>
+        <source>Word at the cursor in the active editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="35"/>
+        <source>Name of the current project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="36"/>
+        <source>Full path to the current project file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="37"/>
+        <source>Name of the current project file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/macroinfomodel.cpp" line="38"/>
+        <source>Path to the current project&apos;s folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Red Panda C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="128"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="147"/>
+        <location filename="../mainwindow.cpp" line="3575"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="153"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="178"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="182"/>
+        <source>Move Caret</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="222"/>
+        <location filename="../mainwindow.ui" line="1300"/>
+        <location filename="../mainwindow.ui" line="2805"/>
+        <location filename="../mainwindow.cpp" line="7871"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="233"/>
+        <location filename="../mainwindow.ui" line="396"/>
+        <location filename="../mainwindow.cpp" line="7875"/>
+        <location filename="../mainwindow.cpp" line="7876"/>
+        <location filename="../mainwindow.cpp" line="7877"/>
+        <location filename="../mainwindow.cpp" line="7878"/>
+        <location filename="../mainwindow.cpp" line="7879"/>
+        <source>Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="254"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="266"/>
+        <location filename="../mainwindow.ui" line="594"/>
+        <location filename="../mainwindow.ui" line="2741"/>
+        <source>Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="285"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="306"/>
+        <source>Refactor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="312"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="316"/>
+        <source>Tool Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="341"/>
+        <source>Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="374"/>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="411"/>
+        <location filename="../mainwindow.ui" line="2100"/>
+        <location filename="../mainwindow.ui" line="2103"/>
+        <source>Compile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="433"/>
+        <location filename="../mainwindow.ui" line="1031"/>
+        <location filename="../mainwindow.ui" line="2295"/>
+        <location filename="../mainwindow.ui" line="2298"/>
+        <location filename="../mainwindow.ui" line="2797"/>
+        <location filename="../mainwindow.cpp" line="490"/>
+        <location filename="../mainwindow.cpp" line="491"/>
+        <location filename="../mainwindow.cpp" line="492"/>
+        <location filename="../mainwindow.cpp" line="493"/>
+        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="7874"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="460"/>
+        <source>Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="484"/>
+        <source>Explorer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="513"/>
+        <location filename="../mainwindow.ui" line="2765"/>
+        <source>Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="644"/>
+        <location filename="../mainwindow.ui" line="2749"/>
+        <source>Watch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="685"/>
+        <location filename="../mainwindow.ui" line="2757"/>
+        <source>Structure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="723"/>
+        <location filename="../mainwindow.ui" line="750"/>
+        <location filename="../mainwindow.ui" line="2773"/>
+        <source>Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="775"/>
+        <location filename="../mainwindow.ui" line="778"/>
+        <location filename="../mainwindow.cpp" line="2862"/>
+        <location filename="../mainwindow.cpp" line="8734"/>
+        <source>New Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="790"/>
+        <location filename="../mainwindow.ui" line="793"/>
+        <location filename="../mainwindow.cpp" line="2898"/>
+        <source>Add Problem</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="805"/>
+        <location filename="../mainwindow.ui" line="808"/>
+        <location filename="../mainwindow.cpp" line="2904"/>
+        <source>Remove Problem</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="820"/>
+        <location filename="../mainwindow.ui" line="823"/>
+        <location filename="../mainwindow.cpp" line="2874"/>
+        <location filename="../mainwindow.cpp" line="8795"/>
+        <source>Save Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="835"/>
+        <location filename="../mainwindow.ui" line="838"/>
+        <location filename="../mainwindow.cpp" line="2880"/>
+        <location filename="../mainwindow.cpp" line="8832"/>
+        <source>Load Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="850"/>
+        <location filename="../mainwindow.cpp" line="2886"/>
+        <location filename="../mainwindow.cpp" line="9993"/>
+        <source>Import FPS Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="862"/>
+        <location filename="../mainwindow.cpp" line="2892"/>
+        <location filename="../mainwindow.cpp" line="10024"/>
+        <source>Export FPS Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="921"/>
+        <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="947"/>
+        <location filename="../mainwindow.ui" line="2781"/>
+        <location filename="../mainwindow.cpp" line="6000"/>
+        <location filename="../mainwindow.cpp" line="6003"/>
+        <location filename="../mainwindow.cpp" line="6007"/>
+        <location filename="../mainwindow.cpp" line="6010"/>
+        <location filename="../mainwindow.cpp" line="8333"/>
+        <source>Issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="996"/>
+        <location filename="../mainwindow.ui" line="2789"/>
+        <source>Tools Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1080"/>
+        <source>Evaluate:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1121"/>
+        <location filename="../mainwindow.cpp" line="2001"/>
+        <source>Debug Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1150"/>
+        <source>Call Stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1188"/>
+        <source>Breakpoints</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1226"/>
+        <source>Locals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1255"/>
+        <source>Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1261"/>
+        <source>Address Expression:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1339"/>
+        <source>History:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1374"/>
+        <source>Search Again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1412"/>
+        <source>Replace with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1438"/>
+        <source>Open file in editors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1445"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1452"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1483"/>
+        <location filename="../mainwindow.ui" line="2813"/>
+        <source>TODO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1509"/>
+        <location filename="../mainwindow.ui" line="2821"/>
+        <source>Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1547"/>
+        <location filename="../mainwindow.ui" line="1590"/>
+        <location filename="../mainwindow.ui" line="2829"/>
+        <location filename="../mainwindow.cpp" line="2964"/>
+        <location filename="../mainwindow.cpp" line="2971"/>
+        <location filename="../mainwindow.cpp" line="2978"/>
+        <source>Problem</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1642"/>
+        <location filename="../mainwindow.ui" line="1645"/>
+        <source>Add Probem Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1656"/>
+        <location filename="../mainwindow.ui" line="1659"/>
+        <location filename="../mainwindow.cpp" line="2943"/>
+        <source>Remove Problem Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1670"/>
+        <location filename="../mainwindow.ui" line="1673"/>
+        <location filename="../mainwindow.cpp" line="2949"/>
+        <source>Open Anwser Source File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1691"/>
+        <location filename="../mainwindow.ui" line="1694"/>
+        <location filename="../mainwindow.cpp" line="2962"/>
+        <source>Run All Cases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1705"/>
+        <location filename="../mainwindow.cpp" line="2955"/>
+        <source>Problem Cases Validation Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1741"/>
+        <source>%v/%m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1823"/>
+        <location filename="../mainwindow.ui" line="1826"/>
+        <source>Choose Input File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1837"/>
+        <location filename="../mainwindow.ui" line="1935"/>
+        <location filename="../mainwindow.ui" line="1938"/>
+        <location filename="../mainwindow.cpp" line="3031"/>
+        <location filename="../mainwindow.cpp" line="3052"/>
+        <location filename="../mainwindow.cpp" line="3233"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1844"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1918"/>
+        <source>Expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1945"/>
+        <source>Choose Expected Output File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="1974"/>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2025"/>
+        <source>New C/C++ File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2028"/>
+        <source>New Source File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2031"/>
+        <source>Ctrl+N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2040"/>
+        <source>Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2043"/>
+        <source>Ctrl+O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2052"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2055"/>
+        <source>Ctrl+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2064"/>
+        <source>Save As...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2067"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2070"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2079"/>
+        <source>Save All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2082"/>
+        <source>Ctrl+K, Ctrl+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2091"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2106"/>
+        <source>F9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2115"/>
+        <location filename="../mainwindow.ui" line="2118"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2121"/>
+        <source>F11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2130"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2133"/>
+        <source>Ctrl+Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2142"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2145"/>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2154"/>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2157"/>
+        <source>Ctrl+X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2166"/>
+        <location filename="../mainwindow.cpp" line="3010"/>
+        <location filename="../mainwindow.cpp" line="3038"/>
+        <location filename="../mainwindow.cpp" line="3238"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2169"/>
+        <source>Ctrl+C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2178"/>
+        <location filename="../mainwindow.cpp" line="3017"/>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2181"/>
+        <source>Ctrl+V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2186"/>
+        <location filename="../mainwindow.cpp" line="3024"/>
+        <location filename="../mainwindow.cpp" line="3244"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2189"/>
+        <source>Ctrl+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2198"/>
+        <source>Indent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2201"/>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2210"/>
+        <source>UnIndent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2213"/>
+        <source>Shift+Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2218"/>
+        <source>Toggle Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2221"/>
+        <source>Ctrl+/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2229"/>
+        <source>Collapse All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2234"/>
+        <source>Uncollapse All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2239"/>
+        <source>Encode in ANSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2244"/>
+        <source>Encode in UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2249"/>
+        <source>Auto Detect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2254"/>
+        <source>Convert to ANSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2259"/>
+        <source>Convert to UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2268"/>
+        <location filename="../mainwindow.ui" line="2271"/>
+        <source>Rebuild All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2274"/>
+        <source>F12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2283"/>
+        <source>Stop Execution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2286"/>
+        <source>F6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2301"/>
+        <source>F5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2310"/>
+        <source>Step Over</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2313"/>
+        <source>F8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2322"/>
+        <source>Step Into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2325"/>
+        <source>F7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2334"/>
+        <source>Step Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2337"/>
+        <source>Ctrl+F8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2346"/>
+        <source>Run To Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2349"/>
+        <source>Ctrl+F5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2358"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2361"/>
+        <source>F4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2370"/>
+        <source>Add Watch...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2375"/>
+        <source>View CPU Window...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2380"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2385"/>
+        <source>Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2388"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2393"/>
+        <source>Find in Files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2396"/>
+        <source>Ctrl+Shift+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2401"/>
+        <source>Replace...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2404"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2409"/>
+        <source>Find Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2412"/>
+        <source>F3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2417"/>
+        <source>Find Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2420"/>
+        <source>Shift+F3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2429"/>
+        <source>Remove Watch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2434"/>
+        <source>Remove All Watches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2439"/>
+        <source>Modify Watch...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2448"/>
+        <source>Reformat Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2451"/>
+        <source>Ctrl+Shift+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2460"/>
+        <source>Go back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2463"/>
+        <source>Ctrl+Alt+Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2472"/>
+        <source>Forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2475"/>
+        <source>Ctrl+Alt+Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2480"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2483"/>
+        <source>Ctrl+W</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2488"/>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2491"/>
+        <source>Ctrl+Shift+W</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2496"/>
+        <source>Maximize Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2499"/>
+        <source>Ctrl+F11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2504"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2507"/>
+        <source>Ctrl+Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2512"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2515"/>
+        <source>Ctrl+Shift+Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2525"/>
+        <source>Toggle breakpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2528"/>
+        <source>Ctrl+F4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2533"/>
+        <location filename="../mainwindow.cpp" line="6956"/>
+        <source>Clear all breakpoints</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2538"/>
+        <source>Breakpoint property...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2543"/>
+        <source>Goto Declaration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2546"/>
+        <source>Ctrl+J</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2551"/>
+        <source>Goto Definition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2554"/>
+        <source>Ctrl+Shift+J</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2559"/>
+        <source>Find references</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2564"/>
+        <source>Open containing folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2572"/>
+        <source>Open a terminal here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2577"/>
+        <source>File Properties...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2582"/>
+        <source>Close Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2587"/>
+        <source>Project options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2592"/>
+        <source>New Project...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2597"/>
+        <location filename="../mainwindow.ui" line="2600"/>
+        <source>New Project File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2605"/>
+        <source>Add to project...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2610"/>
+        <source>Remove from project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2615"/>
+        <source>View Makefile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2620"/>
+        <source>Clean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2625"/>
+        <source>Open Folder in Explorer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2630"/>
+        <source>Open In Terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2635"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2640"/>
+        <location filename="../mainwindow.cpp" line="8275"/>
+        <source>Rename Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2643"/>
+        <source>Shift+F6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2648"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2651"/>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2656"/>
+        <location filename="../mainwindow.cpp" line="8529"/>
+        <source>Export As RTF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2661"/>
+        <location filename="../mainwindow.cpp" line="8551"/>
+        <source>Export As HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2666"/>
+        <source>Move To Other View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2669"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2677"/>
+        <location filename="../mainwindow.ui" line="2680"/>
+        <source>C++ Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2685"/>
+        <source>EGE Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2690"/>
+        <source>Modify Bookmark Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2695"/>
+        <source>Locate in Files View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2700"/>
+        <location filename="../mainwindow.ui" line="2703"/>
+        <location filename="../mainwindow.cpp" line="8713"/>
+        <source>Choose Working Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2712"/>
+        <source>Running Parameters...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2717"/>
+        <source>C Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2725"/>
+        <source>Show Tool Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2733"/>
+        <source>Status Bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2834"/>
+        <source>Delete Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2837"/>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2842"/>
+        <source>Duplicate Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2845"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2850"/>
+        <source>Delete Word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2853"/>
+        <source>Ctrl+Shift+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2858"/>
+        <source>Delete to EOL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2861"/>
+        <source>Ctrl+Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2866"/>
+        <source>Delete to BOL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2869"/>
+        <source>Ctrl+Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2878"/>
+        <source>Interrupt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2883"/>
+        <location filename="../mainwindow.ui" line="2886"/>
+        <source>Delete To Word Begin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2889"/>
+        <source>Ctrl+Shift+B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2894"/>
+        <source>Delete to Word End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2897"/>
+        <source>Ctrl+Shift+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2902"/>
+        <source>New Class...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2907"/>
+        <location filename="../mainwindow.ui" line="2910"/>
+        <source>New Header...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2915"/>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2923"/>
+        <source>Hide Non Support Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2928"/>
+        <source>Toggle Block Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2931"/>
+        <source>Alt+Shift+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2936"/>
+        <source>Match Bracket</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2939"/>
+        <source>Ctrl+]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2944"/>
+        <source>Move Selection Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2947"/>
+        <source>Ctrl+Shift+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2952"/>
+        <source>Move Selection Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2955"/>
+        <source>Ctrl+Shift+Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2960"/>
+        <source>Convert to UTF-8 BOM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2965"/>
+        <source>Encode in UTF-8 BOM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2974"/>
+        <source>Compiler Options...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2979"/>
+        <source>Toggle Explorer Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2982"/>
+        <source>Ctrl+F9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2987"/>
+        <source>Toggle Messages Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2990"/>
+        <source>Ctrl+F10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="2995"/>
+        <source>Raylib Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3000"/>
+        <source>Select Word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3005"/>
+        <source>Go to Line...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3008"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3013"/>
+        <source>New Template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3016"/>
+        <source>New Template from Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3021"/>
+        <source>Goto block start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3024"/>
+        <source>Ctrl+Alt+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3029"/>
+        <source>Goto block end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3032"/>
+        <source>Ctrl+Alt+Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3037"/>
+        <source>Switch header/source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3040"/>
+        <source>Switch Header/Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3045"/>
+        <source>Generate Assembly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3048"/>
+        <source>Ctrl+F12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3053"/>
+        <source>Trim trailing spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3058"/>
+        <source>Toggle Readonly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3061"/>
+        <source>Ctrl+Shift+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3066"/>
+        <source>Submit Issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3071"/>
+        <source>Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3074"/>
+        <source>F1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3079"/>
+        <source>New GAS File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3084"/>
+        <source>GNU Assembler Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3089"/>
+        <source>x86 Assembly Language Reference Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3094"/>
+        <source>IA-32 Assembly Language Reference Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3099"/>
+        <source>Add Watchpoint...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3102"/>
+        <source>Add a watchpoint that&apos;s triggered when it&apos;s modified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3107"/>
+        <source>New Text File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3112"/>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3120"/>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3128"/>
+        <source>Goto Line Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3136"/>
+        <source>Goto Line End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3144"/>
+        <source>Goto File Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3152"/>
+        <source>Goto File End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3160"/>
+        <source>Page Up and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3168"/>
+        <source>Page Down and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3176"/>
+        <source>Goto Page Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3184"/>
+        <source>Goto Page End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3192"/>
+        <source>Goto Page Start and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3200"/>
+        <source>Goto Page End and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3208"/>
+        <source>Goto Line Start and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3216"/>
+        <source>Goto Line End and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3224"/>
+        <source>Goto File Start and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3232"/>
+        <source>Goto File End and Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3240"/>
+        <source>Close Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3248"/>
+        <source>OI Wiki</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3256"/>
+        <source>Turtle Graphics Tutorial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3264"/>
+        <source>Toggle Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3267"/>
+        <source>Ctrl+B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3275"/>
+        <source>Code Completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="3278"/>
+        <source>Ctrl+Shift+/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="152"/>
+        <source>Exact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="153"/>
+        <source>Ignore leading/trailing spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="154"/>
+        <source>Ignore spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="245"/>
+        <location filename="../mainwindow.cpp" line="307"/>
+        <location filename="../mainwindow.cpp" line="316"/>
+        <location filename="../mainwindow.cpp" line="324"/>
+        <location filename="../mainwindow.cpp" line="333"/>
+        <location filename="../mainwindow.cpp" line="394"/>
+        <location filename="../mainwindow.cpp" line="1799"/>
+        <location filename="../mainwindow.cpp" line="3615"/>
+        <location filename="../mainwindow.cpp" line="3732"/>
+        <location filename="../mainwindow.cpp" line="5529"/>
+        <location filename="../mainwindow.cpp" line="5679"/>
+        <location filename="../mainwindow.cpp" line="6389"/>
+        <location filename="../mainwindow.cpp" line="6401"/>
+        <location filename="../mainwindow.cpp" line="9824"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="251"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="264"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="272"/>
+        <source>Recent Projects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="276"/>
+        <source>Recent Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="282"/>
+        <source>Insert Snippet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="361"/>
+        <location filename="../mainwindow.cpp" line="8743"/>
+        <source>Problem Set %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1014"/>
+        <location filename="../mainwindow.cpp" line="1021"/>
+        <source>Load Theme Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1315"/>
+        <source> - Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1377"/>
+        <source> %1 Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1388"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1420"/>
+        <location filename="../mainwindow.cpp" line="1422"/>
+        <location filename="../mainwindow.cpp" line="1449"/>
+        <location filename="../mainwindow.cpp" line="1451"/>
+        <source>Debugging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1393"/>
+        <location filename="../mainwindow.cpp" line="1395"/>
+        <location filename="../mainwindow.cpp" line="1426"/>
+        <location filename="../mainwindow.cpp" line="1428"/>
+        <location filename="../mainwindow.cpp" line="1454"/>
+        <location filename="../mainwindow.cpp" line="1456"/>
+        <source>Running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1400"/>
+        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1434"/>
+        <location filename="../mainwindow.cpp" line="1459"/>
+        <location filename="../mainwindow.cpp" line="1461"/>
+        <source>Compiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1516"/>
+        <location filename="../mainwindow.cpp" line="1538"/>
+        <source>Clear History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1639"/>
+        <source>Line: %1/%2 Col: %3 Sel: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1645"/>
+        <source>Line: %1/%2 Col: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1652"/>
+        <source>Line: %1/%2 Char: %3/%4 Sel: %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1659"/>
+        <source>Line: %1/%2 Char: %3/%4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1683"/>
+        <source>Read Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1685"/>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1687"/>
+        <source>Overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2293"/>
+        <source>Missing Project Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2294"/>
+        <source>The following files is missing, can&apos;t build the project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2382"/>
+        <source>Source file is not compiled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2484"/>
+        <location filename="../mainwindow.cpp" line="2691"/>
+        <location filename="../mainwindow.cpp" line="6099"/>
+        <location filename="../mainwindow.cpp" line="6106"/>
+        <source>Wrong Compiler Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2485"/>
+        <location filename="../mainwindow.cpp" line="2692"/>
+        <location filename="../mainwindow.cpp" line="6100"/>
+        <location filename="../mainwindow.cpp" line="6107"/>
+        <source>Compiler is set not to generate executable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2486"/>
+        <location filename="../mainwindow.cpp" line="6101"/>
+        <source>We need the executabe to run problem case.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2501"/>
+        <source>No compiler set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <source>No compiler set is configured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <source>Can&apos;t start debugging.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2522"/>
+        <location filename="../mainwindow.cpp" line="2645"/>
+        <location filename="../mainwindow.cpp" line="5300"/>
+        <source>Correct compile settings for debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2523"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
+        <source>The generated executable won&apos;t have debug symbol infos, and can&apos;t be debugged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2525"/>
+        <location filename="../mainwindow.cpp" line="2648"/>
+        <location filename="../mainwindow.cpp" line="5303"/>
+        <source>If you are using the Release compiler set, please use choose the Debug version from toolbar.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
+        <location filename="../mainwindow.cpp" line="2650"/>
+        <location filename="../mainwindow.cpp" line="5305"/>
+        <source>Or you can manually change the following settings in the options dialog&apos;s compiler set page:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2529"/>
+        <location filename="../mainwindow.cpp" line="2652"/>
+        <location filename="../mainwindow.cpp" line="5307"/>
+        <source> - Turned on the &quot;Generate debug info (-g3)&quot; option.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2531"/>
+        <location filename="../mainwindow.cpp" line="2654"/>
+        <location filename="../mainwindow.cpp" line="5309"/>
+        <source> - Turned off the &quot;Strip executable (-s)&quot; option.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2533"/>
+        <location filename="../mainwindow.cpp" line="2656"/>
+        <location filename="../mainwindow.cpp" line="5311"/>
+        <source> - Turned off the &quot;Optimization level (-O)&quot; option or set it to &quot;Debug (-Og)&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2535"/>
+        <location filename="../mainwindow.cpp" line="2658"/>
+        <location filename="../mainwindow.cpp" line="5313"/>
+        <location filename="../mainwindow.cpp" line="5315"/>
+        <source>You should recompile after change the compiler set or it&apos;s settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2537"/>
+        <location filename="../mainwindow.cpp" line="2660"/>
+        <location filename="../mainwindow.cpp" line="5317"/>
+        <source>Do you want to mannually change the compiler set settings now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2587"/>
+        <source>Host applcation missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2588"/>
+        <source>DLL project needs a host application to run.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2590"/>
+        <source>But it&apos;s missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2595"/>
+        <source>Host application not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2596"/>
+        <source>Host application file &apos;%1&apos; doesn&apos;t exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2693"/>
+        <location filename="../mainwindow.cpp" line="6108"/>
+        <source>Please correct this before start debugging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2852"/>
+        <source>Auto Save Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2853"/>
+        <source>Auto save &quot;%1&quot; to &quot;%2&quot; failed:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2868"/>
+        <source>Rename Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2911"/>
+        <source>Open Source File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2917"/>
+        <source>Rename Problem</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2923"/>
+        <source>Goto Url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2929"/>
+        <source>Properties...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2937"/>
+        <source>Add Problem Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2969"/>
+        <source>Run Current Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2976"/>
+        <location filename="../mainwindow.cpp" line="4432"/>
+        <source>Batch Set Cases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2985"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2991"/>
+        <source>Remove All Bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2996"/>
+        <source>Modify Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3003"/>
+        <source>Show detail debug logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3045"/>
+        <source>Copy all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3059"/>
+        <source>Remove this search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3065"/>
+        <source>Clear all searches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3072"/>
+        <source>Breakpoint condition...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3078"/>
+        <source>Remove All Breakpoints</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3083"/>
+        <source>Remove Breakpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3090"/>
+        <source>Rename File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3095"/>
+        <location filename="../mainwindow.cpp" line="5042"/>
+        <source>Add Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3101"/>
+        <source>Rename Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3107"/>
+        <source>Remove Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3112"/>
+        <source>Switch to normal view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3118"/>
+        <source>Switch to custom view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3125"/>
+        <source>Sort By Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3129"/>
+        <source>Sort alphabetically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3133"/>
+        <source>Show inherited members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3137"/>
+        <source>Goto declaration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3140"/>
+        <source>Goto definition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3143"/>
+        <source>In current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3147"/>
+        <source>In current project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3176"/>
+        <location filename="../mainwindow.cpp" line="4594"/>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3182"/>
+        <source>New File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3188"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3194"/>
+        <location filename="../mainwindow.cpp" line="4655"/>
+        <location filename="../mainwindow.cpp" line="4662"/>
+        <location filename="../mainwindow.cpp" line="4668"/>
+        <location filename="../mainwindow.cpp" line="7727"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3202"/>
+        <source>Open in Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3212"/>
+        <source>Open in External Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3218"/>
+        <source>Open in Terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3225"/>
+        <source>Open in Windows Explorer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3436"/>
+        <location filename="../mainwindow.cpp" line="3444"/>
+        <source>Save last open info error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3437"/>
+        <source>Can&apos;t open last open information file &apos;%1&apos; for write!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3445"/>
+        <source>Can&apos;t save last open info file &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3466"/>
+        <location filename="../mainwindow.cpp" line="3476"/>
+        <source>Load last open info error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3467"/>
+        <location filename="../mainwindow.cpp" line="3477"/>
+        <source>Can&apos;t load last open info file &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3707"/>
+        <source>Character sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3741"/>
+        <source>File Encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3757"/>
+        <source>Convert to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3763"/>
+        <location filename="../mainwindow.cpp" line="6418"/>
+        <location filename="../mainwindow.cpp" line="6432"/>
+        <location filename="../mainwindow.cpp" line="9807"/>
+        <source>Confirm Convertion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3764"/>
+        <location filename="../mainwindow.cpp" line="6419"/>
+        <location filename="../mainwindow.cpp" line="6433"/>
+        <location filename="../mainwindow.cpp" line="9808"/>
+        <source>The editing file will be saved using %1 encoding. &lt;br /&gt;This operation can&apos;t be reverted. &lt;br /&gt;Are you sure to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3784"/>
+        <source>Newline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="3885"/>
+        <source>%1 files autosaved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4011"/>
+        <location filename="../mainwindow.cpp" line="4172"/>
+        <source>Version Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4237"/>
+        <source>Set answer to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4269"/>
+        <source>select other file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4274"/>
+        <source>Select Answer Source File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4276"/>
+        <source>C/C++ Source Files (*.c *.cpp *.cc *.cxx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4433"/>
+        <source>This operation will remove all cases for the current problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4435"/>
+        <location filename="../mainwindow.cpp" line="5909"/>
+        <source>Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4444"/>
+        <source>Choose input files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4446"/>
+        <source>Input data files (*.in)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4472"/>
+        <source>Problem &apos;%1&apos; received (%2/%3).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4598"/>
+        <source>New Folder %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4656"/>
+        <location filename="../mainwindow.cpp" line="4663"/>
+        <source>Do you really want to delete %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4669"/>
+        <source>Do you really want to delete %1 files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4739"/>
+        <source>Set Problem Set Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4740"/>
+        <source>Problem Set Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4781"/>
+        <location filename="../mainwindow.cpp" line="8634"/>
+        <location filename="../mainwindow.cpp" line="10342"/>
+        <source>Bookmark Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="4782"/>
+        <location filename="../mainwindow.cpp" line="8635"/>
+        <location filename="../mainwindow.cpp" line="10343"/>
+        <source>Description:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5034"/>
+        <location filename="../mainwindow.cpp" line="5037"/>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5043"/>
+        <source>Folder name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5301"/>
+        <source>The executable doesn&apos;t have symbol table, and can&apos;t be debugged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5357"/>
+        <source>Watchpoint hitted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5358"/>
+        <source>Value of &quot;%1&quot; has changed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5360"/>
+        <source>Old value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5362"/>
+        <source>New value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5409"/>
+        <source>Save project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5410"/>
+        <source>The project &apos;%1&apos; has modifications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5412"/>
+        <location filename="../mainwindow.cpp" line="8737"/>
+        <source>Do you want to save it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5518"/>
+        <location filename="../mainwindow.cpp" line="5536"/>
+        <source>File Changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5519"/>
+        <source>File &apos;%1&apos; was changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5519"/>
+        <source>Reload its content from disk?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5537"/>
+        <source>File &apos;%1&apos; was removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5537"/>
+        <source>Keep it open?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5556"/>
+        <source>Project folder removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5557"/>
+        <source>Folder for project &apos;%1&apos; was removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5559"/>
+        <source>It will be closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5623"/>
+        <location filename="../mainwindow.cpp" line="10070"/>
+        <location filename="../mainwindow.cpp" line="10138"/>
+        <source>New Project File?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5624"/>
+        <location filename="../mainwindow.cpp" line="10071"/>
+        <location filename="../mainwindow.cpp" line="10139"/>
+        <source>Do you want to add the new file to the project?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5672"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5721"/>
+        <location filename="../mainwindow.cpp" line="5734"/>
+        <location filename="../mainwindow.cpp" line="5745"/>
+        <location filename="../mainwindow.cpp" line="5755"/>
+        <location filename="../mainwindow.cpp" line="8821"/>
+        <source>Save Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5722"/>
+        <source>Save settings failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5906"/>
+        <source>Change Project Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="5907"/>
+        <source>Change the project&apos;s compiler set will lose all custom compiler set options.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6061"/>
+        <location filename="../mainwindow.cpp" line="6166"/>
+        <source>Compile Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6062"/>
+        <source>Failed to generate the executable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6063"/>
+        <source>Please check detail info in &quot;Tools Output&quot; panel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6172"/>
+        <source>Run Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6559"/>
+        <source>New Watch Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6560"/>
+        <source>Enter Watch Expression (it is recommended to use &apos;this-&gt;&apos; for class members):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6616"/>
+        <source>Parsing file %1 of %2: &quot;%3&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6638"/>
+        <location filename="../mainwindow.cpp" line="6644"/>
+        <source>Done parsing %1 files in %2 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6641"/>
+        <source>(%1 files per second)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6825"/>
+        <source>Modify Watch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6826"/>
+        <source>Watch Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="6957"/>
+        <source>Do you really want to clear all breakpoints in this file?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7145"/>
+        <source>New project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7146"/>
+        <source>Close %1 and start new project?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7159"/>
+        <source>Folder not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7160"/>
+        <source>Folder &apos;%1&apos; doesn&apos;t exist. Create it now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7167"/>
+        <source>Can&apos;t create folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7168"/>
+        <source>Failed to create folder &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7178"/>
+        <source>Folder Not Empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7179"/>
+        <source>The project folder is not empty, existing files may be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7181"/>
+        <source>Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7194"/>
+        <source>Save new project as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7196"/>
+        <source>Red Panda C++ project file (*.dev)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7208"/>
+        <source>New project fail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7209"/>
+        <source>Can&apos;t assign project template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7267"/>
+        <source>Add to project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7315"/>
+        <source>Remove file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7316"/>
+        <source>Remove the file from disk?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7633"/>
+        <source>New Project File Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7634"/>
+        <source>File Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7642"/>
+        <source>File Already Exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7643"/>
+        <source>File &apos;%1&apos; already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7680"/>
+        <source>Input Data File is too large to display!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7685"/>
+        <location filename="../mainwindow.cpp" line="7704"/>
+        <source>File doesn&apos;t exist!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7728"/>
+        <source>Folder %1 is not empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7729"/>
+        <source>Do you really want to delete it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7838"/>
+        <source>Break point condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7839"/>
+        <source>Enter the condition of the breakpoint:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7927"/>
+        <source>Error in Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="7928"/>
+        <source>Current Compiler set has the following critical error: 
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8248"/>
+        <source>Rename Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8249"/>
+        <source>Symbol &apos;%1&apos; is defined in system header.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8276"/>
+        <source>New Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8434"/>
+        <location filename="../mainwindow.cpp" line="8457"/>
+        <location filename="../mainwindow.cpp" line="8468"/>
+        <location filename="../mainwindow.cpp" line="8489"/>
+        <source>Replace Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8435"/>
+        <source>Can&apos;t open file &apos;%1&apos; for replace!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8469"/>
+        <source>Contents has changed since last search!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8531"/>
+        <source>Rich Text Format Files (*.rtf)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8553"/>
+        <source>HTML Files (*.html)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8657"/>
+        <source>Change working folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8658"/>
+        <source>File &apos;%1&apos; is not in the current working folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8661"/>
+        <source>Do you want to change working folder to &apos;%1&apos;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8735"/>
+        <source>The current problem set is not empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8754"/>
+        <source>Problem %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8802"/>
+        <location filename="../mainwindow.cpp" line="8834"/>
+        <source>Problem Set Files (*.pbs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8848"/>
+        <location filename="../mainwindow.cpp" line="10003"/>
+        <source>Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8862"/>
+        <source>Problem Case %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9184"/>
+        <location filename="../mainwindow.cpp" line="9233"/>
+        <source>Header Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9185"/>
+        <location filename="../mainwindow.cpp" line="9234"/>
+        <source>Header file &quot;%1&quot; already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9239"/>
+        <source>Source Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9240"/>
+        <source>Source file &quot;%1&quot; already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9394"/>
+        <source>Can&apos;t commit!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9395"/>
+        <source>The following files are in conflicting:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9400"/>
+        <source>Commit Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9400"/>
+        <source>Commit Message:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9403"/>
+        <source>Commit Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9404"/>
+        <source>Commit message shouldn&apos;t be empty!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9415"/>
+        <source>Can&apos;t Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9416"/>
+        <source>Git needs user info to commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9684"/>
+        <source>Choose Input Data File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9686"/>
+        <location filename="../mainwindow.cpp" line="9741"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9739"/>
+        <source>Choose Expected Output Data File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9893"/>
+        <source>Go to Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9893"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9914"/>
+        <source>Template Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9915"/>
+        <source>Template %1 already exists. Do you want to overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9995"/>
+        <source>FPS Problem Set Files (*.fps;*.xml)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="10026"/>
+        <source>FPS Problem Set Files (*.fps)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="10031"/>
+        <source>Export Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="10123"/>
+        <source>Watchpoint variable name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="10124"/>
+        <source>Stop execution when the following variable is modified (it must be visible from the currect scope):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MemoryModel</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2555"/>
+        <source>addr: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2557"/>
+        <source>dec: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2559"/>
+        <source>oct: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2561"/>
+        <source>bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2576"/>
+        <source>ascii: &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewClassDialog</name>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="14"/>
+        <source>New Class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="33"/>
+        <source>Header Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="46"/>
+        <source>Class Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="88"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="95"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="105"/>
+        <source>Path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="112"/>
+        <source>Base Class:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="119"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.ui" line="129"/>
+        <source>Source Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newclassdialog.cpp" line="99"/>
+        <source>Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewHeaderDialog</name>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="14"/>
+        <source>New Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="23"/>
+        <source>Header:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="30"/>
+        <location filename="../widgets/newheaderdialog.ui" line="33"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="40"/>
+        <source>Path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="63"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.ui" line="70"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newheaderdialog.cpp" line="93"/>
+        <source>Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewProjectDialog</name>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="14"/>
+        <source>New Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="109"/>
+        <source>Make default language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="116"/>
+        <source>C Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="126"/>
+        <source>C++ Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="157"/>
+        <source>Icon Info:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="201"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="208"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="215"/>
+        <source>Create in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.ui" line="222"/>
+        <source>Use as the default project location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.cpp" line="178"/>
+        <location filename="../widgets/newprojectdialog.cpp" line="199"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectdialog.cpp" line="284"/>
+        <source>Choose directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewProjectUnitDialog</name>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="14"/>
+        <source>New Project Unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="20"/>
+        <source>Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="34"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="41"/>
+        <location filename="../widgets/newprojectunitdialog.ui" line="44"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="82"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.ui" line="89"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newprojectunitdialog.cpp" line="94"/>
+        <source>Choose directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewTemplateDialog</name>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="14"/>
+        <source>Create Template From Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="35"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="42"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="49"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="113"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/newtemplatedialog.ui" line="120"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OJProblemCasesRunner</name>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="87"/>
+        <source>--- stderr from %1 ---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="178"/>
+        <source>Time limit exceeded!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="181"/>
+        <source>Memory limit exceeded!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="199"/>
+        <source>The runner process &apos;%1&apos; failed to start.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="206"/>
+        <source>The last waitFor...() function timed out.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="209"/>
+        <source>An error occurred when attempting to write to the runner process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/ojproblemcasesrunner.cpp" line="212"/>
+        <source>An error occurred when attempting to read from the runner process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OJProblemModel</name>
+    <message>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="565"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="567"/>
+        <source>Time(ms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="570"/>
+        <source>Memory(kb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OJProblemPropertyWidget</name>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="20"/>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="30"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="37"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="65"/>
+        <source>Time Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="72"/>
+        <source>Memory Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="140"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.ui" line="147"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="30"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="54"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="82"/>
+        <source>sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="31"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="57"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="32"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="62"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="86"/>
+        <source>KB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="33"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="65"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="88"/>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="34"/>
+        <location filename="../widgets/ojproblempropertywidget.cpp" line="68"/>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Project</name>
+    <message>
+        <location filename="../project.cpp" line="1015"/>
+        <source>Error Load File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1040"/>
+        <location filename="../project.cpp" line="1139"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1041"/>
+        <source>Can&apos;t create folder %1 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1110"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1111"/>
+        <location filename="../project.cpp" line="1140"/>
+        <source>Can&apos;t save file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1285"/>
+        <source>File Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1286"/>
+        <source>File &apos;%1&apos; is already in the project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1657"/>
+        <source>Project Updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1658"/>
+        <source>Your project was succesfully updated to a newer file format!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1660"/>
+        <source>If something has gone wrong, we kept a backup-file: &apos;%1&apos;...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1731"/>
+        <source>Headers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1739"/>
+        <source>Sources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1747"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1967"/>
+        <source>Settings need update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1968"/>
+        <source>The compiler settings format of Red Panda C++ has changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="1970"/>
+        <source>Please update your settings at Project &gt;&gt; Project Options &gt;&gt; Compiler and save your project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2011"/>
+        <source>Compiler not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2012"/>
+        <source>The compiler set you have selected for this project, no longer exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2014"/>
+        <source>It will be substituted by the global compiler set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2108"/>
+        <source>Developed using the Red Panda C++ IDE</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectAlreadyOpenDialog</name>
+    <message>
+        <location filename="../widgets/projectalreadyopendialog.ui" line="14"/>
+        <source>Open Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/projectalreadyopendialog.ui" line="20"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Projects can either be opened in a new window or replace the project in the existing window or be attached to the already opened projects. How would you like to open the project?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/projectalreadyopendialog.ui" line="62"/>
+        <source>&amp;This Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/projectalreadyopendialog.ui" line="72"/>
+        <source>New &amp;Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/projectalreadyopendialog.ui" line="82"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectCompileParamatersWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="20"/>
+        <source>Parallel Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="29"/>
+        <source>Parallel Jobs(0 means infinite):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="59"/>
+        <source>C Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="81"/>
+        <source>C++ Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="103"/>
+        <source>Linker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="146"/>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="82"/>
+        <source>Add Library Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="160"/>
+        <source>Resource</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="75"/>
+        <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="77"/>
+        <source>Library Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectCompiler</name>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="127"/>
+        <source>Building makefile...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="129"/>
+        <source>- Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="133"/>
+        <source>Can&apos;t open &apos;%1&apos; for write!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="233"/>
+        <source>- Resource File: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="579"/>
+        <source>Compiling project changes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="581"/>
+        <source>- Project Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="582"/>
+        <source>- Compiler Set Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="591"/>
+        <source>Make program &apos;%1&apos; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="593"/>
+        <source>Please check the &quot;program&quot; page of compiler settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="633"/>
+        <source>Processing makefile:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="635"/>
+        <source>- makefile processer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/projectcompiler.cpp" line="637"/>
+        <source>- Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectCompilerWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.ui" line="23"/>
+        <source>Statically link libraries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.ui" line="46"/>
+        <source>Base compiler set:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.ui" line="53"/>
+        <source>Customize (apply to this project only):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.ui" line="82"/>
+        <source>Set Encoding for the executable:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="120"/>
+        <source>System Default(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="121"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="147"/>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="156"/>
+        <source>Wrong Compiler Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="148"/>
+        <source>Compiler %1 can&apos;t compile a microcontroller project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="157"/>
+        <source>Compiler %1 can only compile microcontroller project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="167"/>
+        <source>Change Project Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="168"/>
+        <source>Change the project&apos;s compiler set will lose all custom compiler set options.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectcompilerwidget.cpp" line="170"/>
+        <source>Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectDLLHostWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectdllhostwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdllhostwidget.ui" line="20"/>
+        <location filename="../settingsdialog/projectdllhostwidget.ui" line="23"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdllhostwidget.ui" line="33"/>
+        <source>Host application for DLL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdllhostwidget.cpp" line="57"/>
+        <source>Choose host application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdllhostwidget.cpp" line="59"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectDirectoriesWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectdirectorieswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="30"/>
+        <source>Binaries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="32"/>
+        <source>Libraries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="34"/>
+        <source>Includes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="36"/>
+        <source>Resources</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectFilesWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="41"/>
+        <source>File Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="62"/>
+        <source>Build Priority:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="91"/>
+        <source>Include in compilation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="98"/>
+        <source>Include in linking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="105"/>
+        <source>Compile files as C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="127"/>
+        <source>Encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.ui" line="164"/>
+        <source>Override build command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="39"/>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="41"/>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="268"/>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="270"/>
+        <source>Project(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="39"/>
+        <source>System Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="268"/>
+        <source>ANSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="272"/>
+        <source>System Default(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectfileswidget.cpp" line="273"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="20"/>
+        <source>Default encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="78"/>
+        <source>Output File:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="85"/>
+        <source>Default to C++ when creating new files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="92"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="102"/>
+        <source>Files:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="109"/>
+        <source>File Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="129"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="136"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="143"/>
+        <source>Support Windows XP Themes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="159"/>
+        <source>Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="165"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.ui" line="223"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="97"/>
+        <source>%1 files [ %2 sources, %3 headers, %4 resources, %5 other files ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="156"/>
+        <source>Can&apos;t remove old icon file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="157"/>
+        <source>Can&apos;t remove old icon file &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="179"/>
+        <source>Select icon file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="181"/>
+        <source>Image Files (*.ico *.png *.jpg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="222"/>
+        <source>System Default(%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="223"/>
+        <source>UTF-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectgeneralwidget.cpp" line="224"/>
+        <source>UTF-8 BOM</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectMakefileWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="20"/>
+        <source>Use custom make file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="32"/>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="35"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="45"/>
+        <source>Information about using a custom make file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.ui" line="52"/>
+        <source>Include the following files into the makefile:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.cpp" line="67"/>
+        <source>Custom makefile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectmakefilewidget.cpp" line="69"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectModel</name>
+    <message>
+        <location filename="../project.cpp" line="2695"/>
+        <source>File exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2696"/>
+        <source>File &apos;%1&apos; already exists. Delete it now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2714"/>
+        <source>Remove failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2715"/>
+        <source>Failed to remove file &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2732"/>
+        <source>Rename failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../project.cpp" line="2733"/>
+        <source>Failed to rename file &apos;%1&apos; to &apos;%2&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectOutputWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="20"/>
+        <source>Directory for output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="29"/>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="48"/>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="73"/>
+        <source>browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="39"/>
+        <source>Directory for obj files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="58"/>
+        <source>Auto save compile log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.ui" line="83"/>
+        <source>Override output filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.cpp" line="67"/>
+        <source>Executable output directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.cpp" line="81"/>
+        <source>Object files output directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.cpp" line="96"/>
+        <source>Log file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectoutputwidget.cpp" line="98"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectPreCompileWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="20"/>
+        <source>Use precompiled header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="44"/>
+        <source>Header to be precompiled:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="54"/>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="57"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For more information about gcc precompiled header, see:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.cpp" line="61"/>
+        <source>Select the header file to be precompiled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectprecompilewidget.cpp" line="63"/>
+        <source>Header files (*.h *.hh *.hpp)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectTemplate</name>
+    <message>
+        <location filename="../projecttemplate.cpp" line="76"/>
+        <source>Read failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../projecttemplate.cpp" line="77"/>
+        <source>Can&apos;t read template file &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../projecttemplate.cpp" line="83"/>
+        <source>Can&apos;t Open Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../projecttemplate.cpp" line="84"/>
+        <source>Can&apos;t open template file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../projecttemplate.cpp" line="92"/>
+        <source>Old version template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../projecttemplate.cpp" line="93"/>
+        <source>Template file &apos;%1&apos; has version &apos;%2&apos;, which is unsupported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProjectVersionInfoWidget</name>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="20"/>
+        <source>Include version info in project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="46"/>
+        <source>Major</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="53"/>
+        <source>Minor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="60"/>
+        <source>Rlease</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="81"/>
+        <source>Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="107"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="133"/>
+        <source>Original filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="143"/>
+        <source>Sync product with file version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="150"/>
+        <source>Internal name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="163"/>
+        <source>File version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="170"/>
+        <source>Legal trademarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="177"/>
+        <source>Product name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="187"/>
+        <source>Company name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="197"/>
+        <source>Auto-increase build number on compile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="207"/>
+        <source>File description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="214"/>
+        <source>Product version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/projectversioninfowidget.ui" line="224"/>
+        <source>Legal copyright</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <location filename="../main.cpp" line="479"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../autolinkmanager.cpp" line="54"/>
+        <location filename="../autolinkmanager.cpp" line="70"/>
+        <location filename="../autolinkmanager.cpp" line="91"/>
+        <location filename="../settings.cpp" line="4011"/>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="167"/>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="230"/>
+        <source>Can&apos;t open file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../autolinkmanager.cpp" line="59"/>
+        <location filename="../autolinkmanager.cpp" line="75"/>
+        <location filename="../autolinkmanager.cpp" line="106"/>
+        <source>Can&apos;t open file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="68"/>
+        <source>Can&apos;t open file &apos;%1&apos; for read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="77"/>
+        <source>Can&apos;t parse json file &apos;%1&apos; at offset %2! Error Code: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="81"/>
+        <source>Can&apos;t parse json file &apos;%1&apos; is not a color scheme config file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="106"/>
+        <source>Can&apos;t open file &apos;%1&apos; for write</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="347"/>
+        <source>Can&apos;t Find the color scheme file %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="351"/>
+        <location filename="../colorscheme.cpp" line="369"/>
+        <location filename="../colorscheme.cpp" line="374"/>
+        <source>Can&apos;t remove the color scheme file %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="439"/>
+        <source>Character</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="440"/>
+        <location filename="../colorscheme.cpp" line="444"/>
+        <location filename="../colorscheme.cpp" line="448"/>
+        <location filename="../colorscheme.cpp" line="452"/>
+        <location filename="../colorscheme.cpp" line="456"/>
+        <location filename="../colorscheme.cpp" line="460"/>
+        <location filename="../colorscheme.cpp" line="464"/>
+        <location filename="../colorscheme.cpp" line="468"/>
+        <location filename="../colorscheme.cpp" line="472"/>
+        <location filename="../colorscheme.cpp" line="476"/>
+        <location filename="../colorscheme.cpp" line="480"/>
+        <location filename="../colorscheme.cpp" line="484"/>
+        <location filename="../colorscheme.cpp" line="488"/>
+        <location filename="../colorscheme.cpp" line="492"/>
+        <location filename="../colorscheme.cpp" line="496"/>
+        <location filename="../colorscheme.cpp" line="500"/>
+        <location filename="../colorscheme.cpp" line="504"/>
+        <location filename="../colorscheme.cpp" line="508"/>
+        <location filename="../colorscheme.cpp" line="512"/>
+        <location filename="../colorscheme.cpp" line="516"/>
+        <location filename="../colorscheme.cpp" line="522"/>
+        <location filename="../colorscheme.cpp" line="526"/>
+        <location filename="../colorscheme.cpp" line="530"/>
+        <location filename="../colorscheme.cpp" line="534"/>
+        <source>Syntax</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="443"/>
+        <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="447"/>
+        <source>Class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="451"/>
+        <source>Float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="455"/>
+        <source>Function</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="459"/>
+        <source>Gloabal Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="463"/>
+        <source>Hexadecimal Integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="467"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="471"/>
+        <source>Illegal Char</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="475"/>
+        <source>Local Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="479"/>
+        <source>Integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="483"/>
+        <source>Octal Integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="487"/>
+        <source>Preprocessor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="491"/>
+        <source>Reserve Word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="495"/>
+        <source>Reserve Word for Types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="499"/>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="503"/>
+        <source>String</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="507"/>
+        <source>Escape Sequences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="511"/>
+        <source>Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="515"/>
+        <source>Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="521"/>
+        <source>Brace/Bracket/Parenthesis Level 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="525"/>
+        <source>Brace/Bracket/Parenthesis Level 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="529"/>
+        <source>Brace/Bracket/Parenthesis Level 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="533"/>
+        <source>Brace/Bracket/Parenthesis Level 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="539"/>
+        <source>Gutter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="540"/>
+        <location filename="../colorscheme.cpp" line="544"/>
+        <location filename="../colorscheme.cpp" line="549"/>
+        <location filename="../colorscheme.cpp" line="554"/>
+        <location filename="../colorscheme.cpp" line="559"/>
+        <location filename="../colorscheme.cpp" line="564"/>
+        <location filename="../colorscheme.cpp" line="569"/>
+        <location filename="../colorscheme.cpp" line="574"/>
+        <location filename="../colorscheme.cpp" line="579"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="543"/>
+        <source>Gutter Active Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="548"/>
+        <source>Active Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="553"/>
+        <source>Breakpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="558"/>
+        <source>Active Breakpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="563"/>
+        <source>Fold Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="568"/>
+        <source>Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="573"/>
+        <source>Editor Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="578"/>
+        <source>Current Highlighted Word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="584"/>
+        <location filename="../main.cpp" line="235"/>
+        <location filename="../main.cpp" line="242"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="585"/>
+        <location filename="../colorscheme.cpp" line="589"/>
+        <source>Syntax Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="588"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="609"/>
+        <location filename="../colorscheme.cpp" line="615"/>
+        <source>Rename file &apos;%1&apos; to &apos;%2&apos; failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="624"/>
+        <source>Scheme &apos;%1&apos; already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../colorscheme.cpp" line="764"/>
+        <source>default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="92"/>
+        <location filename="../compiler/compilerinfo.cpp" line="442"/>
+        <source>Code Generation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="101"/>
+        <source>Optimization level (-Ox)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="117"/>
+        <source>C++ Language standard (-std)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="128"/>
+        <source>C Language standard (-std)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="178"/>
+        <source>Enable use of specific instructions (-mx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="182"/>
+        <source>32-bit pointer, 32-bit instruction (-m32)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="183"/>
+        <source>32-bit pointer, 64-bit instruction (-mx32)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="184"/>
+        <source>64-bit pointer, 64-bit instruction (-m64)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="185"/>
+        <source>x86 multilib (-mx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="187"/>
+        <source>Generate debugging information (-g3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="188"/>
+        <source>Generate profiling info for analysis (-pg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="189"/>
+        <source>Only check the code for syntax errors (-fsyntax-only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="192"/>
+        <source>Warnings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="193"/>
+        <source>Inhibit all warning messages (-w)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="194"/>
+        <source>Show most warnings (-Wall)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="195"/>
+        <source>Show some more warnings (-Wextra)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="196"/>
+        <source>Check ISO C/C++ conformance (-pedantic)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="197"/>
+        <source>Make all warnings into errors (-Werror)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="198"/>
+        <source>Abort compilation on first error (-Wfatal-errors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="204"/>
+        <source>Check for stack smashing attacks (-fstack-protector)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="211"/>
+        <source>Enable Sanitizer (-fsanitize=)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="220"/>
+        <source>Linker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="222"/>
+        <source>Stack Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="225"/>
+        <source>Use pipes instead of temporary files during compilation (-pipe)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="227"/>
+        <source>Do not use standard system libraries (-nostdlib)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="228"/>
+        <source>Do not create a console window (-mwindows)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="229"/>
+        <source>Strip executable (-s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="461"/>
+        <source>Processor (-m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="475"/>
+        <source>Language standard (--std)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="483"/>
+        <source>Memory model (--model)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="485"/>
+        <source>Use external stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="486"/>
+        <source>Use movc instead of movx to read from external ram</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="487"/>
+        <source>Replaces lcall/ljmp with acall/ajmp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="488"/>
+        <source>Don&apos;t memcpy initialized xram from code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="489"/>
+        <source>Don&apos;t generate startup code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="491"/>
+        <source>MCU Specification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="493"/>
+        <source>Internal ram size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="494"/>
+        <source>External ram start location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="495"/>
+        <source>External ram size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="496"/>
+        <source>Stack pointer initial value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="497"/>
+        <source>External stack start location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="498"/>
+        <source>Direct data start location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="499"/>
+        <source>Code segment location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/compilerinfo.cpp" line="500"/>
+        <source>Code segment size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editorlist.cpp" line="178"/>
+        <location filename="../mainwindow.cpp" line="3404"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../editorlist.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="3405"/>
+        <source>Save changes to %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="236"/>
+        <source>Can&apos;t create configuration folder %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="243"/>
+        <source>Can&apos;t write to configuration file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="429"/>
+        <source>Can&apos;t load autolink settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../parser/cppparser.cpp" line="1342"/>
+        <source>constructor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../parser/cppparser.cpp" line="1349"/>
+        <source>destructor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../problems/freeprojectsetformat.cpp" line="12"/>
+        <source>Can&apos;t open file &quot;%1&quot; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../problems/freeprojectsetformat.cpp" line="35"/>
+        <source>Problem Case %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../problems/freeprojectsetformat.cpp" line="102"/>
+        <source>Can&apos;t open file &quot;%1&quot; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../problems/freeprojectsetformat.cpp" line="188"/>
+        <source>Error when writing file &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3000"/>
+        <source>C Compiler &quot;%1&quot; is missing!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3003"/>
+        <source>C++ Compiler &quot;%1&quot; is missing!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3006"/>
+        <source>Debugger &quot;%1&quot; is missing!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3009"/>
+        <source>Make program &quot;%1&quot; is missing!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3233"/>
+        <source>Error executing platform compiler hint add-on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3367"/>
+        <location filename="../settings.cpp" line="3373"/>
+        <source>Compiler set not configuared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3369"/>
+        <source>Would you like Red Panda C++ to search for compilers in the following locations: &lt;BR /&gt;&apos;%1&apos;&lt;BR /&gt;&apos;%2&apos;? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3375"/>
+        <source>Would you like Red Panda C++ to search for compilers in PATH?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3377"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3386"/>
+        <source>No Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3387"/>
+        <source>Can&apos;t find a C/C++ compiler.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3389"/>
+        <source>You must have a compiler to compile and execute C/C++ files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="39"/>
+        <source>Binaries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="41"/>
+        <source>Libraries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="43"/>
+        <source>C Includes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="45"/>
+        <source>C++ Includes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="410"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="411"/>
+        <source>Do you really want to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="69"/>
+        <source>Auto Detection Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentprogramswidget.cpp" line="70"/>
+        <source>Failed to detect terminal arguments pattern for “%1”.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="29"/>
+        <location filename="../systemconsts.cpp" line="31"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="33"/>
+        <source>Dev C++ Project files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="34"/>
+        <source>C files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="35"/>
+        <source>C++ files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="36"/>
+        <source>Header files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="37"/>
+        <source>GAS files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="38"/>
+        <source>Lua files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="40"/>
+        <source>Icon files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="94"/>
+        <source>Executable files (*.exe)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../systemconsts.cpp" line="96"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="538"/>
+        <source>bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="540"/>
+        <source>KB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="542"/>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="544"/>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../vcs/gitmanager.cpp" line="475"/>
+        <location filename="../vcs/gitmergedialog.cpp" line="18"/>
+        <source>&lt;Auto Generated by Git&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/ojproblemsetmodel.cpp" line="182"/>
+        <source>Can&apos;t parse problem set file &apos;%1&apos;:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RegisterModel</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2053"/>
+        <location filename="../debugger/debugger.cpp" line="2054"/>
+        <location filename="../debugger/debugger.cpp" line="2055"/>
+        <location filename="../debugger/debugger.cpp" line="2056"/>
+        <location filename="../debugger/debugger.cpp" line="2057"/>
+        <location filename="../debugger/debugger.cpp" line="2058"/>
+        <location filename="../debugger/debugger.cpp" line="2059"/>
+        <location filename="../debugger/debugger.cpp" line="2060"/>
+        <location filename="../debugger/debugger.cpp" line="2061"/>
+        <location filename="../debugger/debugger.cpp" line="2062"/>
+        <location filename="../debugger/debugger.cpp" line="2063"/>
+        <location filename="../debugger/debugger.cpp" line="2064"/>
+        <location filename="../debugger/debugger.cpp" line="2065"/>
+        <location filename="../debugger/debugger.cpp" line="2066"/>
+        <location filename="../debugger/debugger.cpp" line="2067"/>
+        <location filename="../debugger/debugger.cpp" line="2068"/>
+        <location filename="../debugger/debugger.cpp" line="2069"/>
+        <location filename="../debugger/debugger.cpp" line="2157"/>
+        <location filename="../debugger/debugger.cpp" line="2158"/>
+        <location filename="../debugger/debugger.cpp" line="2159"/>
+        <location filename="../debugger/debugger.cpp" line="2160"/>
+        <location filename="../debugger/debugger.cpp" line="2161"/>
+        <location filename="../debugger/debugger.cpp" line="2162"/>
+        <location filename="../debugger/debugger.cpp" line="2163"/>
+        <location filename="../debugger/debugger.cpp" line="2164"/>
+        <source>64-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2053"/>
+        <location filename="../debugger/debugger.cpp" line="2073"/>
+        <source>Accumulator for operands and results data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2054"/>
+        <location filename="../debugger/debugger.cpp" line="2074"/>
+        <source>Pointer to data in the DS segment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2055"/>
+        <location filename="../debugger/debugger.cpp" line="2075"/>
+        <source>Counter for string and loop operations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2056"/>
+        <location filename="../debugger/debugger.cpp" line="2076"/>
+        <source>I/O pointer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2057"/>
+        <location filename="../debugger/debugger.cpp" line="2077"/>
+        <source>Source index for string operations; Pointer to data in the segment pointed to by the DS register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2058"/>
+        <location filename="../debugger/debugger.cpp" line="2078"/>
+        <source>Destination index for string operations; Pointer to data (or destination) in the segment pointed to by the ES register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2059"/>
+        <location filename="../debugger/debugger.cpp" line="2079"/>
+        <source>Stack pointer (in the SS segment)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2060"/>
+        <location filename="../debugger/debugger.cpp" line="2080"/>
+        <source>Pointer to data on the stack (in the SS segment)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2061"/>
+        <location filename="../debugger/debugger.cpp" line="2062"/>
+        <location filename="../debugger/debugger.cpp" line="2063"/>
+        <location filename="../debugger/debugger.cpp" line="2064"/>
+        <location filename="../debugger/debugger.cpp" line="2065"/>
+        <location filename="../debugger/debugger.cpp" line="2066"/>
+        <location filename="../debugger/debugger.cpp" line="2067"/>
+        <location filename="../debugger/debugger.cpp" line="2068"/>
+        <location filename="../debugger/debugger.cpp" line="2081"/>
+        <location filename="../debugger/debugger.cpp" line="2082"/>
+        <location filename="../debugger/debugger.cpp" line="2083"/>
+        <location filename="../debugger/debugger.cpp" line="2084"/>
+        <location filename="../debugger/debugger.cpp" line="2085"/>
+        <location filename="../debugger/debugger.cpp" line="2086"/>
+        <location filename="../debugger/debugger.cpp" line="2087"/>
+        <location filename="../debugger/debugger.cpp" line="2088"/>
+        <source>General purpose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2069"/>
+        <location filename="../debugger/debugger.cpp" line="2089"/>
+        <source>Instruction pointer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2070"/>
+        <location filename="../debugger/debugger.cpp" line="2071"/>
+        <source>Flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2073"/>
+        <location filename="../debugger/debugger.cpp" line="2074"/>
+        <location filename="../debugger/debugger.cpp" line="2075"/>
+        <location filename="../debugger/debugger.cpp" line="2076"/>
+        <location filename="../debugger/debugger.cpp" line="2077"/>
+        <location filename="../debugger/debugger.cpp" line="2078"/>
+        <location filename="../debugger/debugger.cpp" line="2079"/>
+        <location filename="../debugger/debugger.cpp" line="2080"/>
+        <location filename="../debugger/debugger.cpp" line="2081"/>
+        <location filename="../debugger/debugger.cpp" line="2082"/>
+        <location filename="../debugger/debugger.cpp" line="2083"/>
+        <location filename="../debugger/debugger.cpp" line="2084"/>
+        <location filename="../debugger/debugger.cpp" line="2085"/>
+        <location filename="../debugger/debugger.cpp" line="2086"/>
+        <location filename="../debugger/debugger.cpp" line="2087"/>
+        <location filename="../debugger/debugger.cpp" line="2088"/>
+        <location filename="../debugger/debugger.cpp" line="2089"/>
+        <source>32-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2091"/>
+        <location filename="../debugger/debugger.cpp" line="2092"/>
+        <location filename="../debugger/debugger.cpp" line="2093"/>
+        <location filename="../debugger/debugger.cpp" line="2094"/>
+        <location filename="../debugger/debugger.cpp" line="2095"/>
+        <location filename="../debugger/debugger.cpp" line="2096"/>
+        <location filename="../debugger/debugger.cpp" line="2097"/>
+        <location filename="../debugger/debugger.cpp" line="2098"/>
+        <location filename="../debugger/debugger.cpp" line="2099"/>
+        <location filename="../debugger/debugger.cpp" line="2100"/>
+        <location filename="../debugger/debugger.cpp" line="2101"/>
+        <location filename="../debugger/debugger.cpp" line="2102"/>
+        <location filename="../debugger/debugger.cpp" line="2103"/>
+        <location filename="../debugger/debugger.cpp" line="2104"/>
+        <location filename="../debugger/debugger.cpp" line="2105"/>
+        <location filename="../debugger/debugger.cpp" line="2106"/>
+        <location filename="../debugger/debugger.cpp" line="2107"/>
+        <source>lower 16 bits of %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2109"/>
+        <location filename="../debugger/debugger.cpp" line="2110"/>
+        <location filename="../debugger/debugger.cpp" line="2111"/>
+        <location filename="../debugger/debugger.cpp" line="2112"/>
+        <location filename="../debugger/debugger.cpp" line="2113"/>
+        <location filename="../debugger/debugger.cpp" line="2114"/>
+        <location filename="../debugger/debugger.cpp" line="2115"/>
+        <location filename="../debugger/debugger.cpp" line="2116"/>
+        <location filename="../debugger/debugger.cpp" line="2117"/>
+        <location filename="../debugger/debugger.cpp" line="2118"/>
+        <location filename="../debugger/debugger.cpp" line="2119"/>
+        <location filename="../debugger/debugger.cpp" line="2120"/>
+        <location filename="../debugger/debugger.cpp" line="2121"/>
+        <location filename="../debugger/debugger.cpp" line="2122"/>
+        <location filename="../debugger/debugger.cpp" line="2123"/>
+        <location filename="../debugger/debugger.cpp" line="2124"/>
+        <source>lower 8 bits of %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2126"/>
+        <location filename="../debugger/debugger.cpp" line="2127"/>
+        <location filename="../debugger/debugger.cpp" line="2128"/>
+        <location filename="../debugger/debugger.cpp" line="2129"/>
+        <source>8 high bits of lower 16 bits of %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2131"/>
+        <location filename="../debugger/debugger.cpp" line="2132"/>
+        <location filename="../debugger/debugger.cpp" line="2133"/>
+        <location filename="../debugger/debugger.cpp" line="2134"/>
+        <location filename="../debugger/debugger.cpp" line="2135"/>
+        <location filename="../debugger/debugger.cpp" line="2136"/>
+        <source>16-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2131"/>
+        <source>Code segment selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2132"/>
+        <source>Data segment selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2133"/>
+        <location filename="../debugger/debugger.cpp" line="2134"/>
+        <location filename="../debugger/debugger.cpp" line="2135"/>
+        <source>Extra data segment selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2136"/>
+        <source>Stack segment selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2139"/>
+        <location filename="../debugger/debugger.cpp" line="2140"/>
+        <location filename="../debugger/debugger.cpp" line="2141"/>
+        <location filename="../debugger/debugger.cpp" line="2142"/>
+        <location filename="../debugger/debugger.cpp" line="2143"/>
+        <location filename="../debugger/debugger.cpp" line="2144"/>
+        <location filename="../debugger/debugger.cpp" line="2145"/>
+        <location filename="../debugger/debugger.cpp" line="2146"/>
+        <source>Floating-point data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2148"/>
+        <source>Floating-point control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2149"/>
+        <source>Floating-point status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2150"/>
+        <source>Floating-point tag word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2151"/>
+        <source>Floating-point operation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2152"/>
+        <source>Floating-point last instruction segment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2153"/>
+        <source>Floating-point last instruction offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2154"/>
+        <source>Floating-point last operand segment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2155"/>
+        <source>Floating-point last operand offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2166"/>
+        <location filename="../debugger/debugger.cpp" line="2167"/>
+        <location filename="../debugger/debugger.cpp" line="2168"/>
+        <location filename="../debugger/debugger.cpp" line="2169"/>
+        <location filename="../debugger/debugger.cpp" line="2170"/>
+        <location filename="../debugger/debugger.cpp" line="2171"/>
+        <location filename="../debugger/debugger.cpp" line="2172"/>
+        <location filename="../debugger/debugger.cpp" line="2173"/>
+        <location filename="../debugger/debugger.cpp" line="2174"/>
+        <location filename="../debugger/debugger.cpp" line="2175"/>
+        <location filename="../debugger/debugger.cpp" line="2176"/>
+        <location filename="../debugger/debugger.cpp" line="2177"/>
+        <location filename="../debugger/debugger.cpp" line="2178"/>
+        <location filename="../debugger/debugger.cpp" line="2179"/>
+        <location filename="../debugger/debugger.cpp" line="2180"/>
+        <source>128-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2182"/>
+        <location filename="../debugger/debugger.cpp" line="2183"/>
+        <location filename="../debugger/debugger.cpp" line="2184"/>
+        <location filename="../debugger/debugger.cpp" line="2185"/>
+        <location filename="../debugger/debugger.cpp" line="2186"/>
+        <location filename="../debugger/debugger.cpp" line="2187"/>
+        <location filename="../debugger/debugger.cpp" line="2188"/>
+        <location filename="../debugger/debugger.cpp" line="2189"/>
+        <location filename="../debugger/debugger.cpp" line="2190"/>
+        <location filename="../debugger/debugger.cpp" line="2191"/>
+        <location filename="../debugger/debugger.cpp" line="2192"/>
+        <location filename="../debugger/debugger.cpp" line="2193"/>
+        <location filename="../debugger/debugger.cpp" line="2194"/>
+        <location filename="../debugger/debugger.cpp" line="2195"/>
+        <location filename="../debugger/debugger.cpp" line="2196"/>
+        <source>256-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2198"/>
+        <source>SSE status and control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2253"/>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2255"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SDCCFileCompiler</name>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="50"/>
+        <source>Compiling single file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="52"/>
+        <source>- Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="53"/>
+        <source>- Compiler Set Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="64"/>
+        <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="66"/>
+        <source>Please check the &quot;program&quot; page of compiler settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="90"/>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="100"/>
+        <source>Can&apos;t find &quot;%1&quot;.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="109"/>
+        <source>Processing %1 source file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="111"/>
+        <source>- %1 Compiler: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="113"/>
+        <source>- Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccfilecompiler.cpp" line="146"/>
+        <source>Can&apos;t delete the old executable file &quot;%1&quot;.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SDCCProjectCompiler</name>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="73"/>
+        <source>Building makefile...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="75"/>
+        <source>- Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="79"/>
+        <source>Can&apos;t open &apos;%1&apos; for write!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="301"/>
+        <source>Compiling project changes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="303"/>
+        <source>- Project Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="304"/>
+        <source>- Compiler Set Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="313"/>
+        <source>Make program &apos;%1&apos; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="315"/>
+        <source>Please check the &quot;program&quot; page of compiler settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="355"/>
+        <source>Processing makefile:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="357"/>
+        <source>- makefile processer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/sdccprojectcompiler.cpp" line="359"/>
+        <source>- Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchDialog</name>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="14"/>
+        <source>Find</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="80"/>
+        <source>Text to Find:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="122"/>
+        <source>Replace with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="147"/>
+        <source>Scope:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="165"/>
+        <source>Global</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="175"/>
+        <source>Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="185"/>
+        <source>Origin:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="203"/>
+        <source>From cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="213"/>
+        <source>Entire scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="223"/>
+        <source>Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="263"/>
+        <source>Regular Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="270"/>
+        <source>Close after search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="277"/>
+        <source>Whole words only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="284"/>
+        <source>Case Sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="291"/>
+        <source>Wrap Around</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="351"/>
+        <source>Find &amp;Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="361"/>
+        <source>Find &amp;Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="374"/>
+        <source>&amp;Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="384"/>
+        <source>Replace &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.ui" line="410"/>
+        <source>&amp;Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="23"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="24"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="106"/>
+        <source>Beginning of file has been reached. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="107"/>
+        <source>Do you want to continue from file&apos;s end?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="109"/>
+        <location filename="../widgets/searchdialog.cpp" line="166"/>
+        <source>End of file has been reached. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="110"/>
+        <location filename="../widgets/searchdialog.cpp" line="167"/>
+        <source>Do you want to continue from file&apos;s beginning?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="119"/>
+        <location filename="../widgets/searchdialog.cpp" line="175"/>
+        <source>Continue Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="133"/>
+        <source>Not Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchdialog.cpp" line="134"/>
+        <source>Can&apos;t find &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchInFileDialog</name>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="14"/>
+        <source>Search in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="65"/>
+        <source>*.*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="78"/>
+        <source>Text to Find:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="85"/>
+        <source>Filters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="92"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="118"/>
+        <source>Folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="125"/>
+        <source>Search in subfolders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="159"/>
+        <source>Where:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="165"/>
+        <source>Current File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="175"/>
+        <source>Files In Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="182"/>
+        <source>Open Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="189"/>
+        <source>Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="202"/>
+        <source>Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="208"/>
+        <source>Whole words only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="215"/>
+        <source>Case Sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="246"/>
+        <source>Regular Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="313"/>
+        <source>&amp;Find</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="326"/>
+        <source>&amp;Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.ui" line="336"/>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.cpp" line="173"/>
+        <location filename="../widgets/searchinfiledialog.cpp" line="208"/>
+        <location filename="../widgets/searchinfiledialog.cpp" line="280"/>
+        <location filename="../widgets/searchinfiledialog.cpp" line="291"/>
+        <source>Searching...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.cpp" line="174"/>
+        <location filename="../widgets/searchinfiledialog.cpp" line="281"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchinfiledialog.cpp" line="448"/>
+        <source>Choose Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchResultListModel</name>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="385"/>
+        <source>Current File:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="387"/>
+        <source>Files In Project:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="389"/>
+        <source>Open Files:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="391"/>
+        <source>&quot;%1&quot; in Folder &quot;%2&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="395"/>
+        <source>Find Usages in Current File: &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="398"/>
+        <source>Find Usages in Project: &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchResultTreeModel</name>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="237"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchResultTreeViewDelegate</name>
+    <message>
+        <location filename="../widgets/searchresultview.cpp" line="447"/>
+        <location filename="../widgets/searchresultview.cpp" line="461"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <location filename="../settings.cpp" line="3993"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="3994"/>
+        <source>Can&apos;t find terminal program!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.ui" line="14"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="142"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.ui" line="92"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.ui" line="156"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.ui" line="163"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.ui" line="170"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2540"/>
+        <location filename="../mainwindow.cpp" line="2663"/>
+        <location filename="../mainwindow.cpp" line="9834"/>
+        <location filename="../mainwindow.cpp" line="9839"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="169"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="264"/>
+        <source>Compiler Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2541"/>
+        <location filename="../mainwindow.cpp" line="9840"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="258"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="261"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="264"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="267"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="270"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="274"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="278"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="281"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="285"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="291"/>
+        <source>Project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2664"/>
+        <location filename="../mainwindow.cpp" line="9835"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="169"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="172"/>
+        <source>Compiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8724"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="175"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="216"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="222"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="225"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="231"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="258"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="8725"/>
+        <location filename="../mainwindow.cpp" line="9131"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="216"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="219"/>
+        <source>Program Runner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="9130"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="219"/>
+        <source>Problem Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="145"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="145"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="149"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="153"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="156"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="159"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="162"/>
+        <source>Environment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="149"/>
+        <source>File Association</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="153"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="156"/>
+        <source>Terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="159"/>
+        <source>Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="162"/>
+        <source>Folders / Restore Default Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="172"/>
+        <source>Auto Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="175"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="178"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="181"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="184"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="187"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="190"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="193"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="196"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="199"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="202"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="205"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="178"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="181"/>
+        <source>Copy &amp; Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="184"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="187"/>
+        <source>Code Completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="190"/>
+        <source>Symbol Completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="193"/>
+        <source>Snippet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="196"/>
+        <source>Auto Syntax Checking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="199"/>
+        <source>Tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="202"/>
+        <source>Auto save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="205"/>
+        <source>Misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="208"/>
+        <source>Custom C/C++ Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="208"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="213"/>
+        <source>Languages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="213"/>
+        <source>ASM Generation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="222"/>
+        <source>Debugger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="225"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="228"/>
+        <source>Code Formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="228"/>
+        <source>Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="231"/>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="235"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="235"/>
+        <source>Git</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="256"/>
+        <source>Project Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="261"/>
+        <source>Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="267"/>
+        <source>Custom Compile options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="270"/>
+        <source>Directories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="274"/>
+        <source>Precompiled Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="278"/>
+        <source>Makefile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="281"/>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="285"/>
+        <source>DLL host</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="291"/>
+        <source>Version info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="352"/>
+        <source>Save Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingsdialog.cpp" line="353"/>
+        <source>There are changes in the settings, do you want to save them before swtich to other page?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWidget</name>
+    <message>
+        <location filename="../settingsdialog/settingswidget.cpp" line="61"/>
+        <source>Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/settingswidget.cpp" line="73"/>
+        <source>Save Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutManager</name>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="43"/>
+        <location filename="../shortcutmanager.cpp" line="56"/>
+        <source>Read shortcut config failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="44"/>
+        <source>Can&apos;t open shortcut config file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="57"/>
+        <source>Read shortcut config file &apos;%1&apos; failed:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="85"/>
+        <location filename="../shortcutmanager.cpp" line="102"/>
+        <source>Save shortcut config failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="86"/>
+        <source>Can&apos;t open shortcut config file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcutmanager.cpp" line="103"/>
+        <source>Write to shortcut config file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SignalMessageDialog</name>
+    <message>
+        <location filename="../widgets/signalmessagedialog.ui" line="14"/>
+        <source>Signal Received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/signalmessagedialog.ui" line="26"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/signalmessagedialog.ui" line="36"/>
+        <source>Open CPU Info Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StdinCompiler</name>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="32"/>
+        <source>Checking file syntax...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="34"/>
+        <source>Compiling...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="36"/>
+        <source>- Filename: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="37"/>
+        <source>- Compiler Set Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="74"/>
+        <source>Can&apos;t find the compiler for file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="81"/>
+        <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="86"/>
+        <source>Processing %1 source file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="88"/>
+        <source>%1 Compiler: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../compiler/stdincompiler.cpp" line="90"/>
+        <source>Command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SymbolUsageManager</name>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="41"/>
+        <location filename="../symbolusagemanager.cpp" line="52"/>
+        <source>Load symbol usage info failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="42"/>
+        <source>Can&apos;t open symbol usage file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="53"/>
+        <source>Can&apos;t parse symbol usage file &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="78"/>
+        <location filename="../symbolusagemanager.cpp" line="93"/>
+        <source>Save symbol usage info failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="79"/>
+        <source>Can&apos;t open symbol usage file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../symbolusagemanager.cpp" line="94"/>
+        <source>Write to symbol usage file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TodoModel</name>
+    <message>
+        <location filename="../todoparser.cpp" line="288"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../todoparser.cpp" line="290"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../todoparser.cpp" line="292"/>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ToolsGeneralWidget</name>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="35"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="42"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="49"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="148"/>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="155"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="165"/>
+        <source>Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="172"/>
+        <source>Output To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="182"/>
+        <source>Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="202"/>
+        <source>Redirect Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="212"/>
+        <source>Working Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="222"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="251"/>
+        <source>Insert Macro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="311"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="318"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.ui" line="344"/>
+        <source>Use UTF8 as the encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="39"/>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="45"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="40"/>
+        <source>Current Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="41"/>
+        <source>Whole Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="46"/>
+        <source>Tools Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="47"/>
+        <source>Replace Current Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="48"/>
+        <source>Repalce Whole Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="105"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="106"/>
+        <source>Title shouldn&apos;t be empty!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="110"/>
+        <source>Save Changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="111"/>
+        <source>Do you want to save changes to &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="294"/>
+        <source>untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="359"/>
+        <source>Choose Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="370"/>
+        <source>Select program</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ToolsGitWidget</name>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="14"/>
+        <source>Git</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="20"/>
+        <source>Test</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="27"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="30"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="53"/>
+        <source>Path to Git Executable:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.ui" line="60"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.cpp" line="45"/>
+        <source>Git Executable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/toolsgitwidget.cpp" line="47"/>
+        <source>All files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ToolsManager</name>
+    <message>
+        <location filename="../toolsmanager.cpp" line="41"/>
+        <source>Remove Compiled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="73"/>
+        <location filename="../toolsmanager.cpp" line="86"/>
+        <source>Read tools config failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="74"/>
+        <source>Can&apos;t open tools config file &apos;%1&apos; for read.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="87"/>
+        <source>Read tools config file &apos;%1&apos; failed:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="119"/>
+        <location filename="../toolsmanager.cpp" line="141"/>
+        <source>Save tools config failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="120"/>
+        <source>Can&apos;t open tools config file &apos;%1&apos; for write.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsmanager.cpp" line="142"/>
+        <source>Write to tools config file &apos;%1&apos; failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WatchModel</name>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1737"/>
+        <location filename="../debugger/debugger.cpp" line="1808"/>
+        <source>Not Valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="1861"/>
+        <location filename="../debugger/debugger.cpp" line="1967"/>
+        <source>Execute to evaluate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2010"/>
+        <source>Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2012"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../debugger/debugger.cpp" line="2014"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>editorcustomctypekeywords</name>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="14"/>
+        <source>Custom C/C++ Type Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="20"/>
+        <source>Enable Custom C/C++ Type Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="44"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="51"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="58"/>
+        <source>Remove All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="88"/>
+        <source>Note: Custom keywords is not recognized by syntax checker.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>editorgeneralwidget</name>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="20"/>
+        <source>Indents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="41"/>
+        <source>Auto Indent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="48"/>
+        <source>Replace tab with spaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="73"/>
+        <source>Tab Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="106"/>
+        <source>Show Indent Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="128"/>
+        <source>Indent Line Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="161"/>
+        <source>Fill Indents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="171"/>
+        <source>Caret</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="192"/>
+        <source>Move caret to the first non-space char in the current line when press HOME key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="199"/>
+        <source>Move caret to the last non-space char in the current line when press END key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="206"/>
+        <source>Keep X position of the caret when moving vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="231"/>
+        <source>Caret for overwriting mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="248"/>
+        <source>Caret Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="258"/>
+        <source>Caret for inserting mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="281"/>
+        <source>Use text color as caret color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="294"/>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="315"/>
+        <source>Highlight matching braces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="322"/>
+        <source>Highlight current word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="332"/>
+        <source>Scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="338"/>
+        <source>Auto hide scroll bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="345"/>
+        <source>Can scroll the last char to the left edge of the editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="352"/>
+        <source>Can scroll the last line to the top edge of the editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="359"/>
+        <source>Page Up/Down scrolls half a page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="381"/>
+        <source>Mouse Wheel Scroll Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="429"/>
+        <source>Mouse Selection/Dragging Scroll Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="465"/>
+        <source>Show right edge line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="504"/>
+        <source>Right egde width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/editorgeneralwidget.ui" line="555"/>
+        <source>Right edge line color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ru_RU">
+<TS version="2.1" language="ru_RU" sourcelanguage="ru_RU">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="14"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>О программе</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:600;&quot;&gt;Red Panda C++&lt;/span&gt;&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:600;&quot;&gt;Красная Панда Си++&lt;/span&gt;&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="35"/>
         <source>Based on Qt %1 (%2) running on %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Создан с помощью Qt %1 (%2) для архитектуры %3</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="47"/>
         <source>Build time: %1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Время сборки: %1 %2</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="59"/>
         <source>Copyright(C) 2021-2024 瞿华(royqh1979@gmail.com)</source>
-        <translation type="unfinished"></translation>
+        <translation>Copyright(C) 2021-2024 Ку Хуа (royqh1979@gmail.com)</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="71"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Homepage: &lt;a href=&quot;Homepage: https://sourceforge.net/projects/dev-cpp-2020/&quot;&gt;https://sourceforge.net/projects/dev-cpp-2020/&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Сайт: &lt;a href=&quot;Homepage: https://sourceforge.net/projects/dev-cpp-2020/&quot;&gt;https://sourceforge.net/projects/dev-cpp-2020/&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="87"/>
         <source>GNU General Public License</source>
-        <translation type="unfinished"></translation>
+        <translation>Универсальная Общественная Лицензия GNU</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.ui" line="96"/>
@@ -45,22 +45,26 @@
     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>    Эта программа является свободным программным обеспечением: вы можете распространять ее и/или модифицировать в соответствии с условиями GNU General Public License, опубликованной Фондом свободного программного обеспечения, либо версии 3 Лицензии, либо (по вашему выбору) любой более поздней версии.
+
+    Эта программа распространяется в надежде, что она будет полезной, но БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ; даже без подразумеваемой гарантии ТОВАРНОСТИ или ПРИГОДНОСТИ ДЛЯ ОПРЕДЕЛЕННОЙ ЦЕЛИ. Дополнительные сведения см. в Стандартной общественной лицензии GNU.
+
+    Вы должны были получить копию GNU General Public License вместе с этой программой. Если нет, см. &lt; https ://www.gnu.org/licenses/&gt;.</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.cpp" line="30"/>
         <source>Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Версия: </translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.cpp" line="68"/>
         <source>unknown compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>неизвестный компилятор</translation>
     </message>
     <message>
         <location filename="../widgets/aboutdialog.cpp" line="78"/>
         <source>Website: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Сайт: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
@@ -68,17 +72,17 @@
     <message>
         <location filename="../thememanager.cpp" line="199"/>
         <source>Theme file &apos;%1&apos; doesn&apos;t exist!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл темы &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../thememanager.cpp" line="215"/>
         <source>Error in json file &apos;%1&apos;:%2 : %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка в json-файле &apos;%1&apos;:%2 : %3</translation>
     </message>
     <message>
         <location filename="../thememanager.cpp" line="270"/>
         <source>Can&apos;t open the theme file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл темы &apos;%1&apos; для чтения.</translation>
     </message>
 </context>
 <context>
@@ -86,27 +90,27 @@
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="93"/>
         <source>Header</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="95"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="97"/>
         <source>Link options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры связывания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="156"/>
         <source>Header exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл существует</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="157"/>
         <source>Header already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл уже существует.</translation>
     </message>
 </context>
 <context>
@@ -114,17 +118,17 @@
     <message>
         <location filename="../debugger/debugger.cpp" line="1500"/>
         <source>Function</source>
-        <translation type="unfinished"></translation>
+        <translation>Функция</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1502"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1504"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
 </context>
 <context>
@@ -132,37 +136,37 @@
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="292"/>
         <source>Save file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение файла &apos;%1&apos; не удалось.</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="296"/>
         <source>Can&apos;t open file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для записи.</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="315"/>
         <source>Error in json file &apos;%1&apos;:%2 : %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка в json-файле &apos;%1&apos;:%2 : %3</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="341"/>
         <source>Can&apos;t open file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для чтения.</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="547"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="549"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../widgets/bookmarkmodel.cpp" line="551"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
 </context>
 <context>
@@ -170,17 +174,17 @@
     <message>
         <location filename="../debugger/debugger.cpp" line="1267"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1269"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1271"/>
         <source>Condition</source>
-        <translation type="unfinished"></translation>
+        <translation>Условие</translation>
     </message>
 </context>
 <context>
@@ -188,39 +192,39 @@
     <message>
         <location filename="../widgets/cpudialog.ui" line="14"/>
         <source>CPU Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация процессора</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="72"/>
         <location filename="../widgets/cpudialog.ui" line="75"/>
         <source>Step over one machine instruction</source>
-        <translation type="unfinished"></translation>
+        <translation>Перешагнуть через инструкцию процессора</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="85"/>
         <location filename="../widgets/cpudialog.ui" line="88"/>
         <source>Step into one machine instruction</source>
-        <translation type="unfinished"></translation>
+        <translation>Шагнуть внуть инструкции процессора</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="95"/>
         <source>Callstack</source>
-        <translation type="unfinished"></translation>
+        <translation>Стек вызовов</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="149"/>
         <source>AT&amp;&amp;T</source>
-        <translation type="unfinished"></translation>
+        <translation>AT&amp;&amp;T</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="159"/>
         <source>Intel</source>
-        <translation type="unfinished"></translation>
+        <translation>Intel</translation>
     </message>
     <message>
         <location filename="../widgets/cpudialog.ui" line="169"/>
         <source>Blend Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим наложения</translation>
     </message>
 </context>
 <context>
@@ -229,42 +233,42 @@
         <location filename="../widgets/choosethemedialog.ui" line="14"/>
         <location filename="../widgets/choosethemedialog.ui" line="20"/>
         <source>Choose Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор темы</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="58"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Темная тема</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="65"/>
         <source>Light Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Светлая тема</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="72"/>
         <source>System Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная тема</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="85"/>
         <source>Default Language:</source>
-        <translation type="unfinished"></translation>
+        <translation>Язык по умолчанию:</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="92"/>
         <source>C</source>
-        <translation type="unfinished"></translation>
+        <translation>C</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="102"/>
         <source>C++</source>
-        <translation type="unfinished"></translation>
+        <translation>C++</translation>
     </message>
     <message>
         <location filename="../widgets/choosethemedialog.ui" line="169"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
 </context>
 <context>
@@ -273,65 +277,65 @@
         <location filename="../codesnippetsmanager.cpp" line="57"/>
         <location filename="../codesnippetsmanager.cpp" line="66"/>
         <source>Load default code snippets failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось загрузить фрагменты кода по умолчанию</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="58"/>
         <location filename="../codesnippetsmanager.cpp" line="67"/>
         <source>Can&apos;t copy default code snippets &apos;%1&apos; to &apos;%2&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно копировать фрагменты кода по умолчанию &apos;%1&apos; в &apos;%2&apos;.</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="77"/>
         <location filename="../codesnippetsmanager.cpp" line="90"/>
         <source>Read code snippets failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение фрагментов кода не удалось</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="78"/>
         <source>Can&apos;t open code snippet file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для чтения файл с фрагментом кода &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="91"/>
         <source>Read code snippet file &apos;%1&apos; failed:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение файла фрагмента кода &apos;%1&apos; не удалось:%2</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="115"/>
         <location filename="../codesnippetsmanager.cpp" line="134"/>
         <source>Save code snippets failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение фрагментов кода не удалось</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="116"/>
         <source>Can&apos;t open code snippet file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи файл фрагмента кода &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="135"/>
         <source>Write to code snippet file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись в файл фрагмента кода &apos;%1&apos; не удалась.</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="150"/>
         <source>Load new file template failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка нового шаблона файла не удалась</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="151"/>
         <source>Can&apos;t open new file template file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для чтения новый шаблон файла &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="164"/>
         <source>Save new file template failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение нового шаблона файла не удалось</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="165"/>
         <source>Can&apos;t open new file template file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи новый шаблон файла &apos;%1&apos;.</translation>
     </message>
 </context>
 <context>
@@ -339,22 +343,22 @@
     <message>
         <location filename="../codesnippetsmanager.cpp" line="310"/>
         <source>Caption</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовок</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="312"/>
         <source>Completion Prefix</source>
-        <translation type="unfinished"></translation>
+        <translation>Префикс Дополнения</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="314"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
     <message>
         <location filename="../codesnippetsmanager.cpp" line="316"/>
         <source>Menu Section</source>
-        <translation type="unfinished"></translation>
+        <translation>Секция Меню</translation>
     </message>
 </context>
 <context>
@@ -363,12 +367,12 @@
         <location filename="../widgets/coloredit.cpp" line="73"/>
         <location filename="../widgets/coloredit.cpp" line="105"/>
         <source>NONE</source>
-        <translation type="unfinished"></translation>
+        <translation>НЕТ</translation>
     </message>
     <message>
         <location filename="../widgets/coloredit.cpp" line="111"/>
         <source>Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвет</translation>
     </message>
 </context>
 <context>
@@ -376,7 +380,7 @@
     <message>
         <location filename="../problems/competitivecompenionhandler.cpp" line="131"/>
         <source>Problem Case %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблемный случай %1</translation>
     </message>
 </context>
 <context>
@@ -384,131 +388,131 @@
     <message>
         <location filename="../compiler/compiler.cpp" line="62"/>
         <source>Clean before rebuild failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистка перед пересборкой не удалась.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="74"/>
         <source> - Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation> - Команда: %1</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="76"/>
         <source> - Command: %1 &gt; %2</source>
-        <translation type="unfinished"></translation>
+        <translation> - Команда: %1 &gt; %2</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="81"/>
         <source>Compile Result:</source>
-        <translation type="unfinished"></translation>
+        <translation>Результат компиляции:</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="83"/>
         <source>- Errors: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Ошибки: %1</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="84"/>
         <source>- Warnings: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Предупреждения: %1</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="86"/>
         <source>- Output Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Файл: %1</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="88"/>
         <source>- Output Size: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Размер файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="90"/>
         <source>- Compilation Time: %1 secs</source>
-        <translation type="unfinished"></translation>
+        <translation>- Время компиляции: %1 сек</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="181"/>
         <location filename="../compiler/compiler.cpp" line="183"/>
         <source>error:</source>
-        <translation type="unfinished"></translation>
+        <translation>ошибка:</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="183"/>
         <location filename="../compiler/compiler.cpp" line="196"/>
         <source>[Error] </source>
-        <translation type="unfinished"></translation>
+        <translation>[Ошибка] </translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="185"/>
         <location filename="../compiler/compiler.cpp" line="187"/>
         <source>warning:</source>
-        <translation type="unfinished"></translation>
+        <translation>предупреждение:</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="187"/>
         <location filename="../compiler/compiler.cpp" line="201"/>
         <source>[Warning] </source>
-        <translation type="unfinished"></translation>
+        <translation>[Предупреждение] </translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="199"/>
         <source>warning</source>
-        <translation type="unfinished"></translation>
+        <translation>предупреждение</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="204"/>
         <source>info</source>
-        <translation type="unfinished"></translation>
+        <translation>инфо</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="206"/>
         <source>[Info] </source>
-        <translation type="unfinished"></translation>
+        <translation>[Информация] </translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="209"/>
         <source>note</source>
-        <translation type="unfinished"></translation>
+        <translation>замечание</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="211"/>
         <source>[Note] </source>
-        <translation type="unfinished"></translation>
+        <translation>[Замечание] </translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="747"/>
         <source>Can&apos;t open file &quot;%1&quot; for write!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &quot;%1&quot; для записи!</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="799"/>
         <source>The compiler process for &apos;%1&apos; failed to start.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка запуска процесса компиляции для &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="803"/>
         <source>The compiler process crashed after starting successfully.</source>
-        <translation type="unfinished"></translation>
+        <translation>Процесс компиляции обрушился после успешного запуска.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="806"/>
         <source>The last waitFor...() function timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Время ожидания последнего вызова функции waitFor...() истекло.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="809"/>
         <source>An error occurred when attempting to write to the compiler process.</source>
-        <translation type="unfinished"></translation>
+        <translation>Произошла ошибка при попытке записи в процесс компиляции.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="812"/>
         <source>An error occurred when attempting to read from the compiler process.</source>
-        <translation type="unfinished"></translation>
+        <translation>Произошла ошибка при попытке чтения из процесса компиляции.</translation>
     </message>
     <message>
         <location filename="../compiler/compiler.cpp" line="815"/>
         <source>An unknown error occurred.</source>
-        <translation type="unfinished"></translation>
+        <translation>Произошла неизвестная ошибка.</translation>
     </message>
 </context>
 <context>
@@ -516,29 +520,29 @@
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="20"/>
         <source>Enable auto link</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить автоматическое связывание</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="44"/>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="47"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="54"/>
         <location filename="../settingsdialog/compilerautolinkwidget.ui" line="57"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilerautolinkwidget.cpp" line="65"/>
         <source>Save failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение не удалось.</translation>
     </message>
 </context>
 <context>
@@ -550,7 +554,7 @@
         <location filename="../compiler/compilermanager.cpp" line="186"/>
         <location filename="../compiler/compilermanager.cpp" line="205"/>
         <source>No compiler set</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет набора компиляторов</translation>
     </message>
     <message>
         <location filename="../compiler/compilermanager.cpp" line="85"/>
@@ -559,7 +563,7 @@
         <location filename="../compiler/compilermanager.cpp" line="187"/>
         <location filename="../compiler/compilermanager.cpp" line="206"/>
         <source>No compiler set is configured.</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляторов не настроен.</translation>
     </message>
     <message>
         <location filename="../compiler/compilermanager.cpp" line="85"/>
@@ -568,17 +572,17 @@
         <location filename="../compiler/compilermanager.cpp" line="187"/>
         <location filename="../compiler/compilermanager.cpp" line="206"/>
         <source>Can&apos;t start debugging.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя запустить отладку.</translation>
     </message>
     <message>
         <location filename="../compiler/compilermanager.cpp" line="297"/>
         <source>Can&apos;t find Console Pauser</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найден Остановщик Консоли</translation>
     </message>
     <message>
         <location filename="../compiler/compilermanager.cpp" line="298"/>
         <source>Console Pauser &quot;%1&quot; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановщик Консоли &quot;%1&quot; не существует!</translation>
     </message>
 </context>
 <context>
@@ -586,30 +590,30 @@
     <message>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="41"/>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="44"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="54"/>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="57"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="67"/>
         <location filename="../settingsdialog/compilersetdirectorieswidget.ui" line="70"/>
         <source>Remove Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить ошибочный</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetdirectorieswidget.cpp" line="77"/>
         <source>Choose Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор каталога</translation>
     </message>
 </context>
 <context>
@@ -617,117 +621,117 @@
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="20"/>
         <source>Compiler set to config</source>
-        <translation type="unfinished"></translation>
+        <translation>Настрока набора компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="35"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="38"/>
         <source>Auto Find Compilers</source>
-        <translation type="unfinished"></translation>
+        <translation>Автопоиск компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="45"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="48"/>
         <source>Find Compiler in the Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Искать компилятор в каталоге</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="55"/>
         <source>Specify the compiler executable file</source>
-        <translation type="unfinished"></translation>
+        <translation>Указать исполняемый файл компилятора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="58"/>
         <source>Add Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить компилятор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="65"/>
         <source>Copy current compiler set</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать текущий набор компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="68"/>
         <source>Copy compiler set</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать набор компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="75"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="78"/>
         <source>Add Blank Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить пустой набор компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="85"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="88"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="95"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="98"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="115"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Основное</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="136"/>
         <source>Convert Executable&apos;s Charset as</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразовать исполняемый файл в кодировку</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="165"/>
         <source>Statically link libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Статическое связывание библиотек</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="172"/>
         <source>Don&apos;t localize compiler output messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Не переводить сообщения, выводимые компилятором</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="179"/>
         <source>Survive auto-finds</source>
-        <translation type="unfinished"></translation>
+        <translation>Автопоиск путей выживания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="186"/>
         <source>Add the following arguments when calling the compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить следующие аргументы при запуске компилятора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="196"/>
         <source>Add the following arguments when calling the linker</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить следующие аргументы при запуске связывания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="207"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="233"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталоги</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="262"/>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Программы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="277"/>
         <source>Choose Debugger</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор отладчика</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="280"/>
@@ -737,217 +741,217 @@
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="347"/>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="373"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="294"/>
         <source>Resource Compiler（windres)</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор ресурсов（windres)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="307"/>
         <source>Choose make</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор сборщика</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="317"/>
         <source>C Compiler(gcc)</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си(gcc)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="324"/>
         <source>make</source>
-        <translation type="unfinished"></translation>
+        <translation>Сборщик (make)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="334"/>
         <source>Choose C++ Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор компилятора Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="344"/>
         <source>Choose C Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор компилятора Си</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="357"/>
         <source>gdb server</source>
-        <translation type="unfinished"></translation>
+        <translation>gdb-сервер</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="370"/>
         <source>Choose Resource Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор компилятора ресурсов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="380"/>
         <source>C++ Compiler(g++)</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си++ (g++)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="387"/>
         <source>gdb</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик (gdb)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="411"/>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Вывод</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="430"/>
         <source>Compiling output suffix</source>
-        <translation type="unfinished"></translation>
+        <translation>Суффикс вывода компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="437"/>
         <source>Executable suffix</source>
-        <translation type="unfinished"></translation>
+        <translation>Суффикс исполнимого файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="444"/>
         <source>Compilation Stages</source>
-        <translation type="unfinished"></translation>
+        <translation>Этапы компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="450"/>
         <source>Stop after the preprocessing stage</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановка после этапа работы препроцессора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="457"/>
         <source>Stop after the compilation proper stage</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановка после завершения соответствующей стадии компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="464"/>
         <source>Link and generate the executable </source>
-        <translation type="unfinished"></translation>
+        <translation>Сборка и создание исполняемого файла </translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="480"/>
         <source>Preprocessing output suffix</source>
-        <translation type="unfinished"></translation>
+        <translation>Суффикс вывода препроцессора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.ui" line="509"/>
         <source>Binary suffix</source>
-        <translation type="unfinished"></translation>
+        <translation>Суффикс двоичного файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="67"/>
         <source>System Default(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная по умолчанию(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="68"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="315"/>
         <source>Red Panda C++ will clear previously found compiler list and search for compilers in the following locations:&lt;br /&gt; &apos;%1&apos;&lt;br /&gt; &apos;%2&apos;&lt;br /&gt;Do you really want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Красная Панда Си++ очистит список ранее найденных компиляторов и выполнит поиск компиляторов в следующих местах:&lt;br /&gt; &apos;%1&apos;&lt;br /&gt; &apos;%2&apos;&lt;br /&gt; Вы действительно хотите продолжить?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="320"/>
         <source>Red Panda C++ will clear previously found compiler list and search for compilers in the the PATH. &lt;br /&gt;Do you really want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Красная Панда Си++ очистит список ранее найденных компиляторов и выполнит поиск компиляторов в PATH&lt;br /&gt; Вы действительно хотите продолжить?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="323"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтверждение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="327"/>
         <source>Searching for compilers...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск компиляторов...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="328"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Прервать</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="335"/>
         <source>Searching...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="342"/>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="370"/>
         <source>Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Провал</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="342"/>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="370"/>
         <source>Can&apos;t find any compiler.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось найти компилятор.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="348"/>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="379"/>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="396"/>
         <source>Compiler Set Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя набора компиляторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="348"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="361"/>
         <source>Compiler Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог компилятора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="379"/>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="396"/>
         <source>New name</source>
-        <translation type="unfinished"></translation>
+        <translation>Новое имя</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="380"/>
         <source>%1 Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Копия</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="472"/>
         <source>Locate C Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение компилятора Си</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="484"/>
         <source>Locate C++ Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение компилятора Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="496"/>
         <source>Locate Make</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение Make</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="508"/>
         <source>Locate GDB</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение GDB</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="520"/>
         <source>Locate GDB Server</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение GDB-сервера</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="532"/>
         <source>Locate windres</source>
-        <translation type="unfinished"></translation>
+        <translation>Обнаружение windres</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="542"/>
         <source>Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор</translation>
     </message>
 </context>
 <context>
@@ -958,28 +962,28 @@
         <location filename="../cpprefacter.cpp" line="352"/>
         <location filename="../cpprefacter.cpp" line="402"/>
         <source>Rename Symbol Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка переименования символа</translation>
     </message>
     <message>
         <location filename="../cpprefacter.cpp" line="148"/>
         <source>Can&apos;t rename symbols not defined in this file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя переименовать символы, не определенные в этом файле.</translation>
     </message>
     <message>
         <location filename="../cpprefacter.cpp" line="161"/>
         <source>New symbol already exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый символ уже существует!</translation>
     </message>
     <message>
         <location filename="../cpprefacter.cpp" line="192"/>
         <location filename="../cpprefacter.cpp" line="203"/>
         <source>Searching...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск...</translation>
     </message>
     <message>
         <location filename="../cpprefacter.cpp" line="193"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Прекратить</translation>
     </message>
 </context>
 <context>
@@ -987,17 +991,17 @@
     <message>
         <location filename="../widgets/custommakefileinfodialog.ui" line="14"/>
         <source>Information for custom makefile</source>
-        <translation type="unfinished"></translation>
+        <translation>Информацию о пользовательском makefile</translation>
     </message>
     <message>
         <location filename="../widgets/custommakefileinfodialog.ui" line="20"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../widgets/custommakefileinfodialog.ui" line="53"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red Panda C++&apos;s Makefile has two important targets:&lt;/p&gt;&lt;p&gt;- all (which builds the executable)&lt;/p&gt;&lt;p&gt;- clean (which cleans up object files)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;all&amp;quot; depends on 2 targets: all-before and all-after. All-before&lt;/p&gt;&lt;p&gt;gets called before the compilation process, and all-after gets&lt;/p&gt;&lt;p&gt;called after the compilation process.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;clean&amp;quot; depends on the target clean-custom, which gets called&lt;/p&gt;&lt;p&gt;before the cleaning process.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;You can change the Makefile&apos;s behavior by defining the targets&lt;/p&gt;&lt;p&gt;that &amp;quot;all&amp;quot; and &amp;quot;clean&amp;quot; depend on.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;У Red Panda C++&apos;s Makefile есть две основных цели:&lt;/p&gt;&lt;p&gt;- all (которая собирает исполняемый файл)&lt;/p&gt;&lt;p&gt;- clean (которая удаляет объектные файлы)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;all&amp;quot; зависит от выполнения двух целей: all-before и all-after. All-before вызывается перед процессом компиляции, all-after вызывается после завершения процесса компиляции.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&amp;quot;clean&amp;quot; зависит от выполнения цели clean-custom, которая вызывается&lt;/p&gt;&lt;p&gt;перед процессом очистки.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Вы можете изменить поведение Makefile с помощью переопределния целей&lt;/p&gt;&lt;p&gt;от которых зависят &amp;quot;all&amp;quot; и &amp;quot;clean&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -1005,122 +1009,122 @@
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="20"/>
         <source>Autosave watches</source>
-        <translation type="unfinished"></translation>
+        <translation>Автосохранение наблюдаемых переменных</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="42"/>
         <source>Max number of array elements displayed</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимальное число отображаемых элементов массива</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="87"/>
         <source>Max  characters of a string displayed</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимальное количество отображаемых символов строки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="117"/>
         <source>Use GDB Server to debug</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать GDB-сервер для отладки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="138"/>
         <source>GDB Server Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Порт GDB-сервера</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="171"/>
         <source>Skip header files when step into</source>
-        <translation type="unfinished"></translation>
+        <translation>Пропускать загловочные файлы при шаге внутрь</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="189"/>
         <source>System library</source>
-        <translation type="unfinished"></translation>
+        <translation>Системные библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="196"/>
         <source>Project library</source>
-        <translation type="unfinished"></translation>
+        <translation>Библиотеки проекта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="203"/>
         <source>Custom library</source>
-        <translation type="unfinished"></translation>
+        <translation>Пользовательские библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="226"/>
         <source>Debug Console</source>
-        <translation type="unfinished"></translation>
+        <translation>Консоль отладки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="262"/>
         <source>Font:</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифт:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="272"/>
         <source>Show only monospaced fonts</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать только моноширинные шрифты</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="310"/>
         <source>Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="340"/>
         <source>Show detail debug logs</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать подробные протоколы отладки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="350"/>
         <source>Memory View</source>
-        <translation type="unfinished"></translation>
+        <translation>Просмотр памяти</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="368"/>
         <source>Rows</source>
-        <translation type="unfinished"></translation>
+        <translation>Строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="388"/>
         <source>Columns</source>
-        <translation type="unfinished"></translation>
+        <translation>Колонок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="421"/>
         <source>CPU Window</source>
-        <translation type="unfinished"></translation>
+        <translation>Окно Процессора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="439"/>
         <source>Show CPU Window when signal received</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать Окно Процессора при получении сигнала</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="446"/>
         <source>Show disassembly code in blend mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать дизассемблированный код в режиме наложения (blend mode)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="468"/>
         <source>Disassembly Coding Style:</source>
-        <translation type="unfinished"></translation>
+        <translation>Стиль кода дизассемблирования:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="499"/>
         <source>AT&amp;&amp;T</source>
-        <translation type="unfinished"></translation>
+        <translation>AT&amp;&amp;T</translation>
     </message>
     <message>
         <location filename="../settingsdialog/debuggeneralwidget.ui" line="509"/>
         <source>Intel</source>
-        <translation type="unfinished"></translation>
+        <translation>Intel</translation>
     </message>
 </context>
 <context>
@@ -1128,102 +1132,102 @@
     <message>
         <location filename="../debugger/debugger.cpp" line="97"/>
         <source>No compiler set</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет набора компиляторов</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="98"/>
         <source>No compiler set is configured.</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляоров не настроен.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="98"/>
         <source>Can&apos;t start debugging.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно запустить отладку.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="123"/>
         <source>Debugger not exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик не существует</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="124"/>
         <source>Can&apos;&apos;t find debugger (gdb) in : &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найден отладчик (gdb) в : &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="126"/>
         <source>Please check the &quot;program&quot; page of compiler settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте вкладку &quot;Программа&quot; настроек компилятора.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="132"/>
         <source>GDB Server path error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка пути к GDB-серверу</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="133"/>
         <source>GDB Server&apos;s path &quot;%1&quot; contains non-ascii characters.</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к GDB-серверу &quot;%1&quot; содержит не-ascii символы.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="136"/>
         <source>This prevents it from executing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Это предотвращает его выполнение.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="141"/>
         <source>GDB Server not exists</source>
-        <translation type="unfinished"></translation>
+        <translation>GDB-сервер не сущестует</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="142"/>
         <source>Can&apos;&apos;t find gdb server in : &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найден gdb-сервер в : &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="585"/>
         <source>Execute to evaluate</source>
-        <translation type="unfinished"></translation>
+        <translation>Выполнить для вычисления</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="929"/>
         <source>Save file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение файла &apos;%1&apos; не удалось.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="933"/>
         <source>Can&apos;t open file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для записи.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="958"/>
         <source>Error in json file &apos;%1&apos;:%2 : %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка в json-файле &apos;%1&apos;:%2 : %3</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="977"/>
         <source>Can&apos;t open file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для чтения.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1006"/>
         <source>Compile</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1007"/>
         <source>Source file is more recent than executable.</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный файл является более поздним, чем исполняемый файл.</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1007"/>
         <source>Recompile?</source>
-        <translation type="unfinished"></translation>
+        <translation>Перекомпилировать?</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1045"/>
         <source>Signal &quot;%1&quot; Received: </source>
-        <translation type="unfinished"></translation>
+        <translation>Сигнал &quot;%1&quot; получен: </translation>
     </message>
 </context>
 <context>
@@ -1232,87 +1236,87 @@
         <location filename="../editor.cpp" line="127"/>
         <location filename="../editor.cpp" line="632"/>
         <source>Error Load File</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки файла</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="382"/>
         <location filename="../editor.cpp" line="453"/>
         <location filename="../editor.cpp" line="482"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="418"/>
         <source>Save As</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить как</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="454"/>
         <source>File %1 already opened!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл %1 уже открыт!</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="2207"/>
         <source>hex: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>hex: %1</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="2209"/>
         <source>dec: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>dec: %1</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="3381"/>
         <source>Print Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Печать документа</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="4130"/>
         <location filename="../editor.cpp" line="4155"/>
         <location filename="../editor.cpp" line="4201"/>
         <source>Ctrl+click for more info</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+щелчок для подробностей</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5143"/>
         <source>astyle not found</source>
-        <translation type="unfinished"></translation>
+        <translation>astyle не найден</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5144"/>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="331"/>
         <source>Can&apos;t find astyle in &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не могу найти astyle в &quot;%1&quot;.</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5152"/>
         <source>Reformatting content using astyle...</source>
-        <translation type="unfinished"></translation>
+        <translation>Переформатирование содержимого с помощью astyle...</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5154"/>
         <source>- Astyle: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Astyle: %1</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5155"/>
         <source>- Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Команда: %1</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5323"/>
         <source>Break point condition</source>
-        <translation type="unfinished"></translation>
+        <translation>Условие точки останова</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5324"/>
         <source>Enter the condition of the breakpoint:</source>
-        <translation type="unfinished"></translation>
+        <translation>Введите условие для точки останова:</translation>
     </message>
     <message>
         <location filename="../editor.cpp" line="5584"/>
         <source>Readonly</source>
-        <translation type="unfinished"></translation>
+        <translation>Только чтение</translation>
     </message>
 </context>
 <context>
@@ -1320,79 +1324,79 @@
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="20"/>
         <source>Auto backup editing contents</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматическое резервное копирование редактируемого содержимого</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="27"/>
         <source>Enable auto save</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить автосохранение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="51"/>
         <source>Time interval:</source>
-        <translation type="unfinished"></translation>
+        <translation>Временной интервал:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="58"/>
         <source>minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>минут</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="87"/>
         <source>Objects to save</source>
-        <translation type="unfinished"></translation>
+        <translation>Объекты для сохранения</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="93"/>
         <source>Current File</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущий файл</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="100"/>
         <source>All files opened</source>
-        <translation type="unfinished"></translation>
+        <translation>Все открыте файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="107"/>
         <source>Project files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы проекта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="117"/>
         <source>Save strategy</source>
-        <translation type="unfinished"></translation>
+        <translation>Стратегия сохрания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="123"/>
         <source>Overwrite</source>
-        <translation type="unfinished"></translation>
+        <translation>Перезаписывать</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="130"/>
         <source>Append UNIX timestamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять метку времени UNIX</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="137"/>
         <source>Append formatted timestamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять форматированную метку времени</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.ui" line="147"/>
         <source>Demo file name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Демонстрационное имя файла:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorautosavewidget.cpp" line="38"/>
         <location filename="../settingsdialog/editorautosavewidget.cpp" line="40"/>
         <location filename="../settingsdialog/editorautosavewidget.cpp" line="44"/>
         <source>Demo file name: </source>
-        <translation type="unfinished"></translation>
+        <translation>Демонстрационное имя файла: </translation>
     </message>
 </context>
 <context>
@@ -1400,50 +1404,50 @@
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="35"/>
         <source>Copy with format as</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирование с формате</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="61"/>
         <source>Copy &amp;&amp; Export As HTML</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирование и экспорт в HTML</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="70"/>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="151"/>
         <source>Use background color</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать фоновый цвет</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="77"/>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="158"/>
         <source>Use editor&apos;s color scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать цветовую схему редактора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="84"/>
         <source>Copy with line number</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирование с номерами строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="91"/>
         <source>Recalc line number</source>
-        <translation type="unfinished"></translation>
+        <translation>Пересчёт номеров строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="113"/>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="180"/>
         <source>Color scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>Цветовая схема</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorclipboardwidget.ui" line="142"/>
         <source>Export As RTF</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт в RTF</translation>
     </message>
 </context>
 <context>
@@ -1451,102 +1455,102 @@
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="20"/>
         <source>Enable code competion</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить дополнение кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="47"/>
         <source>Minimum id length to show completion </source>
-        <translation type="unfinished"></translation>
+        <translation>Минимальная длина идентификатора для дополнения кода </translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="80"/>
         <source>Editors share one code parser</source>
-        <translation type="unfinished"></translation>
+        <translation>Редакторы используют один и тот же анализатор кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="87"/>
         <source>Clear all parsed symbols when editor is hidden</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистить все проанализированные символы, когда редактор скрыт</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="94"/>
         <source>Show completion suggestions while typing</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать предложения по завершению при вводе текста</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="101"/>
         <source>Engine options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры движка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="107"/>
         <source>Scan local header files</source>
-        <translation type="unfinished"></translation>
+        <translation>Сканировать локальные заголовочные файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="114"/>
         <source>Scan system header files</source>
-        <translation type="unfinished"></translation>
+        <translation>Сканировать системные заголовочные файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="124"/>
         <source>Show keywords in suggestions</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать ключевые слова в предложениях</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="131"/>
         <source>Show code snippets in suggestions</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать фрагменты кода в предложениях</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="138"/>
         <source>Append () when complete functions</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять () при завершении функций</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="145"/>
         <source>Ignore case when search suggestions</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать регистр при поиска предложений</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="152"/>
         <source>Prefer local symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Предпочитать локальные символы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="159"/>
         <source>Hide symbols start with underscore</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрывать символы, начинающиеся со знака подчеркивания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="166"/>
         <source>Hide symbols start with two underscores</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрывать символы, начинающиеся с двух знаков подчеркивания</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="188"/>
         <source>Prefer symbols mostly used</source>
-        <translation type="unfinished"></translation>
+        <translation>Предпочитать наиболее часто используемые символы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="208"/>
         <source>Clear usage data</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистка данных об использовании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="233"/>
         <source>Completion suggestion window width:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ширина окна предложения дополнения:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcodecompletionwidget.ui" line="263"/>
         <source>Completion suggestion window height:</source>
-        <translation type="unfinished"></translation>
+        <translation>Высота окна предложения дополнения:</translation>
     </message>
 </context>
 <context>
@@ -1554,87 +1558,87 @@
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="20"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="44"/>
         <source>Scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>Схема</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="54"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="188"/>
         <source>Background:</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвет фона:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="195"/>
         <source>Foreground:</source>
-        <translation type="unfinished"></translation>
+        <translation>Основной цвет:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="265"/>
         <source>Font Styles</source>
-        <translation type="unfinished"></translation>
+        <translation>Стили шрифта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="271"/>
         <source>Bold</source>
-        <translation type="unfinished"></translation>
+        <translation>Жирный</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="278"/>
         <source>Italic</source>
-        <translation type="unfinished"></translation>
+        <translation>Курсив</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="285"/>
         <source>Strikeout</source>
-        <translation type="unfinished"></translation>
+        <translation>Зачеркнутый</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="292"/>
         <source>Underlined</source>
-        <translation type="unfinished"></translation>
+        <translation>Подчеркнутый</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="349"/>
         <source>Rainbow parenthesis</source>
-        <translation type="unfinished"></translation>
+        <translation>Радужные скобки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="356"/>
         <source>Duplicate...</source>
-        <translation type="unfinished"></translation>
+        <translation>Дублировать...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="361"/>
         <source>Rename...</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="366"/>
         <source>Restore to Default</source>
-        <translation type="unfinished"></translation>
+        <translation>Восстановить по умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="371"/>
         <source>Import Scheme...</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт схемы...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="376"/>
         <source>Export...</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.ui" line="381"/>
         <source>Delete...</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="345"/>
@@ -1646,48 +1650,48 @@
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="465"/>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="488"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="387"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="387"/>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="458"/>
         <source>Color Scheme Files (*.scheme)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы цветовых схем (*.scheme)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="398"/>
         <source>&apos;%1&apos; is not a valid name for color scheme file.</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; - некорректное имя для файла цветовой схемы.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="416"/>
         <source>New scheme name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя новой схемы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="420"/>
         <source>&apos;%1&apos; is not a valid scheme name!</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; - некорректное имя схемы!</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="458"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="474"/>
         <source>Confirm Delete Scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтверждение удаления схемы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcolorschemewidget.cpp" line="475"/>
         <source>Scheme &apos;%1&apos; will be deleted!&lt;br /&gt;Do you really want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Схема &apos;%1&apos; будет удалена!&lt;br /&gt;Вы действительно хотите продолжить?</translation>
     </message>
 </context>
 <context>
@@ -1695,12 +1699,12 @@
     <message>
         <location filename="../widgets/editorfontdialog.ui" line="14"/>
         <source>Choose Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор шрифта</translation>
     </message>
     <message>
         <location filename="../widgets/editorfontdialog.ui" line="39"/>
         <source>Show only monospaced fonts</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать только моноширинные шрифты</translation>
     </message>
 </context>
 <context>
@@ -1708,166 +1712,166 @@
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="20"/>
         <source>Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифт</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="31"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="34"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="41"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="44"/>
         <source>Modify</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="51"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="54"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Сбросить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="61"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="64"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="84"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="87"/>
         <source>Move down</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить вниз</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="94"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="97"/>
         <source>Move up</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить вверх</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="104"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="107"/>
         <source>Move to top</source>
-        <translation type="unfinished"></translation>
+        <translation>В начало списка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="114"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="117"/>
         <source>Move to bottom</source>
-        <translation type="unfinished"></translation>
+        <translation>В конец списка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="153"/>
         <source>Enable ligatures support</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить поддержку лигатур</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="160"/>
         <source>Force fixed width</source>
-        <translation type="unfinished"></translation>
+        <translation>Принудительно фиксированная ширина</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="183"/>
         <source>Line Spacing:</source>
-        <translation type="unfinished"></translation>
+        <translation>Межстрочный интервал:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="190"/>
         <location filename="../settingsdialog/editorfontwidget.ui" line="542"/>
         <source>Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="285"/>
         <source>Show whitespaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать пустые места</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="291"/>
         <source>Leading</source>
-        <translation type="unfinished"></translation>
+        <translation>В начале</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="298"/>
         <source>Inner</source>
-        <translation type="unfinished"></translation>
+        <translation>Внутри</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="305"/>
         <source>Trailing</source>
-        <translation type="unfinished"></translation>
+        <translation>В конце</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="312"/>
         <source>Line break</source>
-        <translation type="unfinished"></translation>
+        <translation>Разрывы строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="322"/>
         <source>Gutter</source>
-        <translation type="unfinished"></translation>
+        <translation>Поле (корешок)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="343"/>
         <source>Gutter is visible</source>
-        <translation type="unfinished"></translation>
+        <translation>Видимое поле</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="365"/>
         <source>Left Offset</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ слева</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="382"/>
         <source>Right Offset</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ справа</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="415"/>
         <source>Show Line Numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать номера строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="439"/>
         <source>Add leading zeros to line numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять ведущие нули к номерам строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="446"/>
         <source>Line numbers starts at zero</source>
-        <translation type="unfinished"></translation>
+        <translation>Нумерация строк с нуля</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="453"/>
         <source>Auto calculate the digit count of line number</source>
-        <translation type="unfinished"></translation>
+        <translation>Автовычисление количества цифр в номере строки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="475"/>
         <source>Digit count</source>
-        <translation type="unfinished"></translation>
+        <translation>Количество цифр</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="511"/>
         <source>Use Custom Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать пользовательский шрифт</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="535"/>
         <source>Font:</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифт:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorfontwidget.ui" line="630"/>
         <source>Show only monospaced fonts</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать только моноширинные шрифты</translation>
     </message>
 </context>
 <context>
@@ -1875,22 +1879,22 @@
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.cpp" line="30"/>
         <source>Vertical Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Вертикальная линия</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.cpp" line="31"/>
         <source>Horizontal Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Горизонтальная линия</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.cpp" line="32"/>
         <source>Half Block</source>
-        <translation type="unfinished"></translation>
+        <translation>ПолуБлок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.cpp" line="33"/>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Блок</translation>
     </message>
 </context>
 <context>
@@ -1898,82 +1902,82 @@
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="20"/>
         <source>Open system header files in read only mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Открывать системные заголовочные файлы в режиме только для чтения</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="27"/>
         <source>Auto load files being open when Red Panda C++ last exited.</source>
-        <translation type="unfinished"></translation>
+        <translation>Автозагрузка файлов, открытых при последнем завершении работы Red Panda C++.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="34"/>
         <source>Parse TODOs</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбор запланированных дел (TODO)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="77"/>
         <source>Action before saving files</source>
-        <translation type="unfinished"></translation>
+        <translation>Действие перед сохранением файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="83"/>
         <source>Reformat</source>
-        <translation type="unfinished"></translation>
+        <translation>Переформатирование</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="90"/>
         <source>Trim trailing spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Обрезка конечных пробелов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="97"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="120"/>
         <source>Auto detect encoding when openning files</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоопределение кодировки открываемых файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="127"/>
         <source>Default file encoding</source>
-        <translation type="unfinished"></translation>
+        <translation>Кодировка файлов по умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="155"/>
         <source>Default file type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип файла по умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="161"/>
         <source>C files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Си</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.ui" line="168"/>
         <source>C++ files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.cpp" line="102"/>
         <source>System Default(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная по-умолчанию(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.cpp" line="103"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editormiscwidget.cpp" line="104"/>
         <source>UTF-8 BOM</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8 BOM</translation>
     </message>
 </context>
 <context>
@@ -1981,37 +1985,37 @@
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="24"/>
         <source>Code Snippets</source>
-        <translation type="unfinished"></translation>
+        <translation>Фрагменты кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="83"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="90"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="126"/>
         <source>New C File Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый шаблон файла Cи</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="143"/>
         <source>New C++ File Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый шаблон файла Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsnippetwidget.ui" line="160"/>
         <source>New GAS File Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый шаблон файла GAS</translation>
     </message>
 </context>
 <context>
@@ -2019,62 +2023,62 @@
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="33"/>
         <source>Complete Symbols</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение символов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="60"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Детали</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="78"/>
         <source>Complete Braces{}</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение фигурных скобок {}</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="85"/>
         <source>Complete Brackets []</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение квадратных скобок []</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="92"/>
         <source>Complete Parenthesis ()</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение круглых скобок ()</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="99"/>
         <source>Complete Multiline Comments /**/</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение многострочных комментариев /**/</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="106"/>
         <source>Complete Single Quotations &apos;&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение одиночных кавычек &apos;&apos;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="113"/>
         <source>Complete Double Quotations &quot;&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение двойных кавычек &quot;&quot;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="120"/>
         <source>Complete #include &lt;&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение #include &lt;&gt;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="130"/>
         <source>Skip matching symbols while typing</source>
-        <translation type="unfinished"></translation>
+        <translation>Пропускать совпадающие символы при вводе</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsymbolcompletionwidget.ui" line="143"/>
         <source>Remove symbol pairs when delete chars</source>
-        <translation type="unfinished"></translation>
+        <translation>Удаление парного символа при удалении символа</translation>
     </message>
 </context>
 <context>
@@ -2082,22 +2086,22 @@
     <message>
         <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="33"/>
         <source>Enable Auto Syntax Check</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить автопроверку синтаксиса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="42"/>
         <source>Check when save/load file</source>
-        <translation type="unfinished"></translation>
+        <translation>Отслеживать сохранение/загрузку файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorsyntaxcheckwidget.ui" line="49"/>
         <source>Check when count of lines changed</source>
-        <translation type="unfinished"></translation>
+        <translation>Отслеживать изменения количества строк</translation>
     </message>
 </context>
 <context>
@@ -2105,47 +2109,47 @@
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="20"/>
         <source>Show function tips</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать подсказки по функциям</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="27"/>
         <source>Enable mouse hover tooltips</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить всплывающие подсказки при наведении мыши</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="36"/>
         <source>Show syntax issue tooltips</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать всплывающие подсказки по проблемам синтаксиса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="43"/>
         <source>Show full header filename tooltips</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать всплывающие подсказки с полными именами заголовочных файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="50"/>
         <source>Show identifier definition tooltips</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать всплывающие подсказки по определениям идентификаторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="57"/>
         <source>Show expression value tooltips when debugging</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать всплывающие подсказки по значению выражения при отладке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="82"/>
         <source>Tool tips delay</source>
-        <translation type="unfinished"></translation>
+        <translation>Задержка всплывающих подсказок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editortooltipswidget.ui" line="89"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>мс</translation>
     </message>
 </context>
 <context>
@@ -2153,93 +2157,98 @@
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="38"/>
         <source>Use custom icon set</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать пользовательский набор значков</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="79"/>
         <source>*Needs restart</source>
-        <translation type="unfinished"></translation>
+        <translation>*Необходим перезапуск</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="190"/>
         <source>Language:</source>
-        <translation type="unfinished"></translation>
+        <translation>Язык:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="197"/>
         <source>Theme:</source>
-        <translation type="unfinished"></translation>
+        <translation>Тема:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="204"/>
         <source>Icon Set:</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор значков:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="211"/>
         <source>Font:</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифт:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="218"/>
         <source>Font Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер шрифта:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="243"/>
         <source>Create a customized copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Создание пользовательской копии</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="246"/>
         <source>Customize</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="253"/>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="256"/>
         <source>Remove custom theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить пользовательскую тему</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="263"/>
         <source>Open custom themes folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть пользовательский каталог с темами</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="266"/>
         <source>Open Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть каталог</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.ui" line="289"/>
         <source>Icon Zoom:</source>
-        <translation type="unfinished"></translation>
+        <translation>Масштаб значков:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.cpp" line="106"/>
         <source>English</source>
-        <translation type="unfinished"></translation>
+        <translation>Английский</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.cpp" line="107"/>
         <source>Portuguese</source>
-        <translation type="unfinished"></translation>
+        <translation>Португальский</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.cpp" line="108"/>
         <source>Simplified Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation>Упрощенный Китайский</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentappearancewidget.cpp" line="109"/>
         <source>Traditional Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation>Традиционный Китайский</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog/environmentappearancewidget.cpp" line="110"/>
+        <source>Russian</source>
+        <translation>Русский</translation>
     </message>
 </context>
 <context>
@@ -2247,32 +2256,32 @@
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="20"/>
         <source>Open Each File In</source>
-        <translation type="unfinished"></translation>
+        <translation>Открывать каждый файл в</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="26"/>
         <source>Independent Red Panda C++ applications</source>
-        <translation type="unfinished"></translation>
+        <translation>Отдельных приложениях Red Panda C++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="33"/>
         <source>The same Red Panda C++ application</source>
-        <translation type="unfinished"></translation>
+        <translation>В одном приложении Red Panda C++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="43"/>
         <source>File Types:</source>
-        <translation type="unfinished"></translation>
+        <translation>Типы файлов:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.ui" line="59"/>
         <source>Just check or uncheck for which file types Red Panda C++ wil be registered as the default application to open them ... </source>
-        <translation type="unfinished"></translation>
+        <translation>Просто установите или снимите флажок, для открытия каких типов файлов Red Panda C++ будет зарегистрирован в качестве приложения по умолчанию ... </translation>
     </message>
 </context>
 <context>
@@ -2280,7 +2289,7 @@
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="20"/>
@@ -2289,52 +2298,52 @@
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="86"/>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="120"/>
         <source>Open in browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="50"/>
         <source>Custom icon sets folder:</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог пользовательского набора значков:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="73"/>
         <source>Remove all custom settings and exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все пользовательские настройки и выйти</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="93"/>
         <source>Configuration folder:</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог настроек:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="107"/>
         <source>Custom theme folder:</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог пользовательской темы:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.ui" line="117"/>
         <source>Open custom theme folder in file browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть каталог пользовательской темы в проводнике</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.cpp" line="66"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтверждение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.cpp" line="67"/>
         <source>Do you really want to delete all custom settings?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить все пользовательские настройки?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.cpp" line="73"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfolderswidget.cpp" line="74"/>
         <source>Failed to delete custom settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось удалить пользовательские настройки.</translation>
     </message>
 </context>
 <context>
@@ -2342,22 +2351,22 @@
     <message>
         <location filename="../settingsdialog/environmentperformancewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentperformancewidget.ui" line="20"/>
         <source>Reduce Memory Usage</source>
-        <translation type="unfinished"></translation>
+        <translation>Сокращение использования памяти</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentperformancewidget.ui" line="26"/>
         <source>Editors share one code parser</source>
-        <translation type="unfinished"></translation>
+        <translation>Редакторы используют один и тот же анализатор кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentperformancewidget.ui" line="33"/>
         <source>Auto clear parsed symbols when editor hidden</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматическая очистка проанализированных символов, когда редактор скрыт</translation>
     </message>
 </context>
 <context>
@@ -2365,54 +2374,54 @@
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="20"/>
         <source>Use custom terminal</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать пользовательский терминал</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="46"/>
         <source>Args. pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаблон аргументов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="53"/>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="63"/>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="87"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="60"/>
         <source>Auto Detect Terminal Arguments Pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоопределение шаблона аргументов терминала</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="70"/>
         <source>Terminal</source>
-        <translation type="unfinished"></translation>
+        <translation>Терминал</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="77"/>
         <source>Cmd. preview</source>
-        <translation type="unfinished"></translation>
+        <translation>Предпросмотр команд</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.ui" line="84"/>
         <source>Test Command</source>
-        <translation type="unfinished"></translation>
+        <translation>Команда тестирования</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.cpp" line="104"/>
         <source>Choose Terminal Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор программы терминала</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.cpp" line="106"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -2420,27 +2429,27 @@
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="86"/>
         <source>action</source>
-        <translation type="unfinished"></translation>
+        <translation>action</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="142"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="143"/>
         <source>Shortcut &quot;%1&quot; is used by &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сочетание клавиш &quot;%1&quot; используется &quot;%2&quot;.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="163"/>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Действие</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.cpp" line="165"/>
         <source>Shortcut</source>
-        <translation type="unfinished"></translation>
+        <translation>Сочетание клавиш</translation>
     </message>
 </context>
 <context>
@@ -2448,12 +2457,12 @@
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentshortcutwidget.ui" line="35"/>
         <source>Filter Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>Фильтры действий</translation>
     </message>
 </context>
 <context>
@@ -2461,22 +2470,22 @@
     <message>
         <location filename="../compiler/executablerunner.cpp" line="262"/>
         <source>The runner process &apos;%1&apos; failed to start.</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск процесса запуска &apos;%1&apos; не удался.</translation>
     </message>
     <message>
         <location filename="../compiler/executablerunner.cpp" line="269"/>
         <source>The last waitFor...() function timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Время ожидания последней функции waitFor...() истекло.</translation>
     </message>
     <message>
         <location filename="../compiler/executablerunner.cpp" line="272"/>
         <source>An error occurred when attempting to write to the runner process.</source>
-        <translation type="unfinished"></translation>
+        <translation>При попытке записи в процесс запуска произошла ошибка.</translation>
     </message>
     <message>
         <location filename="../compiler/executablerunner.cpp" line="275"/>
         <source>An error occurred when attempting to read from the runner process.</source>
-        <translation type="unfinished"></translation>
+        <translation>При попытке чтения из процесса запуска произошла ошибка.</translation>
     </message>
 </context>
 <context>
@@ -2484,68 +2493,68 @@
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="23"/>
         <source>Pause console programs after return</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановить консольные приложения после завершения</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="30"/>
         <source>Enable ANSI Escape Sequences Support</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить поддержку Escape-последовательностей ANSI</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="37"/>
         <source>Minimize IDE when running programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Свернуть IDE при запуске программ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="60"/>
         <source>Parameters to pass to your program</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры для передачи Вашей программе</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="72"/>
         <source>Parsed argv array (represented in JSON):</source>
-        <translation type="unfinished"></translation>
+        <translation>Расшифровка массива argv (представлено в JSON):</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="85"/>
         <source>Redirect input to the following file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Перенаправлять ввод в следующий файл:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="99"/>
         <source>Debugger doesn&apos;t support this feature in Linux.</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик не поддерживает эту позвожность в Linux.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="111"/>
         <source>Note: </source>
-        <translation type="unfinished"></translation>
+        <translation>Замечание: </translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="123"/>
         <source>Debugger only support this feature in gdb server mode in windows.</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик поддерживает эту возможность только в режиме gdb-сервера в Windows.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="130"/>
         <location filename="../settingsdialog/executorgeneralwidget.ui" line="133"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.cpp" line="80"/>
         <source>Choose input file</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор файла для ввода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorgeneralwidget.cpp" line="82"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -2553,117 +2562,117 @@
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="20"/>
         <source>Enable Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить набор проблем</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="29"/>
         <source>Listen for Competitive Companion</source>
-        <translation type="unfinished"></translation>
+        <translation>Прослушивать Конкурировающего Компаньона</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="61"/>
         <source>Port Number</source>
-        <translation type="unfinished"></translation>
+        <translation>Номер порта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="83"/>
         <source>Convert HTML for：</source>
-        <translation type="unfinished"></translation>
+        <translation>Конвертировать HTML для:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="90"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Ввода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="97"/>
         <source>Expected Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Ожидаемого вывода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="123"/>
         <source>Redirect STDERR to Tools output panel</source>
-        <translation type="unfinished"></translation>
+        <translation>Перенаправить STDERR на панель вывода инструментов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="145"/>
         <source>Problem Case Validate type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип проверки проблемного случая</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="171"/>
         <source>Case Validation Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Предельные случаи проверки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="180"/>
         <source>Time Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ограничение времени</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="190"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>мс</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="219"/>
         <source>Memory Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ограничение памяти</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="226"/>
         <source>kb</source>
-        <translation type="unfinished"></translation>
+        <translation>КБ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="242"/>
         <source>Display problem case input file less than</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображение входного файла проблемного случая меньше чем</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="249"/>
         <source>MB</source>
-        <translation type="unfinished"></translation>
+        <translation>МБ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="278"/>
         <source>Case Editor Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифт редактор ситуации</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="296"/>
         <source>Font Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер шрифта:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="337"/>
         <source>Font:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя шрифта:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.ui" line="382"/>
         <source>Only Monospaced</source>
-        <translation type="unfinished"></translation>
+        <translation>Только моноширинные</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="27"/>
         <source>Exact</source>
-        <translation type="unfinished"></translation>
+        <translation>Точно</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="28"/>
         <source>Ignore leading/trailing spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать начальные/конечные пробелы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/executorproblemsetwidget.cpp" line="29"/>
         <source>Ignore spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать пробелы</translation>
     </message>
 </context>
 <context>
@@ -2671,18 +2680,18 @@
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="128"/>
         <source>Register File Association Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка регистрации Файловых ассоциаций</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="129"/>
         <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="148"/>
         <source>Don&apos;t have privilege to register file types!</source>
-        <translation type="unfinished"></translation>
+        <translation>Не хватает прав для регистрации типов файлов!</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentfileassociationwidget.cpp" line="147"/>
         <source>Register File Type Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка регистрации типа файла</translation>
     </message>
 </context>
 <context>
@@ -2690,64 +2699,64 @@
     <message>
         <location filename="../compiler/filecompiler.cpp" line="60"/>
         <source>Checking single file...</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка единственного файла...</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="62"/>
         <source>Compiling single file...</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция единственного файла...</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="65"/>
         <source>- Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="66"/>
         <source>- Compiler Set Name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя набора компиляторов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="109"/>
         <location filename="../compiler/filecompiler.cpp" line="202"/>
         <source>Can&apos;t delete the old executable file &quot;%1&quot;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно удалить старый исполнимый файл &quot;%1&quot;. </translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="122"/>
         <source>GNU Assembler</source>
-        <translation type="unfinished"></translation>
+        <translation>GNU Assembler</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="140"/>
         <source>Can&apos;t find the compiler for file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось найти компилятор для файла %1</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="180"/>
         <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="182"/>
         <source>Please check the &quot;program&quot; page of compiler settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте вкладку &quot;Программа&quot; настроек компилятора.</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="185"/>
         <source>Processing %1 source file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Обработка исходного файла %1:</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="187"/>
         <source>%1 Compiler: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Компилятор: %2</translation>
     </message>
     <message>
         <location filename="../compiler/filecompiler.cpp" line="189"/>
         <source>Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Команда: %1</translation>
     </message>
 </context>
 <context>
@@ -2755,72 +2764,72 @@
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="14"/>
         <source>File Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры файла</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="29"/>
         <source>File name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="53"/>
         <source>Path:</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="60"/>
         <source>Project:</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="74"/>
         <source>Relative to Project:</source>
-        <translation type="unfinished"></translation>
+        <translation>Отношение к проекту:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="100"/>
         <source>Comment lines:</source>
-        <translation type="unfinished"></translation>
+        <translation>Строк комментариев:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="126"/>
         <source>Code lines:</source>
-        <translation type="unfinished"></translation>
+        <translation>Строк кода:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="152"/>
         <source>Total lines:</source>
-        <translation type="unfinished"></translation>
+        <translation>Всего строк:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="178"/>
         <source>Including files:</source>
-        <translation type="unfinished"></translation>
+        <translation>Включаемых файлов:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="204"/>
         <source>Empty lines:</source>
-        <translation type="unfinished"></translation>
+        <translation>Пустых строк:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="250"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="282"/>
         <source>File date:</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата файла:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="308"/>
         <source>File size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер файла:</translation>
     </message>
     <message>
         <location filename="../widgets/filepropertiesdialog.ui" line="334"/>
         <source>Characters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Символов:</translation>
     </message>
 </context>
 <context>
@@ -2828,401 +2837,401 @@
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="35"/>
         <source>Predefined format style</source>
-        <translation type="unfinished"></translation>
+        <translation>Предопределенный стиль форматирования</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="64"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note for the predefined format style&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Примечания для предопределенного стиля форматирования&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="78"/>
         <source>Basic</source>
-        <translation type="unfinished"></translation>
+        <translation>Основные</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="84"/>
         <source>Brace modifications</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменения фигурных скобок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="90"/>
         <source>Attach braces to namespace statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять фигурные скобки к namespace</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="97"/>
         <source>Attach braces to classes</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять фигурные скобки к классам</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="104"/>
         <source>Attach braces to class inline function definitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять фигурные скобки к определению функций внутри класса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="111"/>
         <source>Attach braces to extern &quot;C&quot; statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять фигурные скобки к Си-выражениям extern</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="118"/>
         <source>Attach the closing while of do-while to the close brace</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединить закрывающий while цикла do-while к закрывающей фигурной скобке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="128"/>
         <source>Convert tabs to the appropriate number of spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразование табуляции в соответствующее число пробелов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="136"/>
         <source>Indentation 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступы 1</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="142"/>
         <source>Indent with:</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ с помощью:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="157"/>
         <source>Indent using spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ с помощью пробелов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="160"/>
         <source>Spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Пробелов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="167"/>
         <source>Indent using tabs</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ с помощью табуляций</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="170"/>
         <source>Tabs</source>
-        <translation type="unfinished"></translation>
+        <translation>Табуляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="195"/>
         <source>Tab Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер табуляции:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="246"/>
         <source>Indent for continuation lines:</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ для строк продолжения:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="294"/>
         <source>Minimal indent for a continuous conditional beloning to a conditional header:</source>
-        <translation type="unfinished"></translation>
+        <translation>Минимальный отступ для продолжающегося условия относительно заголовка условия:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="335"/>
         <source>Maximal indent spaces for a continuation line</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимальное число пробелов отступа для продолжающейся строки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="382"/>
         <source>Indentation 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступы 2</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="388"/>
         <source>Indent line comments that start in column one</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ строковых комментариев, начинающихся в первой колонке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="395"/>
         <source>Indent multi-line preprocessor #define statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ многострочных директив препроцессора #define</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="402"/>
         <source>Indent switch blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ блоков выбора (switch)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="409"/>
         <source>Indent labels</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ меток</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="416"/>
         <source>Indent preprocessor conditional statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ условных директив препроцессора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="423"/>
         <source>Indent after parenthesis &apos;(&apos; or assignment &apos;=&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ после скобки &apos;(&apos; или присваивания &apos;=&apos;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="430"/>
         <source>Indent class access modifiers</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ модификаторов доступа класса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="437"/>
         <source>Indent cases</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ вариантов выбора (cases)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="444"/>
         <source>Indent class blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ блоков класса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="451"/>
         <source>Indent namespaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ пространств имен</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="458"/>
         <source>Indent preprocessor blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступ блоков препроцессора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="479"/>
         <source>Padding 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Заполнение 1</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="485"/>
         <source>Insert spaces after parenthesis headers (&apos;if&apos;,&apos;for&apos;,...)</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы после скобок заголовков операторов (&apos;if&apos;,&apos;for&apos;,...)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="505"/>
         <source>Insert spaces around parenthesis on the inside only</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы с внутренней стороны круглых скобок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="512"/>
         <source>Insert spaces around parenthesis on the outside only</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы с внешней стороны круглых скобок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="519"/>
         <source>Insert spaces around first parenthesis in a series on the out side  only</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы с внешней стороны первой круглой скобки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="526"/>
         <source>Insert spaces after commas</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы после запятых</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="533"/>
         <source>Insert empty lines arround unrelated blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пустые строки вокруг несвязанных блоков</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="555"/>
         <source>Remove superfluous empty lines exceeding</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалите лишние пустые строки, превышающие</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="585"/>
         <source>Insert spaces around operators</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы вокруг операторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="592"/>
         <source>Insert spaces around parenthesis</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлять пробелы вокруг круглых скобок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="599"/>
         <source>Insert empty lines around all blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставлять пустые строки вокруг всех блоков</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="606"/>
         <source>Remove superfluous whitespace</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалять лишние пробелы/табуляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="614"/>
         <source>Padding 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Заполнение 2</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="620"/>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="630"/>
         <source>none</source>
-        <translation type="unfinished"></translation>
+        <translation>нет</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="640"/>
         <source>Remove unnecessary space adding around parenthesis</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалять лишние пробелы, добавленные вокруг круглых скобок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="647"/>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="684"/>
         <source>type(left)</source>
-        <translation type="unfinished"></translation>
+        <translation>типу(слева)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="657"/>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="694"/>
         <source>name(right)</source>
-        <translation type="unfinished"></translation>
+        <translation>имени(справа)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="667"/>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="718"/>
         <source>middle</source>
-        <translation type="unfinished"></translation>
+        <translation>посередине</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="677"/>
         <source>Attach a pointer operator to its :</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикрепить оператор указатель к:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="704"/>
         <source>Remove all empty lines. It will NOT delete lines added by the padding options.</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все пустые строки. Это НЕ приведет к удалению строк, добавленных с помощью параметров заполнения.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="711"/>
         <source>Fill empty lines with the white space of the previous lines.</source>
-        <translation type="unfinished"></translation>
+        <translation>Заполнять пустые строки пробелами/табуляциями предыдущих строк.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="741"/>
         <source>Attach a reference operator to its :</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикрепить оператор ссылка к:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="762"/>
         <source>Other 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Разное 1</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="768"/>
         <source>Add braces to unbraced one line conditional statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавление фигурных скобок к однострочным блокам условных операторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="775"/>
         <source>Add one line braces to unbraced one line conditional statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавление однострочные фигурные скобки к однострочным блокам условных операторов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="782"/>
         <source>Break one line headers (&apos;if&apos;,&apos;while&apos;,&apos;else&apos;...) from the statement on the same line</source>
-        <translation type="unfinished"></translation>
+        <translation>Отделите однострочные заголовки (&quot;if&quot;, &quot;while&quot;, &quot;else&quot;...) от инструкции в той же строке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="789"/>
         <source>Remove braces from a braced one line conditional statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалять фигурные скобки однострочных операторов условных выражений</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="796"/>
         <source>Break braces before close headers (&apos;else&apos;,&apos;catch&quot;...)</source>
-        <translation type="unfinished"></translation>
+        <translation>Отделять фигурные скобки перед закрывающими заголовками (&apos;else&apos;,&apos;catch&quot;...)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="803"/>
         <source>Break &apos;else if&apos; statements into two lines</source>
-        <translation type="unfinished"></translation>
+        <translation>Разделять выражения &apos;else if&apos; на две строки statements into two lines</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="824"/>
         <source>Other 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Разное 2</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="830"/>
         <source>Attach return type to the function name in its definition</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять тип возвращаемого значения к имени функции в ее описании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="837"/>
         <source>Don&apos;t break blocks residing completely on one line</source>
-        <translation type="unfinished"></translation>
+        <translation>Не разбивать блоки, расположенные полностью на одной строке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="844"/>
         <source>Break return type from the function name in its definition</source>
-        <translation type="unfinished"></translation>
+        <translation>Отделять тип возвращаемого значения от имени функции в её описании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="851"/>
         <source>Don&apos;t break multiple statements residing on one line</source>
-        <translation type="unfinished"></translation>
+        <translation>Не разбивать несколько операторов, находящихся в одной строке</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="858"/>
         <source>Break return type from the function name in its declaration</source>
-        <translation type="unfinished"></translation>
+        <translation>Отделять тип возвращаемого значения от имени функции в её объявлении</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="865"/>
         <source>Attach return type to the function name in its declaration</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединять тип возвращаемого значения к имени функции в её объявлении</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="886"/>
         <source>Other 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Разное 3</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="907"/>
         <source>Break lines exceeds</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбивать строки, превышающие</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="914"/>
         <source>characters</source>
-        <translation type="unfinished"></translation>
+        <translation>символов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="959"/>
         <source>Remove the leading &apos;*&apos; prefix on multi-line comments and indent the comment text one line indent.</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалять начальный префикс &quot;*&quot; в многострочных комментариях и делать отступ текста комментария на одну строку.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="966"/>
         <source>Close ending angle brackets on template definitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрывать конечные угловые скобки в определениях шаблонов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.ui" line="973"/>
         <source>Place the logical conditional to the last on the previous line, when break lines</source>
-        <translation type="unfinished"></translation>
+        <translation>Помещать логическое условное обозначение последним в предыдущей строке при разрыве строк</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="37"/>
         <source>No minimal indent</source>
-        <translation type="unfinished"></translation>
+        <translation>Без минимального отступа</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="38"/>
         <source>Indent at least one additional indent</source>
-        <translation type="unfinished"></translation>
+        <translation>Сделать по крайней мере один дополнительный отступ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="39"/>
         <source>Indent at least two additional indents</source>
-        <translation type="unfinished"></translation>
+        <translation>Сделайте по крайней мере два дополнительных отступа</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="40"/>
         <source>Indent at least one-half an additional indent.</source>
-        <translation type="unfinished"></translation>
+        <translation>Зделать по крайней мере половину дополнительного отступа.</translation>
     </message>
 </context>
 <context>
@@ -3230,23 +3239,23 @@
     <message>
         <location filename="../settingsdialog/formatterpathwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formatterpathwidget.ui" line="20"/>
         <location filename="../settingsdialog/formatterpathwidget.cpp" line="40"/>
         <source>Path to astyle</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к astyle</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formatterpathwidget.ui" line="27"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formatterpathwidget.cpp" line="42"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -3254,187 +3263,188 @@
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="168"/>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation>По умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="169"/>
         <source>The opening braces will not be changed and closing braces will be broken from the preceding line.</source>
-        <translation type="unfinished"></translation>
+        <translation>Открывающие фигурные скобки не будут изменены, а закрывающие будут удалены с предыдущей строки.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="174"/>
         <source>Allman</source>
-        <translation type="unfinished"></translation>
+        <translation>Allman</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="175"/>
         <source>Broken braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбитые фигурные скобки.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="180"/>
         <source>Java</source>
-        <translation type="unfinished"></translation>
+        <translation>Java</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="181"/>
         <source>Attached braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединение фигурных скобок.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="186"/>
         <source>K&amp;R</source>
-        <translation type="unfinished"></translation>
+        <translation>K&amp;R</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="187"/>
         <source>Linux braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные скобки Linux.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="192"/>
         <source>Stroustrup</source>
-        <translation type="unfinished"></translation>
+        <translation>Stroustrup</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="193"/>
         <source>Linux braces, with broken closing headers.</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные скобки Linux со сломанными закрывающими заголовками.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="198"/>
         <source>Whitesmith</source>
-        <translation type="unfinished"></translation>
+        <translation>Whitesmith</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="199"/>
         <source>Broken, indented braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбитые фигурные скобки с отступом.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="201"/>
         <source>Indented class blocks and switch blocks.</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступы блоков классов и блоков switch.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="206"/>
         <source>VTK</source>
-        <translation type="unfinished"></translation>
+        <translation>VTK</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="207"/>
         <source>Broken, indented braces except for the opening braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбитые фигурные скобки с отступом, за исключением открывающих фигурных скобок.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="212"/>
         <source>Ratliff</source>
-        <translation type="unfinished"></translation>
+        <translation>Ratliff</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="213"/>
         <source>Attached, indented braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединенные фигурные скобки с отступами.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="218"/>
         <source>GNU</source>
-        <translation type="unfinished"></translation>
+        <translation>GNU</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="219"/>
         <source>Broken braces, indented blocks.</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбитые скобки, блоки с отступом.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="224"/>
         <source>Linux</source>
-        <translation type="unfinished"></translation>
+        <translation>Linux</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="225"/>
         <source>Linux braces, minimum conditional indent is one-half indent.</source>
-        <translation type="unfinished"></translation>
+        <translation>Linux braces, minimum conditional indent is one-half indent.
+Фигурные скобки Linux с минимальным условным отступом в половину отступа.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="230"/>
         <source>Horstmann</source>
-        <translation type="unfinished"></translation>
+        <translation>Horstmann</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="231"/>
         <source>Run-in braces, indented switches.</source>
-        <translation type="unfinished"></translation>
+        <translation>Встроенные фигурные скобки, switch с отступом.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="236"/>
         <source>One True Brace</source>
-        <translation type="unfinished"></translation>
+        <translation>One True Brace</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="237"/>
         <source>Linux braces, add braces to all conditionals.</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные скобки Linux, добавление фигурных скобок везде.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="242"/>
         <source>Google</source>
-        <translation type="unfinished"></translation>
+        <translation>Google</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="243"/>
         <source>Attached braces, indented class modifiers.</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединенные фигурные скобки, модификаторы класса с отступом.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="248"/>
         <source>Mozilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Mozilla</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="249"/>
         <source>Linux braces, with broken braces for structs and enums, and attached braces for namespaces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные скобки Linux с разбитыми фигурными скобками для структур и перечислений и прикрепленными фигурными скобками для пространств имен.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="254"/>
         <source>Webkit</source>
-        <translation type="unfinished"></translation>
+        <translation>Webkit</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="255"/>
         <source>Linux braces, with attached closing headers.</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные скобки Linux с прикрепленными закрывающими заголовками.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="260"/>
         <source>Pico</source>
-        <translation type="unfinished"></translation>
+        <translation>Pico</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="261"/>
         <source>Run-in opening braces and attached closing braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Встроенные открывающие фигурные скобки и прикрепленные закрывающие фигурные скобки.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="263"/>
         <source>Uses keep one line blocks and keep one line statements.</source>
-        <translation type="unfinished"></translation>
+        <translation>Использует сохранение однострочных блоков и сохранение однострочных операторов.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="268"/>
         <source>Lisp</source>
-        <translation type="unfinished"></translation>
+        <translation>Lisp</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="269"/>
         <source>Attached opening braces and attached closing braces.</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединенные открывающиеся и закрывающиеся фигурные скобки.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/formattergeneralwidget.cpp" line="271"/>
         <source>Uses keep one line statements.</source>
-        <translation type="unfinished"></translation>
+        <translation>Использует однострочные выражения.</translation>
     </message>
 </context>
 <context>
@@ -3442,92 +3452,92 @@
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="14"/>
         <source>Branch/Switch</source>
-        <translation type="unfinished"></translation>
+        <translation>Ветка/Переключение</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="20"/>
         <source>Switch To</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключить на</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="26"/>
         <source>Branch</source>
-        <translation type="unfinished"></translation>
+        <translation>Ветка</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="46"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="52"/>
         <source>Overwrite working tree changed(force)</source>
-        <translation type="unfinished"></translation>
+        <translation>Перезаписать измененное рабочее дерево (принудительно)</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="59"/>
         <source>Track</source>
-        <translation type="unfinished"></translation>
+        <translation>Track</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="65"/>
         <source>Pass --track to git</source>
-        <translation type="unfinished"></translation>
+        <translation>Pass --track to git</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="68"/>
         <source>Force Track</source>
-        <translation type="unfinished"></translation>
+        <translation>Force Track</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="75"/>
         <source>Pass --no-track to git</source>
-        <translation type="unfinished"></translation>
+        <translation>Pass --no-track to git</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="78"/>
         <source>Force No Track</source>
-        <translation type="unfinished"></translation>
+        <translation>Force No Track</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="85"/>
         <source>Neither --track nor --no-track is passed to git</source>
-        <translation type="unfinished"></translation>
+        <translation>Neither --track nor --no-track is passed to git</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="88"/>
         <source>Not Specifiied</source>
-        <translation type="unfinished"></translation>
+        <translation>Не определено</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="101"/>
         <source>Create New Branch</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать новую ветку</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="108"/>
         <source>Merge between original branch, working tree contents and the branch to switch to</source>
-        <translation type="unfinished"></translation>
+        <translation>Объединить исходную ветвь, содержимое рабочего дерева и ветвь, на которую нужно переключиться</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="111"/>
         <source>Merge</source>
-        <translation type="unfinished"></translation>
+        <translation>Слияние (merge)</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="121"/>
         <source>Force Creation (Reset branch if exists)</source>
-        <translation type="unfinished"></translation>
+        <translation>Принудительное создание (Переустановить ветку, если существует)</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="160"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../vcs/gitbranchdialog.ui" line="167"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -3535,7 +3545,7 @@
     <message>
         <location filename="../vcs/gitfetchdialog.ui" line="13"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Диалог</translation>
     </message>
 </context>
 <context>
@@ -3543,52 +3553,52 @@
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="14"/>
         <source>Git Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Протокол Git</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="70"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="80"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Переустановка</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="85"/>
         <source>Revert</source>
-        <translation type="unfinished"></translation>
+        <translation>Вернуть (revert)</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="90"/>
         <source>branch</source>
-        <translation type="unfinished"></translation>
+        <translation>ветка</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.ui" line="95"/>
         <source>Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>Метка (tag)</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="134"/>
         <source>Reset &quot;%1&quot; to this...</source>
-        <translation type="unfinished"></translation>
+        <translation>Переустановить &quot;%1&quot; на это...</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="135"/>
         <source>Revert &quot;%1&quot; to this...</source>
-        <translation type="unfinished"></translation>
+        <translation>Вернуть &quot;%1&quot; на это...</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="136"/>
         <source>Create Branch at this version...</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать ветку из этой версии...</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="137"/>
         <source>Create Tag at this version...</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать Метку (tag) из этой версии...</translation>
     </message>
 </context>
 <context>
@@ -3596,17 +3606,17 @@
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="79"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="81"/>
         <source>Author</source>
-        <translation type="unfinished"></translation>
+        <translation>Автор</translation>
     </message>
     <message>
         <location filename="../vcs/gitlogdialog.cpp" line="83"/>
         <source>Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовок</translation>
     </message>
 </context>
 <context>
@@ -3614,7 +3624,7 @@
     <message>
         <location filename="../vcs/gitmanager.cpp" line="18"/>
         <source>Folder &quot;%1&quot; already has a repository!</source>
-        <translation type="unfinished"></translation>
+        <translation>В каталоге &quot;%1&quot; уже есть репозиторий!</translation>
     </message>
 </context>
 <context>
@@ -3622,57 +3632,57 @@
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="14"/>
         <source>Merge</source>
-        <translation type="unfinished"></translation>
+        <translation>Слияние</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="20"/>
         <source>From</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходная</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="26"/>
         <source>Branch</source>
-        <translation type="unfinished"></translation>
+        <translation>Ветка</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="46"/>
         <source>Option</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="52"/>
         <source>No Commit</source>
-        <translation type="unfinished"></translation>
+        <translation>No Commit</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="59"/>
         <source>Squash</source>
-        <translation type="unfinished"></translation>
+        <translation>Подавление (Squash)</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="66"/>
         <source>No Fast Forward</source>
-        <translation type="unfinished"></translation>
+        <translation>Без Fast Forward</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="73"/>
         <source>Fast Forward Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только Fast Forward</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="83"/>
         <source>Merge Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение слияния (merge)</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="129"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../vcs/gitmergedialog.ui" line="136"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -3680,7 +3690,7 @@
     <message>
         <location filename="../vcs/gitpulldialog.ui" line="13"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Диалог</translation>
     </message>
 </context>
 <context>
@@ -3688,7 +3698,7 @@
     <message>
         <location filename="../vcs/gitpushdialog.ui" line="13"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Диалог</translation>
     </message>
 </context>
 <context>
@@ -3696,12 +3706,12 @@
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="14"/>
         <source>Git Remote</source>
-        <translation type="unfinished"></translation>
+        <translation>Git удаленный</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="93"/>
         <source>Add Remote</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить удаленно</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="96"/>
@@ -3710,47 +3720,47 @@
         <location filename="../vcs/gitremotedialog.cpp" line="95"/>
         <location filename="../vcs/gitremotedialog.cpp" line="135"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="103"/>
         <source>Remove Remote</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить удалённо</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="106"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="146"/>
         <source>Detail</source>
-        <translation type="unfinished"></translation>
+        <translation>Детали</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="155"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="162"/>
         <source>URL</source>
-        <translation type="unfinished"></translation>
+        <translation>Адрес (URL)</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.ui" line="258"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.cpp" line="36"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../vcs/gitremotedialog.cpp" line="63"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновить</translation>
     </message>
 </context>
 <context>
@@ -3758,73 +3768,73 @@
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="14"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Переустановка / Сброс</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="20"/>
         <location filename="../vcs/gitresetdialog.cpp" line="32"/>
         <source>Reset current branch &quot;%1&quot; to</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменить текущую ветку &quot;%1&quot; на</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="26"/>
         <source>Branch</source>
-        <translation type="unfinished"></translation>
+        <translation>Ветка</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="43"/>
         <source>Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>Метка</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="53"/>
         <source>Commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="66"/>
         <source>Reset Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип изменения (reset)</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="78"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Leave working tree and index untouched&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Оставить рабочее дерево и индекс нетронутым</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="88"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset working tree and index (discarding local changes)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Переустановить рабочее дерево и индекс (отмена локальных изменений)</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="98"/>
         <source>Soft</source>
-        <translation type="unfinished"></translation>
+        <translation>Мягкий (Soft)</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="105"/>
         <source>Hard</source>
-        <translation type="unfinished"></translation>
+        <translation>Жесткий (Hard)</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="112"/>
         <source>Leave working tree untouched, reset index</source>
-        <translation type="unfinished"></translation>
+        <translation>Оставить рабочее дерево нетронутым, сбросить индекс</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="122"/>
         <source>Mixed</source>
-        <translation type="unfinished"></translation>
+        <translation>Смешанный (Mixed)</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="179"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../vcs/gitresetdialog.ui" line="186"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -3832,32 +3842,32 @@
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="14"/>
         <source>Fill User Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Заполнение информации о пользователе</translation>
     </message>
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="23"/>
         <source>User Email:</source>
-        <translation type="unfinished"></translation>
+        <translation>E-Mail пользователя:</translation>
     </message>
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="49"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="56"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="79"/>
         <source>User Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя пользователя:</translation>
     </message>
     <message>
         <location filename="../vcs/gituserconfigdialog.ui" line="86"/>
         <source>Git needs the following info to commit：</source>
-        <translation type="unfinished"></translation>
+        <translation>Git нужна следующая информация для фиксации изменений (commit)：</translation>
     </message>
 </context>
 <context>
@@ -3865,12 +3875,12 @@
     <message>
         <location filename="../widgets/infomessagebox.ui" line="14"/>
         <source>Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение</translation>
     </message>
     <message>
         <location filename="../widgets/infomessagebox.ui" line="61"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
 </context>
 <context>
@@ -3878,22 +3888,22 @@
     <message>
         <location filename="../widgets/issuestable.cpp" line="259"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="261"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="263"/>
         <source>Col</source>
-        <translation type="unfinished"></translation>
+        <translation>Поз</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="265"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
 </context>
 <context>
@@ -3901,22 +3911,22 @@
     <message>
         <location filename="../widgets/issuestable.cpp" line="63"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="64"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="65"/>
         <source>Col</source>
-        <translation type="unfinished"></translation>
+        <translation>Поз</translation>
     </message>
     <message>
         <location filename="../widgets/issuestable.cpp" line="66"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
 </context>
 <context>
@@ -3924,37 +3934,37 @@
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="20"/>
         <source>Don&apos;t generate debug directives</source>
-        <translation type="unfinished"></translation>
+        <translation>Не генерировать директивы отладки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="27"/>
         <source>Don&apos;t generate SEH directives </source>
-        <translation type="unfinished"></translation>
+        <translation>Не генерировать SEH-директивы </translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="34"/>
         <source>Instruction syntax:</source>
-        <translation type="unfinished"></translation>
+        <translation>Синтаксис инструкций:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="40"/>
         <source>AT&amp;&amp;T</source>
-        <translation type="unfinished"></translation>
+        <translation>AT&amp;&amp;T</translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.ui" line="47"/>
         <source>Intel</source>
-        <translation type="unfinished"></translation>
+        <translation>Intel</translation>
     </message>
     <message>
         <location filename="../settingsdialog/languageasmgenerationwidget.cpp" line="11"/>
         <source>Don&apos;t generate cli directives.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не генерировать cli-директивы.</translation>
     </message>
 </context>
 <context>
@@ -3962,92 +3972,92 @@
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="21"/>
         <source>The default directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог по умолчанию</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="22"/>
         <source>Path to the Red Panda C++&apos;s executable file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к исполнимому файлу Red Panda C++.</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="23"/>
         <source>Version of the Red Panda C++</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия Red Panda C++</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="24"/>
         <source>PATH to the Red Panda C++&apos;s installation folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>ПУТЬ к каталогу установки Red Panda C++.</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="25"/>
         <source>Current date</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущая дата</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="26"/>
         <source>Current date and time</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущая дата и время</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="27"/>
         <source>The first include directory of the working compiler set.</source>
-        <translation type="unfinished"></translation>
+        <translation>Первый каталог подключаемых файла работающего набора компиляторов.</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="28"/>
         <source>The first lib directory of the working compiler set.</source>
-        <translation type="unfinished"></translation>
+        <translation>Первый каталог библиотек работающего набора компиляторов.</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="29"/>
         <source>The compiled filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя скомпилированного файла</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="30"/>
         <source>Full path to the compiled file</source>
-        <translation type="unfinished"></translation>
+        <translation>Полный путь к скомпилированному файлу</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="31"/>
         <source>Filename of the current source file</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя текущего исходного файла</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="32"/>
         <source>Full path to the current source file</source>
-        <translation type="unfinished"></translation>
+        <translation>Полный путь к текущему исходному файлу</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="33"/>
         <source>Path to the current source file&apos;s parent folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к родительскому каталогу текущего исходного файла</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="34"/>
         <source>Word at the cursor in the active editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Слово под курсоров в активном редакторе</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="35"/>
         <source>Name of the current project</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя текущего проекта</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="36"/>
         <source>Full path to the current project file</source>
-        <translation type="unfinished"></translation>
+        <translation>Полный путь к файлу текущего проекта</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="37"/>
         <source>Name of the current project file</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла текущего проекта</translation>
     </message>
     <message>
         <location filename="../widgets/macroinfomodel.cpp" line="38"/>
         <source>Path to the current project&apos;s folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к каталогу текущего проекта</translation>
     </message>
 </context>
 <context>
@@ -4056,33 +4066,33 @@
         <location filename="../mainwindow.ui" line="14"/>
         <location filename="../mainwindow.cpp" line="1375"/>
         <source>Red Panda C++</source>
-        <translation type="unfinished"></translation>
+        <translation>Red Panda C++</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="128"/>
         <source>File</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="147"/>
         <location filename="../mainwindow.cpp" line="3575"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Инструменты</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="153"/>
         <source>Execute</source>
-        <translation type="unfinished"></translation>
+        <translation>Выполнение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="178"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Правка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="182"/>
         <source>Move Caret</source>
-        <translation type="unfinished"></translation>
+        <translation>Перемещение Курсора</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="222"/>
@@ -4090,7 +4100,7 @@
         <location filename="../mainwindow.ui" line="2805"/>
         <location filename="../mainwindow.cpp" line="7871"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="233"/>
@@ -4101,56 +4111,56 @@
         <location filename="../mainwindow.cpp" line="7878"/>
         <location filename="../mainwindow.cpp" line="7879"/>
         <source>Code</source>
-        <translation type="unfinished"></translation>
+        <translation>Код</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="254"/>
         <source>Window</source>
-        <translation type="unfinished"></translation>
+        <translation>Окно</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="266"/>
         <location filename="../mainwindow.ui" line="594"/>
         <location filename="../mainwindow.ui" line="2741"/>
         <source>Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="285"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Справка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="306"/>
         <source>Refactor</source>
-        <translation type="unfinished"></translation>
+        <translation>Переработка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="312"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="316"/>
         <source>Tool Panels</source>
-        <translation type="unfinished"></translation>
+        <translation>Панели инструментов</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="341"/>
         <source>Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="374"/>
         <source>Main</source>
-        <translation type="unfinished"></translation>
+        <translation>Главная</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="411"/>
         <location filename="../mainwindow.ui" line="2100"/>
         <location filename="../mainwindow.ui" line="2103"/>
         <source>Compile</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="433"/>
@@ -4165,42 +4175,42 @@
         <location filename="../mainwindow.cpp" line="494"/>
         <location filename="../mainwindow.cpp" line="7874"/>
         <source>Debug</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="460"/>
         <source>Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляоров</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="484"/>
         <source>Explorer</source>
-        <translation type="unfinished"></translation>
+        <translation>Проводник</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="513"/>
         <location filename="../mainwindow.ui" line="2765"/>
         <source>Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="644"/>
         <location filename="../mainwindow.ui" line="2749"/>
         <source>Watch</source>
-        <translation type="unfinished"></translation>
+        <translation>Наблюдение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="685"/>
         <location filename="../mainwindow.ui" line="2757"/>
         <source>Structure</source>
-        <translation type="unfinished"></translation>
+        <translation>Структура</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="723"/>
         <location filename="../mainwindow.ui" line="750"/>
         <location filename="../mainwindow.ui" line="2773"/>
         <source>Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="775"/>
@@ -4208,21 +4218,21 @@
         <location filename="../mainwindow.cpp" line="2862"/>
         <location filename="../mainwindow.cpp" line="8734"/>
         <source>New Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый набор проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="790"/>
         <location filename="../mainwindow.ui" line="793"/>
         <location filename="../mainwindow.cpp" line="2898"/>
         <source>Add Problem</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить проблему</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="805"/>
         <location filename="../mainwindow.ui" line="808"/>
         <location filename="../mainwindow.cpp" line="2904"/>
         <source>Remove Problem</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить проблему</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="820"/>
@@ -4230,7 +4240,7 @@
         <location filename="../mainwindow.cpp" line="2874"/>
         <location filename="../mainwindow.cpp" line="8795"/>
         <source>Save Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить набор проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="835"/>
@@ -4238,26 +4248,26 @@
         <location filename="../mainwindow.cpp" line="2880"/>
         <location filename="../mainwindow.cpp" line="8832"/>
         <source>Load Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка набора проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="850"/>
         <location filename="../mainwindow.cpp" line="2886"/>
         <location filename="../mainwindow.cpp" line="9993"/>
         <source>Import FPS Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт набора проблем FPS</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="862"/>
         <location filename="../mainwindow.cpp" line="2892"/>
         <location filename="../mainwindow.cpp" line="10024"/>
         <source>Export FPS Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт набора проблем FPS</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="921"/>
         <source>Messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщения</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="947"/>
@@ -4268,91 +4278,91 @@
         <location filename="../mainwindow.cpp" line="6010"/>
         <location filename="../mainwindow.cpp" line="8333"/>
         <source>Issues</source>
-        <translation type="unfinished"></translation>
+        <translation>Предложения</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="996"/>
         <location filename="../mainwindow.ui" line="2789"/>
         <source>Tools Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Вывод инструментов</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1080"/>
         <source>Evaluate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Вычисление:</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1121"/>
         <location filename="../mainwindow.cpp" line="2001"/>
         <source>Debug Console</source>
-        <translation type="unfinished"></translation>
+        <translation>Консоль отладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1150"/>
         <source>Call Stack</source>
-        <translation type="unfinished"></translation>
+        <translation>Стек вызовов</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1188"/>
         <source>Breakpoints</source>
-        <translation type="unfinished"></translation>
+        <translation>Точки останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1226"/>
         <source>Locals</source>
-        <translation type="unfinished"></translation>
+        <translation>Локальные</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1255"/>
         <source>Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Память</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1261"/>
         <source>Address Expression:</source>
-        <translation type="unfinished"></translation>
+        <translation>Выражение адреса:</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1339"/>
         <source>History:</source>
-        <translation type="unfinished"></translation>
+        <translation>История:</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1374"/>
         <source>Search Again</source>
-        <translation type="unfinished"></translation>
+        <translation>Искать снова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1412"/>
         <source>Replace with:</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменить на:</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1438"/>
         <source>Open file in editors</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть файл в редакторах</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1445"/>
         <source>Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>Замена</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1452"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1483"/>
         <location filename="../mainwindow.ui" line="2813"/>
         <source>TODO</source>
-        <translation type="unfinished"></translation>
+        <translation>Дела (TODO)</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1509"/>
         <location filename="../mainwindow.ui" line="2821"/>
         <source>Bookmark</source>
-        <translation type="unfinished"></translation>
+        <translation>Закладка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1547"/>
@@ -4362,51 +4372,51 @@
         <location filename="../mainwindow.cpp" line="2971"/>
         <location filename="../mainwindow.cpp" line="2978"/>
         <source>Problem</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблема</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1642"/>
         <location filename="../mainwindow.ui" line="1645"/>
         <source>Add Probem Case</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить проблемный случай</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1656"/>
         <location filename="../mainwindow.ui" line="1659"/>
         <location filename="../mainwindow.cpp" line="2943"/>
         <source>Remove Problem Case</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить проблемный случай</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1670"/>
         <location filename="../mainwindow.ui" line="1673"/>
         <location filename="../mainwindow.cpp" line="2949"/>
         <source>Open Anwser Source File</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть Ответный исходный файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1691"/>
         <location filename="../mainwindow.ui" line="1694"/>
         <location filename="../mainwindow.cpp" line="2962"/>
         <source>Run All Cases</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск Всех случаев</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1705"/>
         <location filename="../mainwindow.cpp" line="2955"/>
         <source>Problem Cases Validation Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры подтверждения проблемных случаев</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1741"/>
         <source>%v/%m</source>
-        <translation type="unfinished"></translation>
+        <translation>%v/%m</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1823"/>
         <location filename="../mainwindow.ui" line="1826"/>
         <source>Choose Input File</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор файла ввода</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1837"/>
@@ -4416,138 +4426,138 @@
         <location filename="../mainwindow.cpp" line="3052"/>
         <location filename="../mainwindow.cpp" line="3233"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1844"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1918"/>
         <source>Expected</source>
-        <translation type="unfinished"></translation>
+        <translation>Ожидается</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1945"/>
         <source>Choose Expected Output File</source>
-        <translation type="unfinished"></translation>
+        <translation>Выберите файл вывода для ожиданий</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1974"/>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Вывод</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2025"/>
         <source>New C/C++ File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый файл Си/Си++</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2028"/>
         <source>New Source File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый исходный файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2031"/>
         <source>Ctrl+N</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+N</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2040"/>
         <source>Open...</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2043"/>
         <source>Ctrl+O</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2052"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2055"/>
         <source>Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2064"/>
         <source>Save As...</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить как...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2067"/>
         <source>Save As</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить как</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2070"/>
         <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2079"/>
         <source>Save All</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить Всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2082"/>
         <source>Ctrl+K, Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+K, Ctrl+S</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2091"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2106"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation>F9</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2115"/>
         <location filename="../mainwindow.ui" line="2118"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2121"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2130"/>
         <source>Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена действия</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2133"/>
         <source>Ctrl+Z</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Z</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2142"/>
         <source>Redo</source>
-        <translation type="unfinished"></translation>
+        <translation>Повтор действия</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2145"/>
         <source>Ctrl+Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2154"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation>Вырезать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2157"/>
         <source>Ctrl+X</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+X</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2166"/>
@@ -4555,981 +4565,981 @@
         <location filename="../mainwindow.cpp" line="3038"/>
         <location filename="../mainwindow.cpp" line="3238"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2169"/>
         <source>Ctrl+C</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+C</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2178"/>
         <location filename="../mainwindow.cpp" line="3017"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2181"/>
         <source>Ctrl+V</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2186"/>
         <location filename="../mainwindow.cpp" line="3024"/>
         <location filename="../mainwindow.cpp" line="3244"/>
         <source>Select All</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать Всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2189"/>
         <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2198"/>
         <source>Indent</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить отступ</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2201"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Tab</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2210"/>
         <source>UnIndent</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить отступ</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2213"/>
         <source>Shift+Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Shift+Tab</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2218"/>
         <source>Toggle Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>Закомментировать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2221"/>
         <source>Ctrl+/</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+/</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2229"/>
         <source>Collapse All</source>
-        <translation type="unfinished"></translation>
+        <translation>Свернуть Всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2234"/>
         <source>Uncollapse All</source>
-        <translation type="unfinished"></translation>
+        <translation>Развернуть Всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2239"/>
         <source>Encode in ANSI</source>
-        <translation type="unfinished"></translation>
+        <translation>Перекодировка в ANSI</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2244"/>
         <source>Encode in UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>Перекодировка в UTF-8</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2249"/>
         <source>Auto Detect</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоопределение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2254"/>
         <source>Convert to ANSI</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразование в ANSI</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2259"/>
         <source>Convert to UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразование в UTF-8</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2268"/>
         <location filename="../mainwindow.ui" line="2271"/>
         <source>Rebuild All</source>
-        <translation type="unfinished"></translation>
+        <translation>Пересобрать Всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2274"/>
         <source>F12</source>
-        <translation type="unfinished"></translation>
+        <translation>F12</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2283"/>
         <source>Stop Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановка выполнения</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2286"/>
         <source>F6</source>
-        <translation type="unfinished"></translation>
+        <translation>F6</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2301"/>
         <source>F5</source>
-        <translation type="unfinished"></translation>
+        <translation>F5</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2310"/>
         <source>Step Over</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаг через</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2313"/>
         <source>F8</source>
-        <translation type="unfinished"></translation>
+        <translation>F8</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2322"/>
         <source>Step Into</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаг внутрь</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2325"/>
         <source>F7</source>
-        <translation type="unfinished"></translation>
+        <translation>F7</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2334"/>
         <source>Step Out</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаг вовне</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2337"/>
         <source>Ctrl+F8</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F8</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2346"/>
         <source>Run To Cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>Выполнить до Курсора</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2349"/>
         <source>Ctrl+F5</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F5</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2358"/>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Продолжить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2361"/>
         <source>F4</source>
-        <translation type="unfinished"></translation>
+        <translation>F4</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2370"/>
         <source>Add Watch...</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить наблюдаемую переменную...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2375"/>
         <source>View CPU Window...</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать Окно процессора...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2380"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Выход</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2385"/>
         <source>Find...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2388"/>
         <source>Ctrl+F</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2393"/>
         <source>Find in Files...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск в файлах...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2396"/>
         <source>Ctrl+Shift+F</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2401"/>
         <source>Replace...</source>
-        <translation type="unfinished"></translation>
+        <translation>Замена...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2404"/>
         <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+R</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2409"/>
         <source>Find Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Найти следующий</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2412"/>
         <source>F3</source>
-        <translation type="unfinished"></translation>
+        <translation>F3</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2417"/>
         <source>Find Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Найти предыдущий</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2420"/>
         <source>Shift+F3</source>
-        <translation type="unfinished"></translation>
+        <translation>Shift+F3</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2429"/>
         <source>Remove Watch</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить наблюдаемую переменную</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2434"/>
         <source>Remove All Watches</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить Все наблюдаемые переменные</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2439"/>
         <source>Modify Watch...</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактировать наблюдаемую переменную...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2448"/>
         <source>Reformat Code</source>
-        <translation type="unfinished"></translation>
+        <translation>Переформатировать код</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2451"/>
         <source>Ctrl+Shift+A</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2460"/>
         <source>Go back</source>
-        <translation type="unfinished"></translation>
+        <translation>Назад</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2463"/>
         <source>Ctrl+Alt+Left</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Alt+Left</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2472"/>
         <source>Forward</source>
-        <translation type="unfinished"></translation>
+        <translation>Вперёд</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2475"/>
         <source>Ctrl+Alt+Right</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Alt+Left</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2480"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2483"/>
         <source>Ctrl+W</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+W</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2488"/>
         <source>Close All</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2491"/>
         <source>Ctrl+Shift+W</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+W</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2496"/>
         <source>Maximize Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Развернуть Редактор</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2499"/>
         <source>Ctrl+F11</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F11</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2504"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2507"/>
         <source>Ctrl+Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Tab</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2512"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2515"/>
         <source>Ctrl+Shift+Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+Tab</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2525"/>
         <source>Toggle breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключить точку останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2528"/>
         <source>Ctrl+F4</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F4</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2533"/>
         <location filename="../mainwindow.cpp" line="6956"/>
         <source>Clear all breakpoints</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все точки останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2538"/>
         <source>Breakpoint property...</source>
-        <translation type="unfinished"></translation>
+        <translation>Свойства точки останова...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2543"/>
         <source>Goto Declaration</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейтит к Объявлению</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2546"/>
         <source>Ctrl+J</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+J</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2551"/>
         <source>Goto Definition</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к Определению</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2554"/>
         <source>Ctrl+Shift+J</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+J</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2559"/>
         <source>Find references</source>
-        <translation type="unfinished"></translation>
+        <translation>Найти ссылки/упоминания</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2564"/>
         <source>Open containing folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть содержащий каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2572"/>
         <source>Open a terminal here</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть терминал здесь</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2577"/>
         <source>File Properties...</source>
-        <translation type="unfinished"></translation>
+        <translation>Свойства файла...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2582"/>
         <source>Close Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2587"/>
         <source>Project options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2592"/>
         <source>New Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый проект...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2597"/>
         <location filename="../mainwindow.ui" line="2600"/>
         <source>New Project File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый файл проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2605"/>
         <source>Add to project...</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить в проект...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2610"/>
         <source>Remove from project</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2615"/>
         <source>View Makefile</source>
-        <translation type="unfinished"></translation>
+        <translation>Просмотр Makefile</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2620"/>
         <source>Clean</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2625"/>
         <source>Open Folder in Explorer</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть каталог в проводнике</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2630"/>
         <source>Open In Terminal</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть в терминале</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2635"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>О программе</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2640"/>
         <location filename="../mainwindow.cpp" line="8275"/>
         <source>Rename Symbol</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать символ</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2643"/>
         <source>Shift+F6</source>
-        <translation type="unfinished"></translation>
+        <translation>Shift+F6</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2648"/>
         <source>Print...</source>
-        <translation type="unfinished"></translation>
+        <translation>Печать...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2651"/>
         <source>Ctrl+P</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2656"/>
         <location filename="../mainwindow.cpp" line="8529"/>
         <source>Export As RTF</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт в RTF</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2661"/>
         <location filename="../mainwindow.cpp" line="8551"/>
         <source>Export As HTML</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт в HTML</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2666"/>
         <source>Move To Other View</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить в другой вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2669"/>
         <source>Ctrl+M</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2677"/>
         <location filename="../mainwindow.ui" line="2680"/>
         <source>C++ Reference</source>
-        <translation type="unfinished"></translation>
+        <translation>Справочник по языку Си++</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2685"/>
         <source>EGE Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Руководство EGE</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2690"/>
         <source>Modify Bookmark Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменить описание закладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2695"/>
         <source>Locate in Files View</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать расположение в файле</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2700"/>
         <location filename="../mainwindow.ui" line="2703"/>
         <location filename="../mainwindow.cpp" line="8713"/>
         <source>Choose Working Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать рабочий каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2712"/>
         <source>Running Parameters...</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры запуска...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2717"/>
         <source>C Reference</source>
-        <translation type="unfinished"></translation>
+        <translation>Справочник по языку Си</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2725"/>
         <source>Show Tool Panels</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать панель инструментов</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2733"/>
         <source>Status Bar</source>
-        <translation type="unfinished"></translation>
+        <translation>Панель статуса</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2834"/>
         <source>Delete Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить строку</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2837"/>
         <source>Ctrl+E</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2842"/>
         <source>Duplicate Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Дублировать строку</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2845"/>
         <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2850"/>
         <source>Delete Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить слово</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2853"/>
         <source>Ctrl+Shift+D</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2858"/>
         <source>Delete to EOL</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить до конца строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2861"/>
         <source>Ctrl+Del</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Del</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2866"/>
         <source>Delete to BOL</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить до начала строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2869"/>
         <source>Ctrl+Backspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Backspace</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2878"/>
         <source>Interrupt</source>
-        <translation type="unfinished"></translation>
+        <translation>Прерывание</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2883"/>
         <location filename="../mainwindow.ui" line="2886"/>
         <source>Delete To Word Begin</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить до начала слова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2889"/>
         <source>Ctrl+Shift+B</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+B</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2894"/>
         <source>Delete to Word End</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить до конца слова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2897"/>
         <source>Ctrl+Shift+E</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+E</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2902"/>
         <source>New Class...</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый класс...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2907"/>
         <location filename="../mainwindow.ui" line="2910"/>
         <source>New Header...</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый заголовочный файл...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2915"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation>Сайт</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2923"/>
         <source>Hide Non Support Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрыть не поддерживаемые файлы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2928"/>
         <source>Toggle Block Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>Закомментировать блок кода</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2931"/>
         <source>Alt+Shift+A</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt+Shift+A</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2936"/>
         <source>Match Bracket</source>
-        <translation type="unfinished"></translation>
+        <translation>Совпадение скобок</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2939"/>
         <source>Ctrl+]</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+]</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2944"/>
         <source>Move Selection Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить выделенное вверх</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2947"/>
         <source>Ctrl+Shift+Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+Вверх</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2952"/>
         <source>Move Selection Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить выделенное вниз</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2955"/>
         <source>Ctrl+Shift+Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+Вниз</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2960"/>
         <source>Convert to UTF-8 BOM</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразовать в UTF-8 BOM</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2965"/>
         <source>Encode in UTF-8 BOM</source>
-        <translation type="unfinished"></translation>
+        <translation>Перекодировка в UTF-8 BOM</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2974"/>
         <source>Compiler Options...</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры компилятора...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2979"/>
         <source>Toggle Explorer Panel</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать/Скрыть панель проводника</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2982"/>
         <source>Ctrl+F9</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F9</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2987"/>
         <source>Toggle Messages Panel</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать/Скрыть панель сообщений</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2990"/>
         <source>Ctrl+F10</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F10</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="2995"/>
         <source>Raylib Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Руководство по Raylib</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3000"/>
         <source>Select Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор слова</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3005"/>
         <source>Go to Line...</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к строке...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3008"/>
         <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3013"/>
         <source>New Template...</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый шаблон...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3016"/>
         <source>New Template from Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый шаблон из проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3021"/>
         <source>Goto block start</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к началу блока</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3024"/>
         <source>Ctrl+Alt+Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Alt+Вверх</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3029"/>
         <source>Goto block end</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к концу блока</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3032"/>
         <source>Ctrl+Alt+Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Alt+Вниз</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3037"/>
         <source>Switch header/source</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключение заголовочного/исходного файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3040"/>
         <source>Switch Header/Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключение Заголовочного/Исходного файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3045"/>
         <source>Generate Assembly</source>
-        <translation type="unfinished"></translation>
+        <translation>Сформировать код Ассемблера</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3048"/>
         <source>Ctrl+F12</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F12</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3053"/>
         <source>Trim trailing spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Обрезка конечных пробелов</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3058"/>
         <source>Toggle Readonly</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключить режим &quot;только чтение&quot;</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3061"/>
         <source>Ctrl+Shift+R</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+R</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3066"/>
         <source>Submit Issues</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтвердить предложение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3071"/>
         <source>Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Документ</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3074"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3079"/>
         <source>New GAS File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый файл GAS</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3084"/>
         <source>GNU Assembler Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Руководство по Ассемблеру GNU</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3089"/>
         <source>x86 Assembly Language Reference Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Справочное руководство по языку Ассемблера x86</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3094"/>
         <source>IA-32 Assembly Language Reference Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Руководство по языку Ассемблера IA-32</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3099"/>
         <source>Add Watchpoint...</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить Точку наблюдения...</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3102"/>
         <source>Add a watchpoint that&apos;s triggered when it&apos;s modified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить точку наблюдения, которая срабатывает при ее изменении.</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3107"/>
         <source>New Text File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый текстовый файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3112"/>
         <source>Page Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Page Up</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3120"/>
         <source>Page Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Page Down</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3128"/>
         <source>Goto Line Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти на начало строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3136"/>
         <source>Goto Line End</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти на конец строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3144"/>
         <source>Goto File Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к началу файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3152"/>
         <source>Goto File End</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к концу файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3160"/>
         <source>Page Up and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить Страницу Вверх</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3168"/>
         <source>Page Down and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить Страницу Вниз</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3176"/>
         <source>Goto Page Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к началу страницы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3184"/>
         <source>Goto Page End</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к концу страницы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3192"/>
         <source>Goto Page Start and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до начала страницы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3200"/>
         <source>Goto Page End and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до конца страницы</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3208"/>
         <source>Goto Line Start and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до начала строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3216"/>
         <source>Goto Line End and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до конца строки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3224"/>
         <source>Goto File Start and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до начала файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3232"/>
         <source>Goto File End and Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделить до конца файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3240"/>
         <source>Close Others</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть другие</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3248"/>
         <source>OI Wiki</source>
-        <translation type="unfinished"></translation>
+        <translation>OI Wiki</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3256"/>
         <source>Turtle Graphics Tutorial</source>
-        <translation type="unfinished"></translation>
+        <translation>Руководство по графике Turtle</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3264"/>
         <source>Toggle Bookmark</source>
-        <translation type="unfinished"></translation>
+        <translation>Сделать закладку</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3267"/>
         <source>Ctrl+B</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+B</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3275"/>
         <source>Code Completion</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение кода</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="3278"/>
         <source>Ctrl+Shift+/</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+/</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="152"/>
         <source>Exact</source>
-        <translation type="unfinished"></translation>
+        <translation>Точно</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="153"/>
         <source>Ignore leading/trailing spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать начальные/конечные пробелы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="154"/>
         <source>Ignore spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать пробелы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="245"/>
@@ -5547,54 +5557,54 @@
         <location filename="../mainwindow.cpp" line="6401"/>
         <location filename="../mainwindow.cpp" line="9824"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="251"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="264"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="272"/>
         <source>Recent Projects</source>
-        <translation type="unfinished"></translation>
+        <translation>Прежние проекты</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="276"/>
         <source>Recent Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Прежние файлы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="282"/>
         <source>Insert Snippet</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставить фрагмент кода</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="361"/>
         <location filename="../mainwindow.cpp" line="8743"/>
         <source>Problem Set %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор проблем %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1014"/>
         <location filename="../mainwindow.cpp" line="1021"/>
         <source>Load Theme Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки темы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1315"/>
         <source> - Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation> - Команда: %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1377"/>
         <source> %1 Version</source>
-        <translation type="unfinished"></translation>
+        <translation> Версия %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1388"/>
@@ -5604,7 +5614,7 @@
         <location filename="../mainwindow.cpp" line="1449"/>
         <location filename="../mainwindow.cpp" line="1451"/>
         <source>Debugging</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладка</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1393"/>
@@ -5614,7 +5624,7 @@
         <location filename="../mainwindow.cpp" line="1454"/>
         <location filename="../mainwindow.cpp" line="1456"/>
         <source>Running</source>
-        <translation type="unfinished"></translation>
+        <translation>Выполняется</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1398"/>
@@ -5624,63 +5634,63 @@
         <location filename="../mainwindow.cpp" line="1459"/>
         <location filename="../mainwindow.cpp" line="1461"/>
         <source>Compiling</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилируется</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1516"/>
         <location filename="../mainwindow.cpp" line="1538"/>
         <source>Clear History</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистить историю</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1639"/>
         <source>Line: %1/%2 Col: %3 Sel: %4</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка: %1/%2 Колонка: %3 Выделение: %4</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1645"/>
         <source>Line: %1/%2 Col: %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка: %1/%2 Колонка: %3</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1652"/>
         <source>Line: %1/%2 Char: %3/%4 Sel: %5</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка: %1/%2 Символ: %3/%4 Выделение: %5</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1659"/>
         <source>Line: %1/%2 Char: %3/%4</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка: %1/%2 Символ: %3/%4</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1683"/>
         <source>Read Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только чтение</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1685"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставка</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1687"/>
         <source>Overwrite</source>
-        <translation type="unfinished"></translation>
+        <translation>Перезапись</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2293"/>
         <source>Missing Project Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Утраченные файлы проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2294"/>
         <source>The following files is missing, can&apos;t build the project:</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующие файлы утрачены, сборка проекта невозможна:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2382"/>
         <source>Source file is not compiled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный файл не скомпилирован.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2484"/>
@@ -5688,7 +5698,7 @@
         <location filename="../mainwindow.cpp" line="6099"/>
         <location filename="../mainwindow.cpp" line="6106"/>
         <source>Wrong Compiler Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Неправильные настройки компилятора</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2485"/>
@@ -5696,76 +5706,76 @@
         <location filename="../mainwindow.cpp" line="6100"/>
         <location filename="../mainwindow.cpp" line="6107"/>
         <source>Compiler is set not to generate executable.</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор не настроен для формирования исполнимого файла.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2486"/>
         <location filename="../mainwindow.cpp" line="6101"/>
         <source>We need the executabe to run problem case.</source>
-        <translation type="unfinished"></translation>
+        <translation>Необходим исполнимый файл для запуска проблемного случая.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2501"/>
         <source>No compiler set</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет набора компиляторов</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2502"/>
         <source>No compiler set is configured.</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляторов не настроен.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2502"/>
         <source>Can&apos;t start debugging.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя запустить отладку.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2522"/>
         <location filename="../mainwindow.cpp" line="2645"/>
         <location filename="../mainwindow.cpp" line="5300"/>
         <source>Correct compile settings for debug</source>
-        <translation type="unfinished"></translation>
+        <translation>Правильные настройки компилятора для отладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2523"/>
         <location filename="../mainwindow.cpp" line="2646"/>
         <source>The generated executable won&apos;t have debug symbol infos, and can&apos;t be debugged.</source>
-        <translation type="unfinished"></translation>
+        <translation>Создаваемый исполнимый файл не содержит информации для отладки и не может быть отлажен.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2525"/>
         <location filename="../mainwindow.cpp" line="2648"/>
         <location filename="../mainwindow.cpp" line="5303"/>
         <source>If you are using the Release compiler set, please use choose the Debug version from toolbar.</source>
-        <translation type="unfinished"></translation>
+        <translation>Если Вы использует набор компиляторов Выпуск(Release), пожалуйста выберите версию Отладка(Debug) на панели инструментов.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2527"/>
         <location filename="../mainwindow.cpp" line="2650"/>
         <location filename="../mainwindow.cpp" line="5305"/>
         <source>Or you can manually change the following settings in the options dialog&apos;s compiler set page:</source>
-        <translation type="unfinished"></translation>
+        <translation>Или Вы можете вручную изменить следующие настройки на странице настройки компилятора в диалоговом окне &quot;Параметры&quot;:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2529"/>
         <location filename="../mainwindow.cpp" line="2652"/>
         <location filename="../mainwindow.cpp" line="5307"/>
         <source> - Turned on the &quot;Generate debug info (-g3)&quot; option.</source>
-        <translation type="unfinished"></translation>
+        <translation> - Включен параметр &quot;Включение отладочной информации (-g3)&quot;.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2531"/>
         <location filename="../mainwindow.cpp" line="2654"/>
         <location filename="../mainwindow.cpp" line="5309"/>
         <source> - Turned off the &quot;Strip executable (-s)&quot; option.</source>
-        <translation type="unfinished"></translation>
+        <translation> - Выключен парамет &quot;Сжимать исполнимые файлы&quot;.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2533"/>
         <location filename="../mainwindow.cpp" line="2656"/>
         <location filename="../mainwindow.cpp" line="5311"/>
         <source> - Turned off the &quot;Optimization level (-O)&quot; option or set it to &quot;Debug (-Og)&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation> - Выключен параметр &quot;Уровень оптимизации (-O)&quot; или установлен параметр &quot;Отладка (-Og)&quot;.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2535"/>
@@ -5773,228 +5783,228 @@
         <location filename="../mainwindow.cpp" line="5313"/>
         <location filename="../mainwindow.cpp" line="5315"/>
         <source>You should recompile after change the compiler set or it&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Вам следует перекомпилировать файл после изменения набора компиляторов или его настроек.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2537"/>
         <location filename="../mainwindow.cpp" line="2660"/>
         <location filename="../mainwindow.cpp" line="5317"/>
         <source>Do you want to mannually change the compiler set settings now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Хотите ли Вы сейчас вручную изменить настройки набора компиляторов?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2587"/>
         <source>Host applcation missing</source>
-        <translation type="unfinished"></translation>
+        <translation>Host-приложение отсутствует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2588"/>
         <source>DLL project needs a host application to run.</source>
-        <translation type="unfinished"></translation>
+        <translation>DLL-проект нуждается в host-приложении для запуска.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2590"/>
         <source>But it&apos;s missing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Но оно утрачено.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2595"/>
         <source>Host application not exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Host-приложение не существует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2596"/>
         <source>Host application file &apos;%1&apos; doesn&apos;t exist.</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл Host-приложения &apos;%1&apos; не существует.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2693"/>
         <location filename="../mainwindow.cpp" line="6108"/>
         <source>Please correct this before start debugging</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, исправьте это перед началом отладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2852"/>
         <source>Auto Save Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка автосохранения</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2853"/>
         <source>Auto save &quot;%1&quot; to &quot;%2&quot; failed:%3</source>
-        <translation type="unfinished"></translation>
+        <translation>Автосохранение &quot;%1&quot; в &quot;%2&quot; не удалось:%3</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2868"/>
         <source>Rename Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименование набора проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2911"/>
         <source>Open Source File</source>
-        <translation type="unfinished"></translation>
+        <translation>Открытие исходного файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2917"/>
         <source>Rename Problem</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименование проблемы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2923"/>
         <source>Goto Url</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти на адрес</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2929"/>
         <source>Properties...</source>
-        <translation type="unfinished"></translation>
+        <translation>Свойства...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2937"/>
         <source>Add Problem Case</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить проблемный случай</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2969"/>
         <source>Run Current Case</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск проблемного случая</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2976"/>
         <location filename="../mainwindow.cpp" line="4432"/>
         <source>Batch Set Cases</source>
-        <translation type="unfinished"></translation>
+        <translation>Пакетный набор случаев</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2985"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удаление</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2991"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все закладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2996"/>
         <source>Modify Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменить описание</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3003"/>
         <source>Show detail debug logs</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать детальный протокол отладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3045"/>
         <source>Copy all</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать всё</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3059"/>
         <source>Remove this search</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить найденное</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3065"/>
         <source>Clear all searches</source>
-        <translation type="unfinished"></translation>
+        <translation>Очистить все результаты поиска</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3072"/>
         <source>Breakpoint condition...</source>
-        <translation type="unfinished"></translation>
+        <translation>Условие точки останова...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3078"/>
         <source>Remove All Breakpoints</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все точки останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3083"/>
         <source>Remove Breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить точку останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3090"/>
         <source>Rename File</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3095"/>
         <location filename="../mainwindow.cpp" line="5042"/>
         <source>Add Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3101"/>
         <source>Rename Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3107"/>
         <source>Remove Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3112"/>
         <source>Switch to normal view</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключить на нормальный вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3118"/>
         <source>Switch to custom view</source>
-        <translation type="unfinished"></translation>
+        <translation>Переключить на пользовательский вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3125"/>
         <source>Sort By Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Сортировка по типу</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3129"/>
         <source>Sort alphabetically</source>
-        <translation type="unfinished"></translation>
+        <translation>Сортировка по алфавиту</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3133"/>
         <source>Show inherited members</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать унаследованные элементы</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3137"/>
         <source>Goto declaration</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к объявлению</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3140"/>
         <source>Goto definition</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к определению</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3143"/>
         <source>In current file</source>
-        <translation type="unfinished"></translation>
+        <translation>В текущем файле</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3147"/>
         <source>In current project</source>
-        <translation type="unfinished"></translation>
+        <translation>В текущем проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3176"/>
         <location filename="../mainwindow.cpp" line="4594"/>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3182"/>
         <source>New File</source>
-        <translation type="unfinished"></translation>
+        <translation>Новй файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3188"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3194"/>
@@ -6003,70 +6013,70 @@
         <location filename="../mainwindow.cpp" line="4668"/>
         <location filename="../mainwindow.cpp" line="7727"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3202"/>
         <source>Open in Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть в редакторе</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3212"/>
         <source>Open in External Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть во внешней программе</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3218"/>
         <source>Open in Terminal</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть в терминале</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3225"/>
         <source>Open in Windows Explorer</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть в проводнике Windows</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3436"/>
         <location filename="../mainwindow.cpp" line="3444"/>
         <source>Save last open info error</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение информации об ошибке последнего открытия</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3437"/>
         <source>Can&apos;t open last open information file &apos;%1&apos; for write!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи файл с информацией о последнем открытии &apos;%1&apos;!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3445"/>
         <source>Can&apos;t save last open info file &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно сохранить файл с информацией о последнем открытии &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3466"/>
         <location filename="../mainwindow.cpp" line="3476"/>
         <source>Load last open info error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки информации о последнем открытии</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3467"/>
         <location filename="../mainwindow.cpp" line="3477"/>
         <source>Can&apos;t load last open info file &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно загрузить файл с информацией о последнем открытии &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3707"/>
         <source>Character sets</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор символов</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3741"/>
         <source>File Encoding</source>
-        <translation type="unfinished"></translation>
+        <translation>Кодировка файлов</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3757"/>
         <source>Convert to %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразовать в %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3763"/>
@@ -6074,7 +6084,7 @@
         <location filename="../mainwindow.cpp" line="6432"/>
         <location filename="../mainwindow.cpp" line="9807"/>
         <source>Confirm Convertion</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтверждение преобразования</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3764"/>
@@ -6082,221 +6092,221 @@
         <location filename="../mainwindow.cpp" line="6433"/>
         <location filename="../mainwindow.cpp" line="9808"/>
         <source>The editing file will be saved using %1 encoding. &lt;br /&gt;This operation can&apos;t be reverted. &lt;br /&gt;Are you sure to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактируемый файл будет сохранен в кодировке %1 encoding. &lt;br /&gt;Операция не обратима. &lt;br /&gt;Вы уверены в том, что хотите продолжить?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3784"/>
         <source>Newline</source>
-        <translation type="unfinished"></translation>
+        <translation>Newline</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="3885"/>
         <source>%1 files autosaved</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 файлы автоматически сохранены</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4011"/>
         <location filename="../mainwindow.cpp" line="4172"/>
         <source>Version Control</source>
-        <translation type="unfinished"></translation>
+        <translation>Контроль версий</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4237"/>
         <source>Set answer to...</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить ответ в...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4269"/>
         <source>select other file...</source>
-        <translation type="unfinished"></translation>
+        <translation>выбор другого файла...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4274"/>
         <source>Select Answer Source File</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать исходный файл ответа</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4276"/>
         <source>C/C++ Source Files (*.c *.cpp *.cc *.cxx)</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходные файлы Си/Си++ (*.c *.cpp *.cc *.cxx)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4433"/>
         <source>This operation will remove all cases for the current problem.</source>
-        <translation type="unfinished"></translation>
+        <translation>Эта операци удалит все ситуации для текущей проблемы.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4435"/>
         <location filename="../mainwindow.cpp" line="5909"/>
         <source>Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите это сделать?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4444"/>
         <source>Choose input files</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор файла для ввода</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4446"/>
         <source>Input data files (*.in)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы исходных данных (*.in)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4472"/>
         <source>Problem &apos;%1&apos; received (%2/%3).</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблема &apos;%1&apos; получена (%2/%3).</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4598"/>
         <source>New Folder %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый каталог %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4656"/>
         <location filename="../mainwindow.cpp" line="4663"/>
         <source>Do you really want to delete %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить %1?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4669"/>
         <source>Do you really want to delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить %1 файлов?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4739"/>
         <source>Set Problem Set Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Назначить имя набору проблем</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4740"/>
         <source>Problem Set Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя набора проблем:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4781"/>
         <location filename="../mainwindow.cpp" line="8634"/>
         <location filename="../mainwindow.cpp" line="10342"/>
         <source>Bookmark Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание закладки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="4782"/>
         <location filename="../mainwindow.cpp" line="8635"/>
         <location filename="../mainwindow.cpp" line="10343"/>
         <source>Description:</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5034"/>
         <location filename="../mainwindow.cpp" line="5037"/>
         <source>New folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5043"/>
         <source>Folder name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя каталога:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5301"/>
         <source>The executable doesn&apos;t have symbol table, and can&apos;t be debugged.</source>
-        <translation type="unfinished"></translation>
+        <translation>Исполнимый файл не содержит таблицы символов и не может быть отлажен.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5357"/>
         <source>Watchpoint hitted</source>
-        <translation type="unfinished"></translation>
+        <translation>Попадание в Точку наблюдения</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5358"/>
         <source>Value of &quot;%1&quot; has changed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Значение &quot;%1&quot; было изменено:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5360"/>
         <source>Old value: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Старое значение: %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5362"/>
         <source>New value: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Новое значение: %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5409"/>
         <source>Save project</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5410"/>
         <source>The project &apos;%1&apos; has modifications.</source>
-        <translation type="unfinished"></translation>
+        <translation>В проекте &apos;%1&apos; произошли изменения.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5412"/>
         <location filename="../mainwindow.cpp" line="8737"/>
         <source>Do you want to save it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Хотите сохранить его?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5518"/>
         <location filename="../mainwindow.cpp" line="5536"/>
         <source>File Changed</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл изменился</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5519"/>
         <source>File &apos;%1&apos; was changed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; был изменен.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5519"/>
         <source>Reload its content from disk?</source>
-        <translation type="unfinished"></translation>
+        <translation>Перезагрузить содержимое с диска?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5537"/>
         <source>File &apos;%1&apos; was removed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; был удалён.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5537"/>
         <source>Keep it open?</source>
-        <translation type="unfinished"></translation>
+        <translation>Держать его открытым?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5556"/>
         <source>Project folder removed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог проекта удален.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5557"/>
         <source>Folder for project &apos;%1&apos; was removed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог проекта &apos;%1&apos; был удален.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5559"/>
         <source>It will be closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Он будет закрыт.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5623"/>
         <location filename="../mainwindow.cpp" line="10070"/>
         <location filename="../mainwindow.cpp" line="10138"/>
         <source>New Project File?</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый файл проекта?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5624"/>
         <location filename="../mainwindow.cpp" line="10071"/>
         <location filename="../mainwindow.cpp" line="10139"/>
         <source>Do you want to add the new file to the project?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы хотите добавить новый файл в проект?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5672"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5721"/>
@@ -6305,242 +6315,242 @@
         <location filename="../mainwindow.cpp" line="5755"/>
         <location filename="../mainwindow.cpp" line="8821"/>
         <source>Save Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка сохранения</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5722"/>
         <source>Save settings failed!</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение настроек не удалось!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5906"/>
         <source>Change Project Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение набора компиляторов проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="5907"/>
         <source>Change the project&apos;s compiler set will lose all custom compiler set options.</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение набора компиляторов проекта приведет к потере всех пользовательских параметров набора компиляторов.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6061"/>
         <location filename="../mainwindow.cpp" line="6166"/>
         <source>Compile Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция не удалась</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6062"/>
         <source>Failed to generate the executable.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось сформировать исполнимый файл.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6063"/>
         <source>Please check detail info in &quot;Tools Output&quot; panel.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте детальную информацию в панели &quot;Инструменты вывода&quot;.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6172"/>
         <source>Run Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск не удался</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6559"/>
         <source>New Watch Expression</source>
-        <translation type="unfinished"></translation>
+        <translation>Новое выражение для наблюдаемой переменной</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6560"/>
         <source>Enter Watch Expression (it is recommended to use &apos;this-&gt;&apos; for class members):</source>
-        <translation type="unfinished"></translation>
+        <translation>Введите выражение для наблюдаемой переменной (рекомендуется использовать &apos;this-&gt;&apos; для членов классов):</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6616"/>
         <source>Parsing file %1 of %2: &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Разбор файла %1 из %2: &quot;%3&quot;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6638"/>
         <location filename="../mainwindow.cpp" line="6644"/>
         <source>Done parsing %1 files in %2 seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Завершен разбор %1 файлов за %2 секунд</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6641"/>
         <source>(%1 files per second)</source>
-        <translation type="unfinished"></translation>
+        <translation>(%1 файлов в секунду)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6825"/>
         <source>Modify Watch</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение наблюдаемой переменной</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6826"/>
         <source>Watch Expression</source>
-        <translation type="unfinished"></translation>
+        <translation>Выражение для наблюдаемоей переменной</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="6957"/>
         <source>Do you really want to clear all breakpoints in this file?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить все точки останова из этого файла?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7145"/>
         <source>New project</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7146"/>
         <source>Close %1 and start new project?</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть %1 и начать новый проект?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7159"/>
         <source>Folder not exist</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог не существует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7160"/>
         <source>Folder &apos;%1&apos; doesn&apos;t exist. Create it now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог &apos;%1&apos; не существует. Создать его?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7167"/>
         <source>Can&apos;t create folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Не получилось создать каталог</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7168"/>
         <source>Failed to create folder &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось создать каталог &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7178"/>
         <source>Folder Not Empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог не пуст</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7179"/>
         <source>The project folder is not empty, existing files may be overwritten.</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог проекта не пуст, существующие файлы могут быть перезаписаны.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7181"/>
         <source>Do you want to proceed?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы хотите продолжить?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7194"/>
         <source>Save new project as</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить новый проект как</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7196"/>
         <source>Red Panda C++ project file (*.dev)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл проекта Red Panda C++ (*.dev)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7208"/>
         <source>New project fail</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось создать новый проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7209"/>
         <source>Can&apos;t assign project template</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось назначить шаблон проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7267"/>
         <source>Add to project</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавление в проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7315"/>
         <source>Remove file</source>
-        <translation type="unfinished"></translation>
+        <translation>Удаление файла</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7316"/>
         <source>Remove the file from disk?</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить файл с диска?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7633"/>
         <source>New Project File Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла нового проекта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7634"/>
         <source>File Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7642"/>
         <source>File Already Exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл уже существует!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7643"/>
         <source>File &apos;%1&apos; already exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; уже сущесвует!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7680"/>
         <source>Input Data File is too large to display!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл данных ввода слишком большой для отображения!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7685"/>
         <location filename="../mainwindow.cpp" line="7704"/>
         <source>File doesn&apos;t exist!</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл не существует!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7728"/>
         <source>Folder %1 is not empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог %1 не пуст.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7729"/>
         <source>Do you really want to delete it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить его?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7838"/>
         <source>Break point condition</source>
-        <translation type="unfinished"></translation>
+        <translation>Условие для точки останова</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7839"/>
         <source>Enter the condition of the breakpoint:</source>
-        <translation type="unfinished"></translation>
+        <translation>Введите условие для точки останова:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7927"/>
         <source>Error in Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка в наборе компиляторов</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="7928"/>
         <source>Current Compiler set has the following critical error: 
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Текущий набор компиляторов имеет следующую критическую ошибку:  </translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8248"/>
         <source>Rename Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка переименования</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8249"/>
         <source>Symbol &apos;%1&apos; is defined in system header.</source>
-        <translation type="unfinished"></translation>
+        <translation>Символ &apos;%1&apos; определен в системном заголовочном файле.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8276"/>
         <source>New Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Новое имя</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8434"/>
@@ -6548,192 +6558,192 @@
         <location filename="../mainwindow.cpp" line="8468"/>
         <location filename="../mainwindow.cpp" line="8489"/>
         <source>Replace Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка замены</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8435"/>
         <source>Can&apos;t open file &apos;%1&apos; for replace!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для замены!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8469"/>
         <source>Contents has changed since last search!</source>
-        <translation type="unfinished"></translation>
+        <translation>Содержимое изменилось с момента последнего поиска!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8531"/>
         <source>Rich Text Format Files (*.rtf)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Rich Text Format (*.rtf)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8553"/>
         <source>HTML Files (*.html)</source>
-        <translation type="unfinished"></translation>
+        <translation>HTML-файлы (*.html)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8657"/>
         <source>Change working folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Смена рабочего каталога</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8658"/>
         <source>File &apos;%1&apos; is not in the current working folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; не в текущем рабочем каталоге.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8661"/>
         <source>Do you want to change working folder to &apos;%1&apos;?</source>
-        <translation type="unfinished"></translation>
+        <translation>Хотите изменить рабочий каталог на &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8735"/>
         <source>The current problem set is not empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущий набор проблем не пуст.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8754"/>
         <source>Problem %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблема %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8802"/>
         <location filename="../mainwindow.cpp" line="8834"/>
         <source>Problem Set Files (*.pbs)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы набора проблем (*.pbs)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8848"/>
         <location filename="../mainwindow.cpp" line="10003"/>
         <source>Load Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8862"/>
         <source>Problem Case %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблемный случай %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9184"/>
         <location filename="../mainwindow.cpp" line="9233"/>
         <source>Header Exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл существует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9185"/>
         <location filename="../mainwindow.cpp" line="9234"/>
         <source>Header file &quot;%1&quot; already exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл &quot;%1&quot; уже существует!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9239"/>
         <source>Source Exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный файл существует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9240"/>
         <source>Source file &quot;%1&quot; already exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный файл &quot;%1&quot; уже существует!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9394"/>
         <source>Can&apos;t commit!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно фиксировать измения (commit)!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9395"/>
         <source>The following files are in conflicting:</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующие файлы конфликтуют:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9400"/>
         <source>Commit Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение о фиксировании изменений (commit)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9400"/>
         <source>Commit Message:</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение о фиксировании изменений (commit):</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9403"/>
         <source>Commit Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Фиксировать изменения (commit) не удалось</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9404"/>
         <source>Commit message shouldn&apos;t be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение о фиксировании изменений (commit) не может быть пустым!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9415"/>
         <source>Can&apos;t Commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно фиксировать измения (commit)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9416"/>
         <source>Git needs user info to commit.</source>
-        <translation type="unfinished"></translation>
+        <translation>Git требует информацию о пользователе для фиксирования изменений.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9684"/>
         <source>Choose Input Data File</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор файла данных ввода</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9686"/>
         <location filename="../mainwindow.cpp" line="9741"/>
         <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (*.*)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9739"/>
         <source>Choose Expected Output Data File</source>
-        <translation type="unfinished"></translation>
+        <translation>Выберите файл вывода для ожиданий</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9893"/>
         <source>Go to Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Перейти к строке</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9893"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9914"/>
         <source>Template Exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаблон существует</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9915"/>
         <source>Template %1 already exists. Do you want to overwrite?</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаблон %1 уже существует. Хотите перезаписать?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9995"/>
         <source>FPS Problem Set Files (*.fps;*.xml)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы набора проблем FPS (*.fps;*.xml)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="10026"/>
         <source>FPS Problem Set Files (*.fps)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы набора проблем FPS (*.fps)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="10031"/>
         <source>Export Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка экспорта</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="10123"/>
         <source>Watchpoint variable name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя переменной для точки наблюдения</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="10124"/>
         <source>Stop execution when the following variable is modified (it must be visible from the currect scope):</source>
-        <translation type="unfinished"></translation>
+        <translation>Остановать выполнение, если следующая переменная изменилась (она должна быть видима из текущей области видимости):</translation>
     </message>
 </context>
 <context>
@@ -6741,27 +6751,27 @@
     <message>
         <location filename="../debugger/debugger.cpp" line="2555"/>
         <source>addr: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>addr: %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2557"/>
         <source>dec: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>dec: %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2559"/>
         <source>oct: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>oct: %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2561"/>
         <source>bin: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>bin: %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2576"/>
         <source>ascii: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>ascii: &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -6769,52 +6779,52 @@
     <message>
         <location filename="../widgets/newclassdialog.ui" line="14"/>
         <source>New Class</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый класс</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="33"/>
         <source>Header Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл:</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="46"/>
         <source>Class Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя класса:</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="88"/>
         <source>Create</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="95"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="105"/>
         <source>Path:</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь:</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="112"/>
         <source>Base Class:</source>
-        <translation type="unfinished"></translation>
+        <translation>Базовый класс:</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="119"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.ui" line="129"/>
         <source>Source Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный файл:</translation>
     </message>
     <message>
         <location filename="../widgets/newclassdialog.cpp" line="99"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь</translation>
     </message>
 </context>
 <context>
@@ -6822,38 +6832,38 @@
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="14"/>
         <source>New Header</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый заголовочный файл</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="23"/>
         <source>Header:</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл:</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="30"/>
         <location filename="../widgets/newheaderdialog.ui" line="33"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="40"/>
         <source>Path:</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь:</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="63"/>
         <source>Create</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.ui" line="70"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../widgets/newheaderdialog.cpp" line="93"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь</translation>
     </message>
 </context>
 <context>
@@ -6861,58 +6871,58 @@
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="14"/>
         <source>New Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый проект</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="109"/>
         <source>Make default language</source>
-        <translation type="unfinished"></translation>
+        <translation>Сделать языком по умолчанию</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="116"/>
         <source>C Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект Си</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="126"/>
         <source>C++ Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект Си++</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="157"/>
         <source>Icon Info:</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация значка:</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="201"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="208"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="215"/>
         <source>Create in</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать в</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.ui" line="222"/>
         <source>Use as the default project location</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать как разположение проектов по умолчанию</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.cpp" line="178"/>
         <location filename="../widgets/newprojectdialog.cpp" line="199"/>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation>По умолчанию</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectdialog.cpp" line="284"/>
         <source>Choose directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор каталога</translation>
     </message>
 </context>
 <context>
@@ -6920,38 +6930,38 @@
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="14"/>
         <source>New Project Unit</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый модуль проекта</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="20"/>
         <source>Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="34"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="41"/>
         <location filename="../widgets/newprojectunitdialog.ui" line="44"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="82"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.ui" line="89"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../widgets/newprojectunitdialog.cpp" line="94"/>
         <source>Choose directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор каталога</translation>
     </message>
 </context>
 <context>
@@ -6959,32 +6969,32 @@
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="14"/>
         <source>Create Template From Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Создание шаблона из проекта</translation>
     </message>
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="35"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="42"/>
         <source>Category</source>
-        <translation type="unfinished"></translation>
+        <translation>Категория</translation>
     </message>
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="49"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя</translation>
     </message>
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="113"/>
         <source>Create</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать</translation>
     </message>
     <message>
         <location filename="../widgets/newtemplatedialog.ui" line="120"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -6992,37 +7002,37 @@
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="87"/>
         <source>--- stderr from %1 ---</source>
-        <translation type="unfinished"></translation>
+        <translation>--- stderr из %1 ---</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="178"/>
         <source>Time limit exceeded!</source>
-        <translation type="unfinished"></translation>
+        <translation>Превышен лимит времени!</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="181"/>
         <source>Memory limit exceeded!</source>
-        <translation type="unfinished"></translation>
+        <translation>Превышен лимит памяти!</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="199"/>
         <source>The runner process &apos;%1&apos; failed to start.</source>
-        <translation type="unfinished"></translation>
+        <translation>Процесс запуска &apos;%1&apos; не удалось запустить.</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="206"/>
         <source>The last waitFor...() function timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Время ожидания последнего вызова функции waitFor...() истекло.</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="209"/>
         <source>An error occurred when attempting to write to the runner process.</source>
-        <translation type="unfinished"></translation>
+        <translation>При попытке записи в процесс запуска произошла ошибка.</translation>
     </message>
     <message>
         <location filename="../compiler/ojproblemcasesrunner.cpp" line="212"/>
         <source>An error occurred when attempting to read from the runner process.</source>
-        <translation type="unfinished"></translation>
+        <translation>При попытке чтения из процесса запуска произошла ошибка.</translation>
     </message>
 </context>
 <context>
@@ -7030,17 +7040,17 @@
     <message>
         <location filename="../widgets/ojproblemsetmodel.cpp" line="565"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblemsetmodel.cpp" line="567"/>
         <source>Time(ms)</source>
-        <translation type="unfinished"></translation>
+        <translation>Время(мс)</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblemsetmodel.cpp" line="570"/>
         <source>Memory(kb)</source>
-        <translation type="unfinished"></translation>
+        <translation>Память(КБ)</translation>
     </message>
 </context>
 <context>
@@ -7048,75 +7058,75 @@
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="20"/>
         <source>URL</source>
-        <translation type="unfinished"></translation>
+        <translation>Адрес</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="30"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="37"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="65"/>
         <source>Time Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Лимит времени</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="72"/>
         <source>Memory Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Лимит памяти</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="140"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.ui" line="147"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="30"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="54"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="82"/>
         <source>sec</source>
-        <translation type="unfinished"></translation>
+        <translation>сек</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="31"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="57"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>мс</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="32"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="62"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="86"/>
         <source>KB</source>
-        <translation type="unfinished"></translation>
+        <translation>КБ</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="33"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="65"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="88"/>
         <source>MB</source>
-        <translation type="unfinished"></translation>
+        <translation>МБ</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="34"/>
         <location filename="../widgets/ojproblempropertywidget.cpp" line="68"/>
         <source>GB</source>
-        <translation type="unfinished"></translation>
+        <translation>ГБ</translation>
     </message>
 </context>
 <context>
@@ -7124,104 +7134,104 @@
     <message>
         <location filename="../project.cpp" line="1015"/>
         <source>Error Load File</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки файла</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1040"/>
         <location filename="../project.cpp" line="1139"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1041"/>
         <source>Can&apos;t create folder %1 </source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя создать каталог %1 </translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1110"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Предупреждение</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1111"/>
         <location filename="../project.cpp" line="1140"/>
         <source>Can&apos;t save file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя сохранить файл %1</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1285"/>
         <source>File Exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл существует</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1286"/>
         <source>File &apos;%1&apos; is already in the project</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; уже существует в проекте</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1657"/>
         <source>Project Updated</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект обновлен</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1658"/>
         <source>Your project was succesfully updated to a newer file format!</source>
-        <translation type="unfinished"></translation>
+        <translation>Ваш проект успешно обновлен до нового формата файла!</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1660"/>
         <source>If something has gone wrong, we kept a backup-file: &apos;%1&apos;...</source>
-        <translation type="unfinished"></translation>
+        <translation>На случай, если что-то пойдет не так, мы сохранили резервную копию файла: &apos;%1&apos;...</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1731"/>
         <source>Headers</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочные файлы</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1739"/>
         <source>Sources</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходные файлы</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1747"/>
         <source>Others</source>
-        <translation type="unfinished"></translation>
+        <translation>Другие</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1967"/>
         <source>Settings need update</source>
-        <translation type="unfinished"></translation>
+        <translation>Необходимо обновить настройки</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1968"/>
         <source>The compiler settings format of Red Panda C++ has changed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменился формат настроек компилятора Red Panda C++.</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="1970"/>
         <source>Please update your settings at Project &gt;&gt; Project Options &gt;&gt; Compiler and save your project.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, обновите Ваши настроки в Проект &gt;&gt; Настройки проекта &gt;&gt; Компилятор и сохраните проект..</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2011"/>
         <source>Compiler not found</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор не найден</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2012"/>
         <source>The compiler set you have selected for this project, no longer exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор, выбранный Вами для этого проекта, более не поддерживается.</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2014"/>
         <source>It will be substituted by the global compiler set.</source>
-        <translation type="unfinished"></translation>
+        <translation>Он будет заменен глобальным набором компиляторов.</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2108"/>
         <source>Developed using the Red Panda C++ IDE</source>
-        <translation type="unfinished"></translation>
+        <translation>Разработано с использованием Red Panda C++ IDE</translation>
     </message>
 </context>
 <context>
@@ -7229,27 +7239,27 @@
     <message>
         <location filename="../widgets/projectalreadyopendialog.ui" line="14"/>
         <source>Open Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть проект</translation>
     </message>
     <message>
         <location filename="../widgets/projectalreadyopendialog.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Projects can either be opened in a new window or replace the project in the existing window or be attached to the already opened projects. How would you like to open the project?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Проекты можно либо открыть в новом окне, либо заменить проект в существующем окне, либо присоединить к уже открытым проектам. Как бы вы хотели открыть проект?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../widgets/projectalreadyopendialog.ui" line="62"/>
         <source>&amp;This Window</source>
-        <translation type="unfinished"></translation>
+        <translation>В &amp;этом окне</translation>
     </message>
     <message>
         <location filename="../widgets/projectalreadyopendialog.ui" line="72"/>
         <source>New &amp;Window</source>
-        <translation type="unfinished"></translation>
+        <translation>В новом &amp;Окне</translation>
     </message>
     <message>
         <location filename="../widgets/projectalreadyopendialog.ui" line="82"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -7257,49 +7267,49 @@
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="20"/>
         <source>Parallel Build</source>
-        <translation type="unfinished"></translation>
+        <translation>Параллельная сборка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="29"/>
         <source>Parallel Jobs(0 means infinite):</source>
-        <translation type="unfinished"></translation>
+        <translation>Количество параллельных заданий (0 - бесконечность):</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="59"/>
         <source>C Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="81"/>
         <source>C++ Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="103"/>
         <source>Linker</source>
-        <translation type="unfinished"></translation>
+        <translation>Связывание</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="146"/>
         <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="82"/>
         <source>Add Library Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить файлы библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.ui" line="160"/>
         <source>Resource</source>
-        <translation type="unfinished"></translation>
+        <translation>Ресурсы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="75"/>
         <location filename="../settingsdialog/projectcompileparamaterswidget.cpp" line="77"/>
         <source>Library Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы библиотеки</translation>
     </message>
 </context>
 <context>
@@ -7307,62 +7317,62 @@
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="127"/>
         <source>Building makefile...</source>
-        <translation type="unfinished"></translation>
+        <translation>Сборка makefile...</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="129"/>
         <source>- Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="133"/>
         <source>Can&apos;t open &apos;%1&apos; for write!</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя открыть для записи &apos;%1&apos;!</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="233"/>
         <source>- Resource File: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Файл ресурсов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="579"/>
         <source>Compiling project changes...</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция изменений проекта...</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="581"/>
         <source>- Project Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла проекта: %1</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="582"/>
         <source>- Compiler Set Name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя набора компиляторов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="591"/>
         <source>Make program &apos;%1&apos; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа сборки &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="593"/>
         <source>Please check the &quot;program&quot; page of compiler settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте вкладку &quot;Программа&quot; настроек компилятора.</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="633"/>
         <source>Processing makefile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Обработка makefile:</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="635"/>
         <source>- makefile processer: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- обработчик makefile: %1</translation>
     </message>
     <message>
         <location filename="../compiler/projectcompiler.cpp" line="637"/>
         <source>- Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Команда: %1</translation>
     </message>
 </context>
 <context>
@@ -7370,68 +7380,68 @@
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.ui" line="23"/>
         <source>Statically link libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Статически подключаемые библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.ui" line="46"/>
         <source>Base compiler set:</source>
-        <translation type="unfinished"></translation>
+        <translation>Основной набор компиляторов:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.ui" line="53"/>
         <source>Customize (apply to this project only):</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройка (применяется только для проектов):</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.ui" line="82"/>
         <source>Set Encoding for the executable:</source>
-        <translation type="unfinished"></translation>
+        <translation>Установка кодировки для исполнимых файлов:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="120"/>
         <source>System Default(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная по умолчанию(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="121"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="147"/>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="156"/>
         <source>Wrong Compiler Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Неправильный тип компилятора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="148"/>
         <source>Compiler %1 can&apos;t compile a microcontroller project.</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор %1 не может компилировать проект для микроконтроллера.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="157"/>
         <source>Compiler %1 can only compile microcontroller project.</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор %1 может только компилировать проекты для микроконтроллеров.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="167"/>
         <source>Change Project Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение набора компиляторов проекта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="168"/>
         <source>Change the project&apos;s compiler set will lose all custom compiler set options.</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменение компилятора проекта приведет к потере всех настроенных параметров компилятора.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectcompilerwidget.cpp" line="170"/>
         <source>Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите это сделать?</translation>
     </message>
 </context>
 <context>
@@ -7439,28 +7449,28 @@
     <message>
         <location filename="../settingsdialog/projectdllhostwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdllhostwidget.ui" line="20"/>
         <location filename="../settingsdialog/projectdllhostwidget.ui" line="23"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdllhostwidget.ui" line="33"/>
         <source>Host application for DLL:</source>
-        <translation type="unfinished"></translation>
+        <translation>Host-приложение для DLL:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdllhostwidget.cpp" line="57"/>
         <source>Choose host application</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор host-приложения</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdllhostwidget.cpp" line="59"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -7468,27 +7478,27 @@
     <message>
         <location filename="../settingsdialog/projectdirectorieswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="30"/>
         <source>Binaries</source>
-        <translation type="unfinished"></translation>
+        <translation>Двоичные файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="32"/>
         <source>Libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="34"/>
         <source>Includes</source>
-        <translation type="unfinished"></translation>
+        <translation>Включаемые файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectdirectorieswidget.cpp" line="36"/>
         <source>Resources</source>
-        <translation type="unfinished"></translation>
+        <translation>Ресурсы</translation>
     </message>
 </context>
 <context>
@@ -7496,42 +7506,42 @@
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="41"/>
         <source>File Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="62"/>
         <source>Build Priority:</source>
-        <translation type="unfinished"></translation>
+        <translation>Приоритет сборки:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="91"/>
         <source>Include in compilation</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить при компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="98"/>
         <source>Include in linking</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить при связывании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="105"/>
         <source>Compile files as C++</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилировать файлы как Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="127"/>
         <source>Encoding</source>
-        <translation type="unfinished"></translation>
+        <translation>Кодировка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.ui" line="164"/>
         <source>Override build command:</source>
-        <translation type="unfinished"></translation>
+        <translation>Переопределить команду сборки:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="39"/>
@@ -7539,27 +7549,27 @@
         <location filename="../settingsdialog/projectfileswidget.cpp" line="268"/>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="270"/>
         <source>Project(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="39"/>
         <source>System Default</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная по умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="268"/>
         <source>ANSI</source>
-        <translation type="unfinished"></translation>
+        <translation>ANSI</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="272"/>
         <source>System Default(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Системная по умолчанию(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectfileswidget.cpp" line="273"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
 </context>
 <context>
@@ -7567,107 +7577,107 @@
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="20"/>
         <source>Default encoding:</source>
-        <translation type="unfinished"></translation>
+        <translation>Кодировка по умолчанию:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="78"/>
         <source>Output File:</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл вывода:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="85"/>
         <source>Default to C++ when creating new files</source>
-        <translation type="unfinished"></translation>
+        <translation>Си++ по умолчанию при создании новых файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="92"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="102"/>
         <source>Files:</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="109"/>
         <source>File Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="129"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="136"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="143"/>
         <source>Support Windows XP Themes</source>
-        <translation type="unfinished"></translation>
+        <translation>Поддержка тем Windows XP</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="159"/>
         <source>Icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Значок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="165"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.ui" line="223"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="97"/>
         <source>%1 files [ %2 sources, %3 headers, %4 resources, %5 other files ]</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 файлов [ %2 исходных файлов, %3 заголовчных файлов, %4 ресурсов, %5 других файлов ]</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="156"/>
         <source>Can&apos;t remove old icon file</source>
-        <translation type="unfinished"></translation>
+        <translation>Не получилось удалить старый файл значка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="157"/>
         <source>Can&apos;t remove old icon file &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не получилось удалить старый файл значка &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="179"/>
         <source>Select icon file</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор файла значка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="181"/>
         <source>Image Files (*.ico *.png *.jpg)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы изображений (*.ico *.png *.jpg)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="222"/>
         <source>System Default(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Системный по-умолчанию(%1)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="223"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectgeneralwidget.cpp" line="224"/>
         <source>UTF-8 BOM</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8 BOM</translation>
     </message>
 </context>
 <context>
@@ -7675,38 +7685,38 @@
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="20"/>
         <source>Use custom make file</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать пользовательский файл сборки (makefile)</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="32"/>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="35"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="45"/>
         <source>Information about using a custom make file </source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о использовании пользовательского файла сборки </translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.ui" line="52"/>
         <source>Include the following files into the makefile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить следующие файлы в makefile:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.cpp" line="67"/>
         <source>Custom makefile</source>
-        <translation type="unfinished"></translation>
+        <translation>Пользовательский makefile</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectmakefilewidget.cpp" line="69"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -7714,32 +7724,32 @@
     <message>
         <location filename="../project.cpp" line="2695"/>
         <source>File exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл существует</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2696"/>
         <source>File &apos;%1&apos; already exists. Delete it now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &apos;%1&apos; уже существует. Удалить его?</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2714"/>
         <source>Remove failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Удаление не удалось</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2715"/>
         <source>Failed to remove file &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось удалить файл &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2732"/>
         <source>Rename failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименование не удалось</translation>
     </message>
     <message>
         <location filename="../project.cpp" line="2733"/>
         <source>Failed to rename file &apos;%1&apos; to &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось переименовать файл &apos;%1&apos; в &apos;%2&apos;</translation>
     </message>
 </context>
 <context>
@@ -7747,54 +7757,54 @@
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="20"/>
         <source>Directory for output</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог вывода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="29"/>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="48"/>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="73"/>
         <source>browse</source>
-        <translation type="unfinished"></translation>
+        <translation>выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="39"/>
         <source>Directory for obj files</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог для объектных файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="58"/>
         <source>Auto save compile log</source>
-        <translation type="unfinished"></translation>
+        <translation>Автосохранение протокола компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.ui" line="83"/>
         <source>Override output filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Переопределение файла вывода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.cpp" line="67"/>
         <source>Executable output directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог для исполнимого файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.cpp" line="81"/>
         <source>Object files output directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог для объектных файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.cpp" line="96"/>
         <source>Log file</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл протокола</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectoutputwidget.cpp" line="98"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -7802,38 +7812,38 @@
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="20"/>
         <source>Use precompiled header</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать предварительно спомпилированный заголовочный файл</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="44"/>
         <source>Header to be precompiled:</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочный файл для предварительной компиляции:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="54"/>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="57"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.ui" line="73"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For more information about gcc precompiled header, see:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Для более подробной информации о предварительно скомпилированных заголовочных файлах gcc смотрите:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.cpp" line="61"/>
         <source>Select the header file to be precompiled</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор заголовочного файла для предварительной компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectprecompilewidget.cpp" line="63"/>
         <source>Header files (*.h *.hh *.hpp)</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочные файлы (*.h *.hh *.hpp)</translation>
     </message>
 </context>
 <context>
@@ -7841,32 +7851,32 @@
     <message>
         <location filename="../projecttemplate.cpp" line="76"/>
         <source>Read failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение не удалось.</translation>
     </message>
     <message>
         <location filename="../projecttemplate.cpp" line="77"/>
         <source>Can&apos;t read template file &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя прочитать файл шаблона &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../projecttemplate.cpp" line="83"/>
         <source>Can&apos;t Open Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя открыть шаблон</translation>
     </message>
     <message>
         <location filename="../projecttemplate.cpp" line="84"/>
         <source>Can&apos;t open template file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя открыть на чтение файл шаблона &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../projecttemplate.cpp" line="92"/>
         <source>Old version template</source>
-        <translation type="unfinished"></translation>
+        <translation>Старая версия шаблона</translation>
     </message>
     <message>
         <location filename="../projecttemplate.cpp" line="93"/>
         <source>Template file &apos;%1&apos; has version &apos;%2&apos;, which is unsupported.</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл шаблона &apos;%1&apos; имеет не поддерживаемую версию &apos;%2&apos;.</translation>
     </message>
 </context>
 <context>
@@ -7874,92 +7884,92 @@
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="20"/>
         <source>Include version info in project</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить информацию о версии в проект</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="46"/>
         <source>Major</source>
-        <translation type="unfinished"></translation>
+        <translation>Старший</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="53"/>
         <source>Minor</source>
-        <translation type="unfinished"></translation>
+        <translation>Младший</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="60"/>
         <source>Rlease</source>
-        <translation type="unfinished"></translation>
+        <translation>Выпуск</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="81"/>
         <source>Build</source>
-        <translation type="unfinished"></translation>
+        <translation>Сборка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="107"/>
         <source>Language:</source>
-        <translation type="unfinished"></translation>
+        <translation>Язык:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="133"/>
         <source>Original filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходное имя файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="143"/>
         <source>Sync product with file version</source>
-        <translation type="unfinished"></translation>
+        <translation>Синхрованизация продукта с версией файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="150"/>
         <source>Internal name</source>
-        <translation type="unfinished"></translation>
+        <translation>Внутреннее имя</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="163"/>
         <source>File version</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="170"/>
         <source>Legal trademarks</source>
-        <translation type="unfinished"></translation>
+        <translation>Торговые марки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="177"/>
         <source>Product name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя продукта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="187"/>
         <source>Company name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя компании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="197"/>
         <source>Auto-increase build number on compile</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоувеличение номера сборки при компиляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="207"/>
         <source>File description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание файла</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="214"/>
         <source>Product version</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия продукта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/projectversioninfowidget.ui" line="224"/>
         <source>Legal copyright</source>
-        <translation type="unfinished"></translation>
+        <translation>Авторское право</translation>
     </message>
 </context>
 <context>
@@ -7967,7 +7977,7 @@
     <message>
         <location filename="../main.cpp" line="479"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
 </context>
 <context>
@@ -7980,51 +7990,51 @@
         <location filename="../widgets/ojproblemsetmodel.cpp" line="167"/>
         <location filename="../widgets/ojproblemsetmodel.cpp" line="230"/>
         <source>Can&apos;t open file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для чтения.</translation>
     </message>
     <message>
         <location filename="../autolinkmanager.cpp" line="59"/>
         <location filename="../autolinkmanager.cpp" line="75"/>
         <location filename="../autolinkmanager.cpp" line="106"/>
         <source>Can&apos;t open file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для записи.</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="68"/>
         <source>Can&apos;t open file &apos;%1&apos; for read</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для чтения</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="77"/>
         <source>Can&apos;t parse json file &apos;%1&apos; at offset %2! Error Code: %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно расшифровать json-файл &apos;%1&apos; на смещении %2! Код ошибки: %3</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="81"/>
         <source>Can&apos;t parse json file &apos;%1&apos; is not a color scheme config file!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно расшифровать json-файл &apos;%1&apos; - это не конфигурационный файл цветовой схемы!</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="106"/>
         <source>Can&apos;t open file &apos;%1&apos; for write</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &apos;%1&apos; для записи</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="347"/>
         <source>Can&apos;t Find the color scheme file %1!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно найти файл цветовой схемы %1!</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="351"/>
         <location filename="../colorscheme.cpp" line="369"/>
         <location filename="../colorscheme.cpp" line="374"/>
         <source>Can&apos;t remove the color scheme file %1!</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно удалить файл цветовой схемы %1!</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="439"/>
         <source>Character</source>
-        <translation type="unfinished"></translation>
+        <translation>Символ</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="440"/>
@@ -8052,127 +8062,127 @@
         <location filename="../colorscheme.cpp" line="530"/>
         <location filename="../colorscheme.cpp" line="534"/>
         <source>Syntax</source>
-        <translation type="unfinished"></translation>
+        <translation>Синтаксис</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="443"/>
         <source>Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>Комментарий</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="447"/>
         <source>Class</source>
-        <translation type="unfinished"></translation>
+        <translation>Класс</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="451"/>
         <source>Float</source>
-        <translation type="unfinished"></translation>
+        <translation>Вещественный</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="455"/>
         <source>Function</source>
-        <translation type="unfinished"></translation>
+        <translation>Функция</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="459"/>
         <source>Gloabal Variable</source>
-        <translation type="unfinished"></translation>
+        <translation>Глобальная переменная</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="463"/>
         <source>Hexadecimal Integer</source>
-        <translation type="unfinished"></translation>
+        <translation>Шестнадцатеричное целое</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="467"/>
         <source>Identifier</source>
-        <translation type="unfinished"></translation>
+        <translation>Идентификатор</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="471"/>
         <source>Illegal Char</source>
-        <translation type="unfinished"></translation>
+        <translation>Некорректный Символ</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="475"/>
         <source>Local Variable</source>
-        <translation type="unfinished"></translation>
+        <translation>Локальная переменная</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="479"/>
         <source>Integer</source>
-        <translation type="unfinished"></translation>
+        <translation>Целое</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="483"/>
         <source>Octal Integer</source>
-        <translation type="unfinished"></translation>
+        <translation>Восьмеричное Целое</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="487"/>
         <source>Preprocessor</source>
-        <translation type="unfinished"></translation>
+        <translation>Препроцессор</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="491"/>
         <source>Reserve Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Зарезервированное слово</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="495"/>
         <source>Reserve Word for Types</source>
-        <translation type="unfinished"></translation>
+        <translation>Зарезервированное слово для типов</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="499"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation>Пробел</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="503"/>
         <source>String</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="507"/>
         <source>Escape Sequences</source>
-        <translation type="unfinished"></translation>
+        <translation>Escape-последовательности</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="511"/>
         <source>Symbol</source>
-        <translation type="unfinished"></translation>
+        <translation>Символ</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="515"/>
         <source>Variable</source>
-        <translation type="unfinished"></translation>
+        <translation>Переменная</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="521"/>
         <source>Brace/Bracket/Parenthesis Level 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные/Квадратные/Круглые скобки уровня 1</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="525"/>
         <source>Brace/Bracket/Parenthesis Level 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные/Квадратные/Круглые скобки уровня 2</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="529"/>
         <source>Brace/Bracket/Parenthesis Level 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные/Квадратные/Круглые скобки уровня 3</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="533"/>
         <source>Brace/Bracket/Parenthesis Level 4</source>
-        <translation type="unfinished"></translation>
+        <translation>Фигурные/Квадратные/Круглые скобки уровня 4</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="539"/>
         <source>Gutter</source>
-        <translation type="unfinished"></translation>
+        <translation>Поле (корешок)</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="540"/>
@@ -8185,542 +8195,543 @@
         <location filename="../colorscheme.cpp" line="574"/>
         <location filename="../colorscheme.cpp" line="579"/>
         <source>Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактор</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="543"/>
         <source>Gutter Active Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Активная строка на полях</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="548"/>
         <source>Active Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Активная строка</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="553"/>
         <source>Breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Точка останова</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="558"/>
         <source>Active Breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Активная точка останова</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="563"/>
         <source>Fold Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Разделительная линия</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="568"/>
         <source>Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделение</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="573"/>
         <source>Editor Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Текст редактора</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="578"/>
         <source>Current Highlighted Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущее подсвеченное слово</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="584"/>
         <location filename="../main.cpp" line="235"/>
         <location filename="../main.cpp" line="242"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="585"/>
         <location filename="../colorscheme.cpp" line="589"/>
         <source>Syntax Check</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка синтаксиса</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="588"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Предупреждение</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="609"/>
         <location filename="../colorscheme.cpp" line="615"/>
         <source>Rename file &apos;%1&apos; to &apos;%2&apos; failed!</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименование файла &apos;%1&apos; в &apos;%2&apos; не удалось!</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="624"/>
         <source>Scheme &apos;%1&apos; already exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Схема &apos;%1&apos; уже существует!</translation>
     </message>
     <message>
         <location filename="../colorscheme.cpp" line="764"/>
         <source>default</source>
-        <translation type="unfinished"></translation>
+        <translation>по умолчанию</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="92"/>
         <location filename="../compiler/compilerinfo.cpp" line="442"/>
         <source>Code Generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Генерация кода</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="101"/>
         <source>Optimization level (-Ox)</source>
-        <translation type="unfinished"></translation>
+        <translation>Уровень оптимизации (-Ox)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="117"/>
         <source>C++ Language standard (-std)</source>
-        <translation type="unfinished"></translation>
+        <translation>Стандарт языка Си++ (-std)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="128"/>
         <source>C Language standard (-std)</source>
-        <translation type="unfinished"></translation>
+        <translation>Стандарт языка Си (-std)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="178"/>
         <source>Enable use of specific instructions (-mx)</source>
-        <translation type="unfinished"></translation>
+        <translation>Разрешить использование специфических инструкций (-mx)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="182"/>
         <source>32-bit pointer, 32-bit instruction (-m32)</source>
-        <translation type="unfinished"></translation>
+        <translation>32-битные указатели, 32-битные инструкции (-m32)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="183"/>
         <source>32-bit pointer, 64-bit instruction (-mx32)</source>
-        <translation type="unfinished"></translation>
+        <translation>32-битные указатели, 64-битные инструкции (-mx32)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="184"/>
         <source>64-bit pointer, 64-bit instruction (-m64)</source>
-        <translation type="unfinished"></translation>
+        <translation>64-битные указатели, 64-битные инструкции (-m64)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="185"/>
         <source>x86 multilib (-mx)</source>
-        <translation type="unfinished"></translation>
+        <translation>x86 multilib (-mx)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="187"/>
         <source>Generate debugging information (-g3)</source>
-        <translation type="unfinished"></translation>
+        <translation>Встраивать отладочную информацию (-g3)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="188"/>
         <source>Generate profiling info for analysis (-pg)</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить информацию профилирования для анализа (-pg)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="189"/>
         <source>Only check the code for syntax errors (-fsyntax-only)</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверять код только на синтаксические ошибки (-fsyntax-only)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="192"/>
         <source>Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation>Предупреждения</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="193"/>
         <source>Inhibit all warning messages (-w)</source>
-        <translation type="unfinished"></translation>
+        <translation>Отключить все предупреждающие сообщения (-w)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="194"/>
         <source>Show most warnings (-Wall)</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать большинство предупреждений (-Wall)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="195"/>
         <source>Show some more warnings (-Wextra)</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать больше предупреждений (-Wextra)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="196"/>
         <source>Check ISO C/C++ conformance (-pedantic)</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка соответствия ISO Си/Си++ (-pedantic)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="197"/>
         <source>Make all warnings into errors (-Werror)</source>
-        <translation type="unfinished"></translation>
+        <translation>Превратить все предупреждения в ошибки (-Werror)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="198"/>
         <source>Abort compilation on first error (-Wfatal-errors)</source>
-        <translation type="unfinished"></translation>
+        <translation>Прервать компиляцию при первой ошибке (-Wfatal-errors)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="204"/>
         <source>Check for stack smashing attacks (-fstack-protector)</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверять наличие атак, разрушающих стек (-fstack-protector)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="211"/>
         <source>Enable Sanitizer (-fsanitize=)</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить Санитайзер (-fsanitize=)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="220"/>
         <source>Linker</source>
-        <translation type="unfinished"></translation>
+        <translation>Связывание</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="222"/>
         <source>Stack Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер стека</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="225"/>
         <source>Use pipes instead of temporary files during compilation (-pipe)</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать каналы (pipes) вместо временных файлов во время компиляции (-pipe)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="227"/>
         <source>Do not use standard system libraries (-nostdlib)</source>
-        <translation type="unfinished"></translation>
+        <translation>Не использовать стандартные системные библиотеки (-nostdlib)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="228"/>
         <source>Do not create a console window (-mwindows)</source>
-        <translation type="unfinished"></translation>
+        <translation>Не создавать консольное окно (-mwindows)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="229"/>
         <source>Strip executable (-s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Удаление несущественной информации (strip) из исполнимых файлов (-s)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="461"/>
         <source>Processor (-m)</source>
-        <translation type="unfinished"></translation>
+        <translation>Процессор (-m)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="475"/>
         <source>Language standard (--std)</source>
-        <translation type="unfinished"></translation>
+        <translation>Стандарт Языка (--std)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="483"/>
         <source>Memory model (--model)</source>
-        <translation type="unfinished"></translation>
+        <translation>Модель памяти (--model)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="485"/>
         <source>Use external stack</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать внешний стек</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="486"/>
         <source>Use movc instead of movx to read from external ram</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать movc вместо movx для чтения из внешней памяти</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="487"/>
         <source>Replaces lcall/ljmp with acall/ajmp</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменять lcall/ljmp на acall/ajmp</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="488"/>
         <source>Don&apos;t memcpy initialized xram from code</source>
-        <translation type="unfinished"></translation>
+        <translation>Не позволять memcpy инициализировать xram из кода</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="489"/>
         <source>Don&apos;t generate startup code</source>
-        <translation type="unfinished"></translation>
+        <translation>Не создавать код запуска</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="491"/>
         <source>MCU Specification</source>
-        <translation type="unfinished"></translation>
+        <translation>Спецификация MCU</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="493"/>
         <source>Internal ram size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер внутренней памяти</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="494"/>
         <source>External ram start location</source>
-        <translation type="unfinished"></translation>
+        <translation>Начало размещения внешней памяти</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="495"/>
         <source>External ram size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер внешней памяти</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="496"/>
         <source>Stack pointer initial value</source>
-        <translation type="unfinished"></translation>
+        <translation>Начальный адрес указателя стека</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="497"/>
         <source>External stack start location</source>
-        <translation type="unfinished"></translation>
+        <translation>Начало размещения внешнего стека</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="498"/>
         <source>Direct data start location</source>
-        <translation type="unfinished"></translation>
+        <translation>Начало размещения первичных данных (direct data)</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="499"/>
         <source>Code segment location</source>
-        <translation type="unfinished"></translation>
+        <translation>Размещение сегмента кода</translation>
     </message>
     <message>
         <location filename="../compiler/compilerinfo.cpp" line="500"/>
         <source>Code segment size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер сегмента кода</translation>
     </message>
     <message>
         <location filename="../editorlist.cpp" line="178"/>
         <location filename="../mainwindow.cpp" line="3404"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение</translation>
     </message>
     <message>
         <location filename="../editorlist.cpp" line="179"/>
         <location filename="../mainwindow.cpp" line="3405"/>
         <source>Save changes to %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить изменения в %1?</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="236"/>
         <source>Can&apos;t create configuration folder %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удаётся создать папку с настройками %1</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="243"/>
         <source>Can&apos;t write to configuration file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможна запись в конфигурационный файл %1</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="429"/>
         <source>Can&apos;t load autolink settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно загрузить настройки автосвязывания</translation>
     </message>
     <message>
         <location filename="../parser/cppparser.cpp" line="1342"/>
         <source>constructor</source>
-        <translation type="unfinished"></translation>
+        <translation>constructor</translation>
     </message>
     <message>
         <location filename="../parser/cppparser.cpp" line="1349"/>
         <source>destructor</source>
-        <translation type="unfinished"></translation>
+        <translation>destructor</translation>
     </message>
     <message>
         <location filename="../problems/freeprojectsetformat.cpp" line="12"/>
         <source>Can&apos;t open file &quot;%1&quot; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &quot;%1&quot; для чтения.</translation>
     </message>
     <message>
         <location filename="../problems/freeprojectsetformat.cpp" line="35"/>
         <source>Problem Case %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Проблемный случай %1</translation>
     </message>
     <message>
         <location filename="../problems/freeprojectsetformat.cpp" line="102"/>
         <source>Can&apos;t open file &quot;%1&quot; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть файл &quot;%1&quot; для записи.</translation>
     </message>
     <message>
         <location filename="../problems/freeprojectsetformat.cpp" line="188"/>
         <source>Error when writing file &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи файла &quot;%1&quot;.</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3000"/>
         <source>C Compiler &quot;%1&quot; is missing!</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си &quot;%1&quot; утрачен!</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3003"/>
         <source>C++ Compiler &quot;%1&quot; is missing!</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор Си++ &quot;%1&quot; утрачен!</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3006"/>
         <source>Debugger &quot;%1&quot; is missing!</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик &quot;%1&quot; утрачен!</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3009"/>
         <source>Make program &quot;%1&quot; is missing!</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа сборки &quot;%1&quot; утрачена!</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3233"/>
         <source>Error executing platform compiler hint add-on</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Сомнительный перевод, надо переделать</translatorcomment>
+        <translation>Ошибка при запуске дополнения с подсказкой компилятора платформы</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3367"/>
         <location filename="../settings.cpp" line="3373"/>
         <source>Compiler set not configuared.</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляторов не настроен.</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3369"/>
         <source>Would you like Red Panda C++ to search for compilers in the following locations: &lt;BR /&gt;&apos;%1&apos;&lt;BR /&gt;&apos;%2&apos;? </source>
-        <translation type="unfinished"></translation>
+        <translation>Вы хотели бы, чтобы Красная Панда Си++ поискала компиляторы в следующих местах: &lt;BR /&gt;&apos;%1&apos;&lt;BR /&gt;&apos;%2&apos;? </translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3375"/>
         <source>Would you like Red Panda C++ to search for compilers in PATH?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы хотели бы, чтобы Красная Панда Си++ поискала компиляторы в PATH?</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3377"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтверждение</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3386"/>
         <source>No Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет набора компиляторов</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3387"/>
         <source>Can&apos;t find a C/C++ compiler.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не могу найти компилятор Си/Си++.</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3389"/>
         <source>You must have a compiler to compile and execute C/C++ files.</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы должны иметь компилятор, чтобы компилировать файлы Си/Си++.</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="39"/>
         <source>Binaries</source>
-        <translation type="unfinished"></translation>
+        <translation>Двоичные файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="41"/>
         <source>Libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Библиотеки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="43"/>
         <source>C Includes</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключаемые файлы Си</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="45"/>
         <source>C++ Includes</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключаемые файлы Си++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="410"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/compilersetoptionwidget.cpp" line="411"/>
         <source>Do you really want to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы действительно хотите удалить &quot;%1&quot;?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.cpp" line="69"/>
         <source>Auto Detection Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоопределение не удалось</translation>
     </message>
     <message>
         <location filename="../settingsdialog/environmentprogramswidget.cpp" line="70"/>
         <source>Failed to detect terminal arguments pattern for “%1”.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось определить шаблон аргументов терминала для “%1”.</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="29"/>
         <location filename="../systemconsts.cpp" line="31"/>
         <source>All files</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="33"/>
         <source>Dev C++ Project files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы проектов Dev C++</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="34"/>
         <source>C files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Си</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="35"/>
         <source>C++ files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Си++</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="36"/>
         <source>Header files</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовочные файлы</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="37"/>
         <source>GAS files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы GAS</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="38"/>
         <source>Lua files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы Lua</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="40"/>
         <source>Icon files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы значков</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="94"/>
         <source>Executable files (*.exe)</source>
-        <translation type="unfinished"></translation>
+        <translation>Исполнимые файлы (*.exe)</translation>
     </message>
     <message>
         <location filename="../systemconsts.cpp" line="96"/>
         <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (*.*)</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="538"/>
         <source>bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>Бт</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="540"/>
         <source>KB</source>
-        <translation type="unfinished"></translation>
+        <translation>КБ</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="542"/>
         <source>MB</source>
-        <translation type="unfinished"></translation>
+        <translation>МБ</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="544"/>
         <source>GB</source>
-        <translation type="unfinished"></translation>
+        <translation>ГБ</translation>
     </message>
     <message>
         <location filename="../vcs/gitmanager.cpp" line="475"/>
         <location filename="../vcs/gitmergedialog.cpp" line="18"/>
         <source>&lt;Auto Generated by Git&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;Автоматически сформировано Git&gt;</translation>
     </message>
     <message>
         <location filename="../widgets/ojproblemsetmodel.cpp" line="182"/>
         <source>Can&apos;t parse problem set file &apos;%1&apos;:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно расшифроваь файл с набором проблем &apos;%1&apos;:%2</translation>
     </message>
 </context>
 <context>
@@ -8752,55 +8763,55 @@
         <location filename="../debugger/debugger.cpp" line="2163"/>
         <location filename="../debugger/debugger.cpp" line="2164"/>
         <source>64-bit</source>
-        <translation type="unfinished"></translation>
+        <translation>64-бит</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2053"/>
         <location filename="../debugger/debugger.cpp" line="2073"/>
         <source>Accumulator for operands and results data</source>
-        <translation type="unfinished"></translation>
+        <translation>Аккумулятор для операндов и данных результата</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2054"/>
         <location filename="../debugger/debugger.cpp" line="2074"/>
         <source>Pointer to data in the DS segment</source>
-        <translation type="unfinished"></translation>
+        <translation>Указатель на данные в сегменте DS</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2055"/>
         <location filename="../debugger/debugger.cpp" line="2075"/>
         <source>Counter for string and loop operations</source>
-        <translation type="unfinished"></translation>
+        <translation>Счетчик для строк и операций цикла</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2056"/>
         <location filename="../debugger/debugger.cpp" line="2076"/>
         <source>I/O pointer</source>
-        <translation type="unfinished"></translation>
+        <translation>Указатель для ввода-вывода</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2057"/>
         <location filename="../debugger/debugger.cpp" line="2077"/>
         <source>Source index for string operations; Pointer to data in the segment pointed to by the DS register</source>
-        <translation type="unfinished"></translation>
+        <translation>Индекс источника для операций со строками; Указатель на данные в сегменте, на который указывает регистр DS</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2058"/>
         <location filename="../debugger/debugger.cpp" line="2078"/>
         <source>Destination index for string operations; Pointer to data (or destination) in the segment pointed to by the ES register</source>
-        <translation type="unfinished"></translation>
+        <translation>Индекс назначения для операций со строками; Указатель на данные (или назначение) в сегменте, на который указывает регистр ES</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2059"/>
         <location filename="../debugger/debugger.cpp" line="2079"/>
         <source>Stack pointer (in the SS segment)</source>
-        <translation type="unfinished"></translation>
+        <translation>Указатель стека (в сегменте SS)</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2060"/>
         <location filename="../debugger/debugger.cpp" line="2080"/>
         <source>Pointer to data on the stack (in the SS segment)</source>
-        <translation type="unfinished"></translation>
+        <translation>Указатель на данные стека (в сегменте SS)</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2061"/>
@@ -8820,19 +8831,19 @@
         <location filename="../debugger/debugger.cpp" line="2087"/>
         <location filename="../debugger/debugger.cpp" line="2088"/>
         <source>General purpose</source>
-        <translation type="unfinished"></translation>
+        <translation>Общее назначение</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2069"/>
         <location filename="../debugger/debugger.cpp" line="2089"/>
         <source>Instruction pointer</source>
-        <translation type="unfinished"></translation>
+        <translation>Указатель инструкций</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2070"/>
         <location filename="../debugger/debugger.cpp" line="2071"/>
         <source>Flags</source>
-        <translation type="unfinished"></translation>
+        <translation>Флаги</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2073"/>
@@ -8853,7 +8864,7 @@
         <location filename="../debugger/debugger.cpp" line="2088"/>
         <location filename="../debugger/debugger.cpp" line="2089"/>
         <source>32-bit</source>
-        <translation type="unfinished"></translation>
+        <translation>32-бит</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2091"/>
@@ -8874,7 +8885,7 @@
         <location filename="../debugger/debugger.cpp" line="2106"/>
         <location filename="../debugger/debugger.cpp" line="2107"/>
         <source>lower 16 bits of %1</source>
-        <translation type="unfinished"></translation>
+        <translation>младшие 16 бит %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2109"/>
@@ -8894,7 +8905,7 @@
         <location filename="../debugger/debugger.cpp" line="2123"/>
         <location filename="../debugger/debugger.cpp" line="2124"/>
         <source>lower 8 bits of %1</source>
-        <translation type="unfinished"></translation>
+        <translation>младшие 8 бит %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2126"/>
@@ -8902,7 +8913,7 @@
         <location filename="../debugger/debugger.cpp" line="2128"/>
         <location filename="../debugger/debugger.cpp" line="2129"/>
         <source>8 high bits of lower 16 bits of %1</source>
-        <translation type="unfinished"></translation>
+        <translation>старшие 8 бит младших 16 бит %1</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2131"/>
@@ -8912,29 +8923,29 @@
         <location filename="../debugger/debugger.cpp" line="2135"/>
         <location filename="../debugger/debugger.cpp" line="2136"/>
         <source>16-bit</source>
-        <translation type="unfinished"></translation>
+        <translation>16-бит</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2131"/>
         <source>Code segment selector</source>
-        <translation type="unfinished"></translation>
+        <translation>Селектор сегмента кода</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2132"/>
         <source>Data segment selector</source>
-        <translation type="unfinished"></translation>
+        <translation>Селектор сегмента данных</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2133"/>
         <location filename="../debugger/debugger.cpp" line="2134"/>
         <location filename="../debugger/debugger.cpp" line="2135"/>
         <source>Extra data segment selector</source>
-        <translation type="unfinished"></translation>
+        <translation>Селектор дополнительного сегмента данных</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2136"/>
         <source>Stack segment selector</source>
-        <translation type="unfinished"></translation>
+        <translation>Селектор сегмента стека</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2139"/>
@@ -8946,47 +8957,47 @@
         <location filename="../debugger/debugger.cpp" line="2145"/>
         <location filename="../debugger/debugger.cpp" line="2146"/>
         <source>Floating-point data</source>
-        <translation type="unfinished"></translation>
+        <translation>Вещественные данные</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2148"/>
         <source>Floating-point control</source>
-        <translation type="unfinished"></translation>
+        <translation>Вещественный контроль</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2149"/>
         <source>Floating-point status</source>
-        <translation type="unfinished"></translation>
+        <translation>Вещественный статус</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2150"/>
         <source>Floating-point tag word</source>
-        <translation type="unfinished"></translation>
+        <translation>Floating-point tag word</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2151"/>
         <source>Floating-point operation</source>
-        <translation type="unfinished"></translation>
+        <translation>Вещественная операция</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2152"/>
         <source>Floating-point last instruction segment</source>
-        <translation type="unfinished"></translation>
+        <translation>Сегмент последней вещественной инструкции</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2153"/>
         <source>Floating-point last instruction offset</source>
-        <translation type="unfinished"></translation>
+        <translation>Смещение последней вещественной инструкции</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2154"/>
         <source>Floating-point last operand segment</source>
-        <translation type="unfinished"></translation>
+        <translation>Сегмент последнего вещественного операнда</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2155"/>
         <source>Floating-point last operand offset</source>
-        <translation type="unfinished"></translation>
+        <translation>Смещение последнего вещественного операнда</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2166"/>
@@ -9005,7 +9016,7 @@
         <location filename="../debugger/debugger.cpp" line="2179"/>
         <location filename="../debugger/debugger.cpp" line="2180"/>
         <source>128-bit</source>
-        <translation type="unfinished"></translation>
+        <translation>128-бит</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2182"/>
@@ -9024,22 +9035,22 @@
         <location filename="../debugger/debugger.cpp" line="2195"/>
         <location filename="../debugger/debugger.cpp" line="2196"/>
         <source>256-bit</source>
-        <translation type="unfinished"></translation>
+        <translation>256-бит</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2198"/>
         <source>SSE status and control</source>
-        <translation type="unfinished"></translation>
+        <translation>SSE статус и контроль</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2253"/>
         <source>Register</source>
-        <translation type="unfinished"></translation>
+        <translation>Регистр</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2255"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Значение</translation>
     </message>
 </context>
 <context>
@@ -9047,55 +9058,55 @@
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="50"/>
         <source>Compiling single file...</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция единственного файла...</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="52"/>
         <source>- Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="53"/>
         <source>- Compiler Set Name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя набора компиляторов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="64"/>
         <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="66"/>
         <source>Please check the &quot;program&quot; page of compiler settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте вкладку &quot;Программа&quot; настроек компилятора.</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="90"/>
         <location filename="../compiler/sdccfilecompiler.cpp" line="100"/>
         <source>Can&apos;t find &quot;%1&quot;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Не найдено &quot;%1&quot;. </translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="109"/>
         <source>Processing %1 source file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Обработка исходного файла %1:</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="111"/>
         <source>- %1 Compiler: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Компилятор: %2</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="113"/>
         <source>- Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Команда: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccfilecompiler.cpp" line="146"/>
         <source>Can&apos;t delete the old executable file &quot;%1&quot;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно удалить старый исполнимый файл &quot;%1&quot;. </translation>
     </message>
 </context>
 <context>
@@ -9103,57 +9114,57 @@
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="73"/>
         <source>Building makefile...</source>
-        <translation type="unfinished"></translation>
+        <translation>Сборка makefile...</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="75"/>
         <source>- Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="79"/>
         <source>Can&apos;t open &apos;%1&apos; for write!</source>
-        <translation type="unfinished"></translation>
+        <translation>Нельзя открыть для записи &apos;%1&apos;!</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="301"/>
         <source>Compiling project changes...</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция изменений проекта...</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="303"/>
         <source>- Project Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла проекта: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="304"/>
         <source>- Compiler Set Name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя набора компиляторов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="313"/>
         <source>Make program &apos;%1&apos; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа сборки &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="315"/>
         <source>Please check the &quot;program&quot; page of compiler settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Пожалуйста, проверьте вкладку &quot;Программа&quot; настроек компилятора.</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="355"/>
         <source>Processing makefile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Обработка makefile:</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="357"/>
         <source>- makefile processer: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- обработчик makefile: %1</translation>
     </message>
     <message>
         <location filename="../compiler/sdccprojectcompiler.cpp" line="359"/>
         <source>- Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Команда: %1</translation>
     </message>
 </context>
 <context>
@@ -9161,150 +9172,150 @@
     <message>
         <location filename="../widgets/searchdialog.ui" line="14"/>
         <source>Find</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="80"/>
         <source>Text to Find:</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск текста:</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="122"/>
         <source>Replace with:</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменить на:</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="147"/>
         <source>Scope:</source>
-        <translation type="unfinished"></translation>
+        <translation>Область поиска:</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="165"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
+        <translation>Глобальный</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="175"/>
         <source>Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Выделение</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="185"/>
         <source>Origin:</source>
-        <translation type="unfinished"></translation>
+        <translation>Начало:</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="203"/>
         <source>From cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>От курсора</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="213"/>
         <source>Entire scope</source>
-        <translation type="unfinished"></translation>
+        <translation>Вся область</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="223"/>
         <source>Options:</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры:</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="263"/>
         <source>Regular Expression</source>
-        <translation type="unfinished"></translation>
+        <translation>Регулярные выражения</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="270"/>
         <source>Close after search</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть после поиска</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="277"/>
         <source>Whole words only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только целые слова</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="284"/>
         <source>Case Sensitive</source>
-        <translation type="unfinished"></translation>
+        <translation>Учёт регистра</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="291"/>
         <source>Wrap Around</source>
-        <translation type="unfinished"></translation>
+        <translation>Обтекание</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="351"/>
         <source>Find &amp;Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Найти &amp;Предыдущий</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="361"/>
         <source>Find &amp;Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Найти &amp;Следующий</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="374"/>
         <source>&amp;Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Заменить</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="384"/>
         <source>Replace &amp;All</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменить &amp;Всё</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.ui" line="410"/>
         <source>&amp;Close</source>
-        <translation type="unfinished"></translation>
+        <translation>За&amp;крыть</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="23"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="24"/>
         <source>Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>Замена</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="106"/>
         <source>Beginning of file has been reached. </source>
-        <translation type="unfinished"></translation>
+        <translation>Достигнуто начало файла. </translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="107"/>
         <source>Do you want to continue from file&apos;s end?</source>
-        <translation type="unfinished"></translation>
+        <translation>Хотите продолжить с конца файла?</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="109"/>
         <location filename="../widgets/searchdialog.cpp" line="166"/>
         <source>End of file has been reached. </source>
-        <translation type="unfinished"></translation>
+        <translation>Конец файла достигнут. </translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="110"/>
         <location filename="../widgets/searchdialog.cpp" line="167"/>
         <source>Do you want to continue from file&apos;s beginning?</source>
-        <translation type="unfinished"></translation>
+        <translation>Хотите продолжить с начала файла?</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="119"/>
         <location filename="../widgets/searchdialog.cpp" line="175"/>
         <source>Continue Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Продолжение поиска</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="133"/>
         <source>Not Found</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найдено</translation>
     </message>
     <message>
         <location filename="../widgets/searchdialog.cpp" line="134"/>
         <source>Can&apos;t find &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найдено &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -9312,97 +9323,97 @@
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="14"/>
         <source>Search in Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск в файлах</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="65"/>
         <source>*.*</source>
-        <translation type="unfinished"></translation>
+        <translation>*.*</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="78"/>
         <source>Text to Find:</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск текста:</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="85"/>
         <source>Filters:</source>
-        <translation type="unfinished"></translation>
+        <translation>Фильтры:</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="92"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="118"/>
         <source>Folder:</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог:</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="125"/>
         <source>Search in subfolders</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск в подкаталогах</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="159"/>
         <source>Where:</source>
-        <translation type="unfinished"></translation>
+        <translation>Где искать:</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="165"/>
         <source>Current File</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущий файл</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="175"/>
         <source>Files In Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы проекта</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="182"/>
         <source>Open Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Открытые файлы</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="189"/>
         <source>Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталог</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="202"/>
         <source>Options:</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры:</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="208"/>
         <source>Whole words only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только целые слова</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="215"/>
         <source>Case Sensitive</source>
-        <translation type="unfinished"></translation>
+        <translation>Учёт регистра</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="246"/>
         <source>Regular Expression</source>
-        <translation type="unfinished"></translation>
+        <translation>Регулярные выражения</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="313"/>
         <source>&amp;Find</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Поиск</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="326"/>
         <source>&amp;Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Замена</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.ui" line="336"/>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Отмена</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.cpp" line="173"/>
@@ -9410,18 +9421,18 @@
         <location filename="../widgets/searchinfiledialog.cpp" line="280"/>
         <location filename="../widgets/searchinfiledialog.cpp" line="291"/>
         <source>Searching...</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск...</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.cpp" line="174"/>
         <location filename="../widgets/searchinfiledialog.cpp" line="281"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Прервать</translation>
     </message>
     <message>
         <location filename="../widgets/searchinfiledialog.cpp" line="448"/>
         <source>Choose Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор каталога</translation>
     </message>
 </context>
 <context>
@@ -9429,32 +9440,32 @@
     <message>
         <location filename="../widgets/searchresultview.cpp" line="385"/>
         <source>Current File:</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущий файл:</translation>
     </message>
     <message>
         <location filename="../widgets/searchresultview.cpp" line="387"/>
         <source>Files In Project:</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы в проекте:</translation>
     </message>
     <message>
         <location filename="../widgets/searchresultview.cpp" line="389"/>
         <source>Open Files:</source>
-        <translation type="unfinished"></translation>
+        <translation>Открытые файлы:</translation>
     </message>
     <message>
         <location filename="../widgets/searchresultview.cpp" line="391"/>
         <source>&quot;%1&quot; in Folder &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; в каталоге &quot;%2&quot;</translation>
     </message>
     <message>
         <location filename="../widgets/searchresultview.cpp" line="395"/>
         <source>Find Usages in Current File: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск употреблений в текущем файле: &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../widgets/searchresultview.cpp" line="398"/>
         <source>Find Usages in Project: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск употреблений в проекте: &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -9462,7 +9473,7 @@
     <message>
         <location filename="../widgets/searchresultview.cpp" line="237"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
 </context>
 <context>
@@ -9471,7 +9482,7 @@
         <location filename="../widgets/searchresultview.cpp" line="447"/>
         <location filename="../widgets/searchresultview.cpp" line="461"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
 </context>
 <context>
@@ -9479,12 +9490,12 @@
     <message>
         <location filename="../settings.cpp" line="3993"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../settings.cpp" line="3994"/>
         <source>Can&apos;t find terminal program!</source>
-        <translation type="unfinished"></translation>
+        <translation>Не найдена программа-терминал!</translation>
     </message>
 </context>
 <context>
@@ -9493,27 +9504,27 @@
         <location filename="../settingsdialog/settingsdialog.ui" line="14"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="142"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.ui" line="92"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.ui" line="156"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.ui" line="163"/>
         <source>Apply</source>
-        <translation type="unfinished"></translation>
+        <translation>Применить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.ui" line="170"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2540"/>
@@ -9523,7 +9534,7 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="169"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="264"/>
         <source>Compiler Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор компиляторов</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2541"/>
@@ -9539,7 +9550,7 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="285"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="291"/>
         <source>Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Проект</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2664"/>
@@ -9547,7 +9558,7 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="169"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="172"/>
         <source>Compiler</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8724"/>
@@ -9558,7 +9569,7 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="231"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="258"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Основное</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="8725"/>
@@ -9566,18 +9577,18 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="216"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="219"/>
         <source>Program Runner</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск программ</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="9130"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="219"/>
         <source>Problem Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Набор проблем</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="145"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>Оформление</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="145"/>
@@ -9587,37 +9598,37 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="159"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="162"/>
         <source>Environment</source>
-        <translation type="unfinished"></translation>
+        <translation>Окружение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="149"/>
         <source>File Association</source>
-        <translation type="unfinished"></translation>
+        <translation>Ассоциации файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="153"/>
         <source>Shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Сочетания клавиш</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="156"/>
         <source>Terminal</source>
-        <translation type="unfinished"></translation>
+        <translation>Терминал</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="159"/>
         <source>Performance</source>
-        <translation type="unfinished"></translation>
+        <translation>Производительность</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="162"/>
         <source>Folders / Restore Default Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталоги / Сохрание настроек по умолчанию</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="172"/>
         <source>Auto Link</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматическое связывание</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="175"/>
@@ -9632,155 +9643,155 @@
         <location filename="../settingsdialog/settingsdialog.cpp" line="202"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="205"/>
         <source>Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="178"/>
         <source>Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Шрифты</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="181"/>
         <source>Copy &amp; Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирование и Экспорт</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="184"/>
         <source>Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвета</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="187"/>
         <source>Code Completion</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="190"/>
         <source>Symbol Completion</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнение символов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="193"/>
         <source>Snippet</source>
-        <translation type="unfinished"></translation>
+        <translation>Фрагменты кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="196"/>
         <source>Auto Syntax Checking</source>
-        <translation type="unfinished"></translation>
+        <translation>Автопроверка синтаксиса</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="199"/>
         <source>Tooltips</source>
-        <translation type="unfinished"></translation>
+        <translation>Высплывающие подсказки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="202"/>
         <source>Auto save</source>
-        <translation type="unfinished"></translation>
+        <translation>Автосохранение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="205"/>
         <source>Misc</source>
-        <translation type="unfinished"></translation>
+        <translation>Разное</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="208"/>
         <source>Custom C/C++ Keywords</source>
-        <translation type="unfinished"></translation>
+        <translation>Пользовательские ключевые слова C/C++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="208"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="213"/>
         <source>Languages</source>
-        <translation type="unfinished"></translation>
+        <translation>Языки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="213"/>
         <source>ASM Generation</source>
-        <translation type="unfinished"></translation>
+        <translation>Генерация ASM</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="222"/>
         <source>Debugger</source>
-        <translation type="unfinished"></translation>
+        <translation>Отладчик</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="225"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="228"/>
         <source>Code Formatter</source>
-        <translation type="unfinished"></translation>
+        <translation>Форматирование кода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="228"/>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="231"/>
         <location filename="../settingsdialog/settingsdialog.cpp" line="235"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Инструменты</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="235"/>
         <source>Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Git</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="256"/>
         <source>Project Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры проекта</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="261"/>
         <source>Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="267"/>
         <source>Custom Compile options</source>
-        <translation type="unfinished"></translation>
+        <translation>Настрока параметров компиляци</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="270"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Каталоги</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="274"/>
         <source>Precompiled Header</source>
-        <translation type="unfinished"></translation>
+        <translation>Скомпилированные заголовочные файлы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="278"/>
         <source>Makefile</source>
-        <translation type="unfinished"></translation>
+        <translation>Makefile</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="281"/>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Вывод</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="285"/>
         <source>DLL host</source>
-        <translation type="unfinished"></translation>
+        <translation>DLL host</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="291"/>
         <source>Version info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о версии</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="352"/>
         <source>Save Changes</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить изменения</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingsdialog.cpp" line="353"/>
         <source>There are changes in the settings, do you want to save them before swtich to other page?</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки изменились, хотите их сохранить перед переключением на другую страницу?</translation>
     </message>
 </context>
 <context>
@@ -9788,12 +9799,12 @@
     <message>
         <location filename="../settingsdialog/settingswidget.cpp" line="61"/>
         <source>Load Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/settingswidget.cpp" line="73"/>
         <source>Save Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка сохранения</translation>
     </message>
 </context>
 <context>
@@ -9802,33 +9813,33 @@
         <location filename="../shortcutmanager.cpp" line="43"/>
         <location filename="../shortcutmanager.cpp" line="56"/>
         <source>Read shortcut config failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение конфигурации сочетаний клавиш не удалось</translation>
     </message>
     <message>
         <location filename="../shortcutmanager.cpp" line="44"/>
         <source>Can&apos;t open shortcut config file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для чтения файл конфигурации сочетаний клавиш &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../shortcutmanager.cpp" line="57"/>
         <source>Read shortcut config file &apos;%1&apos; failed:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение конфигурационного файла сочетаний клавиш &apos;%1&apos; не удалось:%2</translation>
     </message>
     <message>
         <location filename="../shortcutmanager.cpp" line="85"/>
         <location filename="../shortcutmanager.cpp" line="102"/>
         <source>Save shortcut config failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранение конфигурации сочетаний клавиш не удалось</translation>
     </message>
     <message>
         <location filename="../shortcutmanager.cpp" line="86"/>
         <source>Can&apos;t open shortcut config file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи файл конфигурации сочетаний клавиш &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../shortcutmanager.cpp" line="103"/>
         <source>Write to shortcut config file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись в конфигурационный файл сочетаний клавиш &apos;%1&apos; не удалась.</translation>
     </message>
 </context>
 <context>
@@ -9836,17 +9847,17 @@
     <message>
         <location filename="../widgets/signalmessagedialog.ui" line="14"/>
         <source>Signal Received</source>
-        <translation type="unfinished"></translation>
+        <translation>Сигнал получен</translation>
     </message>
     <message>
         <location filename="../widgets/signalmessagedialog.ui" line="26"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../widgets/signalmessagedialog.ui" line="36"/>
         <source>Open CPU Info Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть Информацию Процессора</translation>
     </message>
 </context>
 <context>
@@ -9854,47 +9865,47 @@
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="32"/>
         <source>Checking file syntax...</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка синтаксиса файла...</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="34"/>
         <source>Compiling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Компиляция...</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="36"/>
         <source>- Filename: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя файла: %1</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="37"/>
         <source>- Compiler Set Name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>- Имя набора компиляторов: %1</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="74"/>
         <source>Can&apos;t find the compiler for file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось найти компилятор для файла %1</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="81"/>
         <source>The Compiler &apos;%1&apos; doesn&apos;t exists!</source>
-        <translation type="unfinished"></translation>
+        <translation>Компилятор &apos;%1&apos; не существует!</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="86"/>
         <source>Processing %1 source file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Обработка исходного файла %1:</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="88"/>
         <source>%1 Compiler: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Компилятор: %2</translation>
     </message>
     <message>
         <location filename="../compiler/stdincompiler.cpp" line="90"/>
         <source>Command: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Команда: %1</translation>
     </message>
 </context>
 <context>
@@ -9903,33 +9914,33 @@
         <location filename="../symbolusagemanager.cpp" line="41"/>
         <location filename="../symbolusagemanager.cpp" line="52"/>
         <source>Load symbol usage info failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка информации об использовании символов не удалась</translation>
     </message>
     <message>
         <location filename="../symbolusagemanager.cpp" line="42"/>
         <source>Can&apos;t open symbol usage file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для чтения файл использования символов &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../symbolusagemanager.cpp" line="53"/>
         <source>Can&apos;t parse symbol usage file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно расшифровать файл использования символов &apos;%1&apos;: %2</translation>
     </message>
     <message>
         <location filename="../symbolusagemanager.cpp" line="78"/>
         <location filename="../symbolusagemanager.cpp" line="93"/>
         <source>Save symbol usage info failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохрание информации использования символов не удалось</translation>
     </message>
     <message>
         <location filename="../symbolusagemanager.cpp" line="79"/>
         <source>Can&apos;t open symbol usage file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи файл использования символов &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../symbolusagemanager.cpp" line="94"/>
         <source>Write to symbol usage file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись в файл использования символов &apos;%1&apos; не удалась.</translation>
     </message>
 </context>
 <context>
@@ -9937,17 +9948,17 @@
     <message>
         <location filename="../todoparser.cpp" line="288"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
         <location filename="../todoparser.cpp" line="290"/>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Строка</translation>
     </message>
     <message>
         <location filename="../todoparser.cpp" line="292"/>
         <source>Content</source>
-        <translation type="unfinished"></translation>
+        <translation>Содержимое</translation>
     </message>
 </context>
 <context>
@@ -9955,144 +9966,144 @@
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="35"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="42"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактировать</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="49"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="148"/>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="155"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Обзор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="165"/>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="172"/>
         <source>Output To</source>
-        <translation type="unfinished"></translation>
+        <translation>Перенаправление вывода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="182"/>
         <source>Parameters</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="202"/>
         <source>Redirect Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Перенаправление ввода</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="212"/>
         <source>Working Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Рабочий каталог</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="222"/>
         <source>Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовок</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="251"/>
         <source>Insert Macro</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставить макрос</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="311"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Ладно</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="318"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.ui" line="344"/>
         <source>Use UTF8 as the encoding</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать кодировку UTF8</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="39"/>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="45"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="40"/>
         <source>Current Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Текущее выделение</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="41"/>
         <source>Whole Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Весь документ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="46"/>
         <source>Tools Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Вывод инструментария</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="47"/>
         <source>Replace Current Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменить в текущем выделении</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="48"/>
         <source>Repalce Whole Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменить во всем документе</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="105"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="106"/>
         <source>Title shouldn&apos;t be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>Заголовок не может быть пустым!</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="110"/>
         <source>Save Changes?</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить изменения?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="111"/>
         <source>Do you want to save changes to &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы хотите сохранить измения в &quot;%1&quot;?</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="294"/>
         <source>untitled</source>
-        <translation type="unfinished"></translation>
+        <translation>беззаголовочный</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="359"/>
         <source>Choose Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор каталога</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgeneralwidget.cpp" line="370"/>
         <source>Select program</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор программы</translation>
     </message>
 </context>
 <context>
@@ -10100,42 +10111,42 @@
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="14"/>
         <source>Git</source>
-        <translation type="unfinished"></translation>
+        <translation>Git</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="20"/>
         <source>Test</source>
-        <translation type="unfinished"></translation>
+        <translation>Тест</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="27"/>
         <source>Browse</source>
-        <translation type="unfinished"></translation>
+        <translation>Обзор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="30"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="53"/>
         <source>Path to Git Executable:</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к исполнимому файлу Git:</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.ui" line="60"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.cpp" line="45"/>
         <source>Git Executable</source>
-        <translation type="unfinished"></translation>
+        <translation>Исполнимый файл Git</translation>
     </message>
     <message>
         <location filename="../settingsdialog/toolsgitwidget.cpp" line="47"/>
         <source>All files (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все файлы (%1)</translation>
     </message>
 </context>
 <context>
@@ -10143,39 +10154,39 @@
     <message>
         <location filename="../toolsmanager.cpp" line="41"/>
         <source>Remove Compiled</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить скомпилированное</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="73"/>
         <location filename="../toolsmanager.cpp" line="86"/>
         <source>Read tools config failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось чтение конфигурации инструкментов</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="74"/>
         <source>Can&apos;t open tools config file &apos;%1&apos; for read.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для чтения конфигурационный файл инструментов &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="87"/>
         <source>Read tools config file &apos;%1&apos; failed:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Чтение файла конфигурации инструментов &apos;%1&apos; не удалось:%2</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="119"/>
         <location filename="../toolsmanager.cpp" line="141"/>
         <source>Save tools config failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось сохранить конфигурацию инструментов</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="120"/>
         <source>Can&apos;t open tools config file &apos;%1&apos; for write.</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно открыть для записи конфигурационный файл инструментов &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../toolsmanager.cpp" line="142"/>
         <source>Write to tools config file &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось записать файл конфигурации инструментов &apos;%1&apos;.</translation>
     </message>
 </context>
 <context>
@@ -10184,28 +10195,28 @@
         <location filename="../debugger/debugger.cpp" line="1737"/>
         <location filename="../debugger/debugger.cpp" line="1808"/>
         <source>Not Valid</source>
-        <translation type="unfinished"></translation>
+        <translation>Не корректное</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="1861"/>
         <location filename="../debugger/debugger.cpp" line="1967"/>
         <source>Execute to evaluate</source>
-        <translation type="unfinished"></translation>
+        <translation>Выполнить для вычисления</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2010"/>
         <source>Expression</source>
-        <translation type="unfinished"></translation>
+        <translation>Выражение</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2012"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <location filename="../debugger/debugger.cpp" line="2014"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Значение</translation>
     </message>
 </context>
 <context>
@@ -10213,32 +10224,32 @@
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="14"/>
         <source>Custom C/C++ Type Keywords</source>
-        <translation type="unfinished"></translation>
+        <translation>Пользовательские типы C/C++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="20"/>
         <source>Enable Custom C/C++ Type Keywords</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить пользовательские типы C/C++</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="44"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="51"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="58"/>
         <source>Remove All</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить Всё</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorcustomctypekeywords.ui" line="88"/>
         <source>Note: Custom keywords is not recognized by syntax checker.</source>
-        <translation type="unfinished"></translation>
+        <translation>Замечание: Пользовательские ключевые слова не распознаниются проверкой синтаксиса.</translation>
     </message>
 </context>
 <context>
@@ -10246,147 +10257,147 @@
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="20"/>
         <source>Indents</source>
-        <translation type="unfinished"></translation>
+        <translation>Отступы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="41"/>
         <source>Auto Indent</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоотступ</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="48"/>
         <source>Replace tab with spaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Заменять табуляцию пробелами</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="73"/>
         <source>Tab Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер табуляции</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="106"/>
         <source>Show Indent Lines</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать линии отступов</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="128"/>
         <source>Indent Line Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвет отступа строки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="161"/>
         <source>Fill Indents</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрашивать отступы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="171"/>
         <source>Caret</source>
-        <translation type="unfinished"></translation>
+        <translation>Курсор</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="192"/>
         <source>Move caret to the first non-space char in the current line when press HOME key</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить курсор к первому непробельному символу текущей строки при нажатии клавиши HOME</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="199"/>
         <source>Move caret to the last non-space char in the current line when press END key</source>
-        <translation type="unfinished"></translation>
+        <translation>Переместить курсор к последнему непробельному символу текущей строки при нажатии клавиши END</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="206"/>
         <source>Keep X position of the caret when moving vertically</source>
-        <translation type="unfinished"></translation>
+        <translation>При вертикальном перемещении курсора сохранять позицию X</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="231"/>
         <source>Caret for overwriting mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Курсор для режима замены</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="248"/>
         <source>Caret Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвет курсора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="258"/>
         <source>Caret for inserting mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Курсор для режима вставки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="281"/>
         <source>Use text color as caret color</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать цвет текста как цвет курсора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="294"/>
         <source>Highlight</source>
-        <translation type="unfinished"></translation>
+        <translation>Подсветка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="315"/>
         <source>Highlight matching braces</source>
-        <translation type="unfinished"></translation>
+        <translation>Подсвечивать связанные скобки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="322"/>
         <source>Highlight current word</source>
-        <translation type="unfinished"></translation>
+        <translation>Подсветка текущего слова</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="332"/>
         <source>Scroll</source>
-        <translation type="unfinished"></translation>
+        <translation>Прокрутка</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="338"/>
         <source>Auto hide scroll bars</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматическое скрытие полос прокрутки</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="345"/>
         <source>Can scroll the last char to the left edge of the editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Возможна прокрутка последнего символа до левого края окна редактора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="352"/>
         <source>Can scroll the last line to the top edge of the editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Возможна прокрутка последней строки до верхнего края окна редактора</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="359"/>
         <source>Page Up/Down scrolls half a page</source>
-        <translation type="unfinished"></translation>
+        <translation>Клавиши Page Up/Down приводят к прокрутке половины страницы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="381"/>
         <source>Mouse Wheel Scroll Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Скорость прокрутки колеса мыши</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="429"/>
         <source>Mouse Selection/Dragging Scroll Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Скорость прокрутки при выделении мышью или перетаскивании</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="465"/>
         <source>Show right edge line</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать линию правой границы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="504"/>
         <source>Right egde width</source>
-        <translation type="unfinished"></translation>
+        <translation>Ширина правой границы</translation>
     </message>
     <message>
         <location filename="../settingsdialog/editorgeneralwidget.ui" line="555"/>
         <source>Right edge line color</source>
-        <translation type="unfinished"></translation>
+        <translation>Цвет линии правой границы</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Note: In some configurations (half of Windows and AppImage), the assembly failed due to the connection of the qtbase_ru_RU.qm file (apparently, this file is simply not present on these configurations). Temporarily removed this file from the RedPandaIDE.pro and now the build check on all architectures is fine.