### PR TITLE
Simplify Windows on ARM support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,45 +180,6 @@ jobs:
           name: Windows MSVC x64
           path: pkg/
 
-  windows_msvc_arm64ec:
-    name: Windows MSVC ARM64EC
-    runs-on: windows-2019
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup
-        uses: jurplel/install-qt-action@v3
-        with:
-          version: '5.15.2'
-          host: windows
-          target: desktop
-          arch: win64_msvc2019_64
-          archives: qtbase qtsvg qttools
-          tools: tools_qtcreator,qt.tools.qtcreator
-
-      - name: Build
-        run: |
-          $JOM = "${Env:RUNNER_WORKSPACE}/Qt/Tools/QtCreator/bin/jom/jom.exe"
-          $VS_INSTALL_PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
-          Import-Module "$VS_INSTALL_PATH\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-          Enter-VsDevShell -VsInstallPath "$VS_INSTALL_PATH" -SkipAutomaticLocation -DevCmdArguments "-arch=arm64 -host_arch=amd64"
-          mkdir build && pushd build
-          qmake QMAKE_CFLAGS="/arm64EC" QMAKE_CXXFLAGS="/arm64EC" QMAKE_LFLAGS="/MACHINE:ARM64EC" QMAKE_LIBFLAGS="/MACHINE:ARM64X" PREFIX=${Env:GITHUB_WORKSPACE}/pkg ${Env:GITHUB_WORKSPACE}/Red_Panda_CPP.pro
-          & $JOM "-j${Env:NUMBER_OF_PROCESSORS}"
-          & $JOM install
-          windeployqt ${Env:GITHUB_WORKSPACE}/pkg/RedPandaIDE.exe
-          rm ${Env:GITHUB_WORKSPACE}/pkg/vc_redist.x64.exe
-          popd
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: Windows MSVC ARM64EC (do not use)
-          path: pkg/
-
   debian:
     name: Debian
     strategy:

