### PR TITLE
Fix Qt 6.9 build

### DIFF
--- a/RedPandaIDE/debugger/gdbmidebugger.cpp
+++ b/RedPandaIDE/debugger/gdbmidebugger.cpp
@@ -1186,7 +1186,7 @@ void GDBMIDebuggerClient::evalExpression(const QString &expression)
     QString escaped;
     foreach(const QChar& ch, expression) {
         if (ch.unicode()<32) {
-            escaped+=QString("\\%1").arg(ch.unicode(),0,8);
+            escaped+=QString("\\%1").arg(int(ch.unicode()),0,8);
         } else
             escaped+=ch;
     }


### PR DESCRIPTION
Qt 6.9 adds constraint to first parameter of `QString::arg(int a, int fieldWidth, int base, QChar fillChar)`, disallowing character type.

https://doc.qt.io/qt-6.9/qstring.html#arg-2