### PR TITLE
Remove use of `PREFIX` from XDG program

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: |
           name="redpanda-cpp-${{ matrix.lua_addon }}-${{ matrix.sdcc }}"
-          xmake f --qt=/usr --prefix=/ --lua-addon=${{ matrix.lua_addon }} --sdcc=${{ matrix.sdcc }}
+          xmake f --qt=/usr --lua-addon=${{ matrix.lua_addon }} --sdcc=${{ matrix.sdcc }}
           xmake b
           xmake i -o "pkg/$name"
           tar -cf "pkg/$name.tar" -C pkg "$name"

--- a/RedPandaIDE/RedPandaIDE.pro
+++ b/RedPandaIDE/RedPandaIDE.pro
@@ -52,7 +52,7 @@ isEmpty(PREFIX) {
     PREFIX = /usr/local
 }
 isEmpty(LIBEXECDIR) {
-    LIBEXECDIR = $${PREFIX}/libexec
+    LIBEXECDIR = libexec
 }
 
 win32: {
@@ -63,7 +63,6 @@ win32: {
     LIBS += -luser32  # window message APIs
 }
 
-DEFINES += PREFIX=\\\"$${PREFIX}\\\"
 DEFINES += LIBEXECDIR=\\\"$${LIBEXECDIR}\\\"
 DEFINES += APP_NAME=\\\"$${APP_NAME}\\\"
 

--- a/RedPandaIDE/settings.cpp
+++ b/RedPandaIDE/settings.cpp
@@ -230,10 +230,8 @@ QString Settings::Dirs::appLibexecDir() const
 #elif defined(Q_OS_MACOS)
     return QApplication::instance()->applicationDirPath();
 #else // XDG desktop
-    // in AppImage or tarball LIBEXECDIR is not true, resolve from relative path
-    const static QString relativeLibExecDir(QDir(PREFIX "/bin").relativeFilePath(LIBEXECDIR "/" APP_NAME));
-    const static QString absoluteLibExecDir(QDir(appDir()).absoluteFilePath(relativeLibExecDir));
-    return absoluteLibExecDir;
+    const static QString libExecDir(QDir(appDir()).absoluteFilePath("../" LIBEXECDIR "/" APP_NAME));
+    return libExecDir;
 #endif
 }
 

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -233,12 +233,6 @@ target("RedPandaIDE")
         add_links("psapi", "shlwapi")
     end
 
-    -- install
-
-    if is_xdg() then
-        on_install(install_bin)
-    end
-
 target("test-escape")
     set_kind("binary")
     add_rules("qt.console")

--- a/Red_Panda_CPP.pro
+++ b/Red_Panda_CPP.pro
@@ -43,7 +43,7 @@ unix:!macos: {
         PREFIX = /usr/local
     }
     isEmpty(LIBEXECDIR) {
-        LIBEXECDIR = $${PREFIX}/libexec
+        LIBEXECDIR = libexec
     }
 
     QMAKE_SUBSTITUTES += platform/linux/RedPandaIDE.desktop.in

--- a/docs/detailed-build-xdg-cn.md
+++ b/docs/detailed-build-xdg-cn.md
@@ -23,14 +23,17 @@
    ```
 
 qmake 变量:
-- `PREFIX`：默认值是 `/usr/local`。打包时应该定义为 `/usr`。
-- `LIBEXECDIR`：辅助程序的路径，默认值是 `$PREFIX/libexec`。Arch Linux 使用 `/usr/lib`。
+- `PREFIX`：`$MAKE install` 的安装路径。
+  - 小熊猫C++ 内部使用相对路径，不受影响。
+  - `.desktop` 文件受影响。
+- `LIBEXECDIR`：辅助程序的路径，**相对于 `PREFIX`**。
+  - Arch Linux 使用 `lib`。
 
 ### 基于 xmake 构建
 
 1. 配置：
    ```bash
-   xmake f -p linux -a x86_64 -m release --qt=/usr --prefix=/usr/local
+   xmake f -p linux -a x86_64 -m release --qt=/usr
    ```
 2. 构建：
    ```bash
@@ -38,7 +41,7 @@ qmake 变量:
    ```
 3. 安装：
    ```bash
-   sudo xmake install --root -o /  # -o ... 模拟了 make install 的 DESTDIR=...
+   sudo xmake install --root -o /usr/local
    ```
 
 提示：`xmake f --help` 可以查看更多选项。

--- a/docs/detailed-build-xdg.md
+++ b/docs/detailed-build-xdg.md
@@ -23,14 +23,17 @@
    ```
 
 qmake variables:
-- `PREFIX`: default to `/usr/local`. It should be set to `/usr` when packaging.
-- `LIBEXECDIR`: directory for auxiliary executables, default to `$PREFIX/libexec`. Arch Linux uses `/usr/lib`.
+- `PREFIX`: where `$MAKE install` installs files to.
+  - Red Panda C++ itself is not affected by `PREFIX`, because it internally uses relative path.
+  - `.desktop` file is affected by `PREFIX`.
+- `LIBEXECDIR`: directory for auxiliary executables, RELATIVE TO `PREFIX`.
+  - Arch Linux uses `lib`.
 
 ### xmake-based Build Steps
 
 1. Configure:
    ```bash
-   xmake f -p linux -a x86_64 -m release --qt=/usr --prefix=/usr/local
+   xmake f -p linux -a x86_64 -m release --qt=/usr
    ```
 2. Build:
    ```bash
@@ -38,7 +41,7 @@ qmake variables:
    ```
 3. Install:
    ```bash
-   sudo xmake install --root -o /  # `-o ...` imitates `DESTDIR=...` in `make install`
+   sudo xmake install --root -o /usr/local
    ```
 
 Hint: `xmake f --help` for more options.