--- a/RedPandaIDE/addon/luaapi.cpp
+++ b/RedPandaIDE/addon/luaapi.cpp
@@ -411,8 +411,6 @@ extern "C" int luaApi_System_supportedAppArchList(lua_State *L) noexcept {
             arches.insert("i386");
         if (pGetMachineTypeAttributes(IMAGE_FILE_MACHINE_AMD64, &result) == 0 && result & win32_flag_UserEnabled)
             arches.insert("x86_64");
-        if (pGetMachineTypeAttributes(IMAGE_FILE_MACHINE_ARMNT, &result) == 0 && result & win32_flag_UserEnabled)
-            arches.insert("arm");
         if (pGetMachineTypeAttributes(IMAGE_FILE_MACHINE_ARM64, &result) == 0 && result & win32_flag_UserEnabled)
             arches.insert("arm64");
     } else {
@@ -441,8 +439,6 @@ extern "C" int luaApi_System_supportedAppArchList(lua_State *L) noexcept {
             BOOL wow64SupportResult;
             if (pIsWow64GuestMachineSupported(IMAGE_FILE_MACHINE_I386, &wow64SupportResult) == S_OK && wow64SupportResult)
                 arches.insert("i386");
-            if (pIsWow64GuestMachineSupported(IMAGE_FILE_MACHINE_ARMNT, &wow64SupportResult) == S_OK && wow64SupportResult)
-                arches.insert("arm");
         } else {
             // legacy Windows, hardcode
             SYSTEM_INFO si;

--- a/RedPandaIDE/utils.cpp
+++ b/RedPandaIDE/utils.cpp
@@ -638,11 +638,7 @@ QStringList platformCommandForTerminalArgsPreview()
 
 QString appArch()
 {
-#ifdef _M_ARM64EC
-    return "arm64ec";
-#else
     return QSysInfo::buildCpuArchitecture();
-#endif
 }
 
 QString osArch()

--- a/addon/defs/global_env.d.tl
+++ b/addon/defs/global_env.d.tl
@@ -62,7 +62,6 @@ local record env
     record C_System
         -- returns the architecture of Red Panda C++, name following `QSysInfo`
         -- e.g. "i386", "x86_64", "arm", "arm64", "riscv64", "loongarch64"
-        -- though unsupported, MSVC arm64ec is handled correctly (returns "arm64ec")
         appArch: function (): string
 
         -- returns the directory of Red Panda C++
@@ -87,7 +86,7 @@ local record env
 
         -- returns supported application architectures by OS, name following `QSysInfo`
         -- e.g. {"i386", "x86_64", "arm64"}
-        -- Windows 10 1709 or later: accurate result
+        -- Windows 10 1709 or later: accurate result without "arm"
         -- Legacy Windows: hardcoded result, i.e. "i386" is always included even though WoW64 is not available
         -- macOS: accurate result supposed, but not tested
         -- Linux: osArch + appArch + QEMU user mode emulation, no multilib detection

--- a/docs/detailed-build-win-cn.md
+++ b/docs/detailed-build-win-cn.md
@@ -16,7 +16,8 @@ qmake 变量：
   - `OpenConsole.exe` 需要 Windows 10 1809 加入的 ConPTY 接口。
 
 关于 ARM 上的 Windows 的注记：
-- 小熊猫C++ 只能在 Windows 11 ARM64 上构建 ARM64 版，成品应该能在 Windows 10 ARM64 上运行（但没有测试过）。
+- 小熊猫C++ 只能在 Windows 11 ARM64 上构建 ARM64 版。
+  - 在 Windows 10 上运行不再受支持。安装程序假设 x64 仿真始终可用。（原生的 “带 LLVM MinGW 工具链的小熊猫C++” 应该能用。）
   - 不支持 ARM64EC（“仿真兼容”）主机，即不能用 ARM64EC 工具链构建小熊猫 C++。
   - （理论上）支持 ARM64EC 目标，也就是说，如果上游工具链支持 ARM64EC，那么小熊猫C++ 可以构建 ARM64EC 程序和库。
 - 随着 [Windows 11 Insider Preview Build 25905 弃用 ARM32](https://blogs.windows.com/windows-insider/2023/07/12/announcing-windows-11-insider-preview-build-25905/)，小熊猫 C++ 今后也不会添加 ARM32 支持了。

--- a/docs/detailed-build-win.md
+++ b/docs/detailed-build-win.md
@@ -16,7 +16,8 @@ qmake variables:
   - `OpenConsole.exe` requires ConPTY, which was introduced in Windows 10 1809.
 
 Notes for Windows on ARM:
-- Red Panda C++ can be built for ARM64 ABI only on Windows 11 ARM64, while it is supposed (but not tested) to run on Windows 10 ARM64.
+- Red Panda C++ can be built for ARM64 ABI only on Windows 11 ARM64.
+  - Running on Windows 10 ARM64 is no longer supported. Installers assume x64 emulation is always available. (The native package “Red Panda C++ with LLVM MinGW toolchain” may work.)
   - ARM64EC (“emulation compatible”) host is not supported, i.e., Red Panda C++ cannot be built with ARM64EC toolchain.
   - ARM64EC target is (theoretically) supported, i.e. Red Panda C++ will build ARM64EC binaries if upstream toolchain supports ARM64EC.
 - With the [ARM32 deprecation in Windows 11 Insider Preview Build 25905](https://blogs.windows.com/windows-insider/2023/07/12/announcing-windows-11-insider-preview-build-25905/), ARM32 support will never be added.

--- a/platform/windows/installer-scripts/utils.nsh
+++ b/platform/windows/installer-scripts/utils.nsh
@@ -17,7 +17,7 @@ Var /GLOBAL sectionDepTemp
 !macro CheckOsArch
   ; special check for OpenConsole.exe:
   ; - 32-bit cannot be installed on 64-bit OS
-  ; - x64 can be install on arm64 OS, following general rule
+  ; - x64 can be install on arm64 OS
   !ifdef HAVE_OPENCONSOLE
     !if "${ARCH}" == "x86"
       ${If} $osArch != "x86"
@@ -27,11 +27,8 @@ Var /GLOBAL sectionDepTemp
     !endif
   !endif
 
-  ; x64 cannot be installed on arm64 prior to Windows 11
   !if "${ARCH}" == "x64"
-    ${If} $osArch == "arm64"
-    ${AndIfNot} ${AtLeastBuild} 22000
-    ${OrIf} $osArch == "x86"
+    ${If} $osArch == "x86"
       MessageBox MB_OK|MB_ICONSTOP "$(ErrorArchMismatch)"
       Abort
     ${EndIf}
@@ -92,9 +89,7 @@ Var /GLOBAL sectionDepTemp
 
 !macro SectionAction_CheckMingw64
   !ifdef HAVE_MINGW64
-    ${If} $osArch == "arm64"
-    ${AndIfNot} ${AtLeastBuild} 22000
-    ${OrIf} $osArch == "x86"
+    ${If} $osArch == "x86"
       !insertmacro DisableSection ${SectionMingw64}
     ${EndIf}
   !endif


### PR DESCRIPTION
- Deprecate Windows 10
  - Lack of usage; no test environment.
- Remove ARM64EC ABI
  - Was added for uncertainty of add-on tech, and x64 IME support. Now add-on will based on scripting language, and IMEs have good support for ARM64.
- Deprecate ARM32
  - Lack of usage; dropped by hardware, OS, and libraries.