### PR TITLE
Revert "fix: Selecting too long causes the search dialog too wide for the screen to display"

### DIFF
--- a/RedPandaIDE/widgets/searchdialog.ui
+++ b/RedPandaIDE/widgets/searchdialog.ui
@@ -95,9 +95,6 @@
               <property name="insertPolicy">
                <enum>QComboBox::InsertAtTop</enum>
               </property>
-              <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-              </property>
              </widget>
             </item>
             <item row="1" column="1">
@@ -115,7 +112,7 @@
                <enum>QComboBox::InsertAtTop</enum>
               </property>
               <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+               <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
               </property>
              </widget>
             </item>

--- a/RedPandaIDE/widgets/searchinfiledialog.ui
+++ b/RedPandaIDE/widgets/searchinfiledialog.ui
@@ -107,9 +107,6 @@
            <property name="insertPolicy">
             <enum>QComboBox::InsertAtTop</enum>
            </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
-           </property>
           </widget>
          </item>
          <item row="2" column="1">


### PR DESCRIPTION
Reverts royqh1979/RedPanda-CPP#572

这个解决方案会导致搜索对话框不能按照设计的默认大小显示。太紧凑，不太好看