--- a/packages/archlinux/PKGBUILD.in
+++ b/packages/archlinux/PKGBUILD.in
@@ -31,7 +31,7 @@ build() {
     cd redpanda-build
     qmake6 \
         PREFIX='/usr' \
-        LIBEXECDIR='/usr/lib' \
+        LIBEXECDIR='lib' \
         "$srcdir/$_pkgname/Red_Panda_CPP.pro"
     make
 }

--- a/tools/consolepauser/consolepauser.pro
+++ b/tools/consolepauser/consolepauser.pro
@@ -39,7 +39,7 @@ isEmpty(PREFIX) {
     PREFIX = /usr/local
 }
 isEmpty(LIBEXECDIR) {
-    LIBEXECDIR = $${PREFIX}/libexec
+    LIBEXECDIR = libexec
 }
 
 win32: {
@@ -49,6 +49,6 @@ win32: {
 }
 
 # Default rules for deployment.
-qnx: target.path = $${LIBEXECDIR}/$${APP_NAME}
-else: unix:!android: target.path = $${LIBEXECDIR}/$${APP_NAME}
+qnx: target.path = $${PREFIX}/$${LIBEXECDIR}/$${APP_NAME}
+else: unix:!android: target.path = $${PREFIX}/$${LIBEXECDIR}/$${APP_NAME}
 !isEmpty(target.path): INSTALLS += target

--- a/tools/redpanda-git-askpass/redpanda-git-askpass.pro
+++ b/tools/redpanda-git-askpass/redpanda-git-askpass.pro
@@ -25,10 +25,10 @@ isEmpty(PREFIX) {
     PREFIX = /usr/local
 }
 isEmpty(LIBEXECDIR) {
-    LIBEXECDIR = $${PREFIX}/libexec
+    LIBEXECDIR = libexec
 }
 
 # Default rules for deployment.
-qnx: target.path = $${LIBEXECDIR}/$${APP_NAME}
-else: unix:!android: target.path = $${LIBEXECDIR}/$${APP_NAME}
+qnx: target.path = $${PREFIX}/$${LIBEXECDIR}/$${APP_NAME}
+else: unix:!android: target.path = $${PREFIX}/$${LIBEXECDIR}/$${APP_NAME}
 !isEmpty(target.path): INSTALLS += target

--- a/xmake.lua
+++ b/xmake.lua
@@ -29,16 +29,11 @@ option("prefix")
         set_showmenu(false)
         set_default("")
     end
-    add_defines('PREFIX="$(prefix)"')
 
 option("libexecdir")
-    add_deps("prefix")
     if is_xdg() then
-        set_default("$prefix/libexec")  -- dummy
+        set_default("libexec")
         set_showmenu(true)
-        before_check(function (option)
-            option:set_value(option:dep("prefix"):value() .. "/libexec")
-        end)
     else
         set_default("")
         set_showmenu(false)
@@ -182,16 +177,8 @@ function add_ui_classes(...)
     end
 end
 
--- imitate `make DESTDIR=... install` on XDG platforms
-
 function install_libexec(target)
     local installdir = target:installdir() .. "/$(libexecdir)/$(app-name)"
-    print("installing", target:name(), "to", installdir, "..")
-    os.cp(target:targetfile(), installdir .. "/" .. target:filename())
-end
-
-function install_bin(target)
-    local installdir = target:installdir() .. "/$(prefix)/bin"
     print("installing", target:name(), "to", installdir, "..")
     os.cp(target:targetfile(), installdir .. "/" .. target:filename())
 end
@@ -217,7 +204,7 @@ target("resources")
     -- templates
 
     if is_xdg() then
-        add_installfiles("platform/linux/templates/(**.*)", {prefixdir = "$(prefix)/share/$(app-name)/templates"})
+        add_installfiles("platform/linux/templates/(**.*)", {prefixdir = "share/$(app-name)/templates"})
     elseif is_os("windows") then
         add_installfiles("platform/windows/templates/(**.*)", {prefixdir = "bin/templates"})
         if is_arch("x86_64") then
@@ -228,7 +215,7 @@ target("resources")
     -- docs
 
     if is_xdg() then
-        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "$(prefix)/share/doc/$(app-name)"})
+        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "share/doc/$(app-name)"})
     else
         add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "bin"})
     end
@@ -236,7 +223,7 @@ target("resources")
     -- icon
 
     if is_xdg() then
-        add_installfiles("platform/linux/redpandaide.svg", {prefixdir = "$(prefix)/share/icons/hicolor/scalable/apps"})
+        add_installfiles("platform/linux/redpandaide.svg", {prefixdir = "share/icons/hicolor/scalable/apps"})
     end
 
     -- desktop entry
@@ -248,13 +235,13 @@ target("resources")
                 PREFIX = get_config("prefix"),
             },
         })
-        add_installfiles("$(buildir)/RedPandaIDE.desktop", {prefixdir = "$(prefix)/share/applications"})
+        add_installfiles("$(buildir)/RedPandaIDE.desktop", {prefixdir = "share/applications"})
     end
 
     -- mime type
 
     if is_xdg() then
-        add_installfiles("platform/linux/redpandaide.xml", {prefixdir = "$(prefix)/share/mime/packages"})
+        add_installfiles("platform/linux/redpandaide.xml", {prefixdir = "share/mime/packages"})
     end
 
     -- qt.conf


### PR DESCRIPTION
Reinterpret `LIBEXECDIR` as "relative to `PREFIX`", so we can directly use relative path, not calculate from `PREFIX` and `LIBEXECDR`.