### PR TITLE
fix: Selecting too long causes the search dialog too wide for the screen to display

### DIFF
--- a/RedPandaIDE/widgets/searchdialog.ui
+++ b/RedPandaIDE/widgets/searchdialog.ui
@@ -95,6 +95,9 @@
               <property name="insertPolicy">
                <enum>QComboBox::InsertAtTop</enum>
               </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+              </property>
              </widget>
             </item>
             <item row="1" column="1">
@@ -112,7 +115,7 @@
                <enum>QComboBox::InsertAtTop</enum>
               </property>
               <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+               <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
               </property>
              </widget>
             </item>

--- a/RedPandaIDE/widgets/searchinfiledialog.ui
+++ b/RedPandaIDE/widgets/searchinfiledialog.ui
@@ -107,6 +107,9 @@
            <property name="insertPolicy">
             <enum>QComboBox::InsertAtTop</enum>
            </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+           </property>
           </widget>
          </item>
          <item row="2" column="1">


### PR DESCRIPTION
Hi! Thanks for providing so excellent an IDE! I'm finding it extremely useful for me, especially the Competitive Companion integration. 
If you select a lot of code, then press `Ctrl+R/F`, or select `Search -> Replace.../Find...`, the selected text will be filled into the new window, but wrongly expanding the window to be **VERY VERY** wide, and making subsequent callings for this function have the same problem. The only solution seems to be restarting the application.
I set a maximize limit to the dialog widget, and finding it works well. The width limit is currently 2x of the original size 609, and maybe a better limit should be adjusted properly? More discussions are welcome.

您好！感谢您提供了如此优秀的IDE！它对我非常有用，特别是 Competitive Companion 的集成功能。

如果我选中大量代码，然后按下 `Ctrl+R/F` 或选择 `查找 -> 替换.../查找...`，被选中的文本将会填入新窗口中。但此时窗口会错误地扩展得**非常非常**宽，并且导致后续调用此功能时也出现同样的问题。目前看来，唯一的解决办法似乎是重启应用程序。

我为对话框的Widget设置了一个最大宽度限制，发现这样做效果很好。我目前的宽度限制设置是原始尺寸609的两倍，或许应该适当调整以找到更合适的限制？欢迎更多的讨论。
