### PR TITLE
修复GASFileTemplate中代码不着色的情况

### DIFF
--- a/RedPandaIDE/settingsdialog/editorsnippetwidget.cpp
+++ b/RedPandaIDE/settingsdialog/editorsnippetwidget.cpp
@@ -69,7 +69,7 @@ EditorSnippetWidget::EditorSnippetWidget(const QString& name, const QString& gro
     ui->editCppFileTemplate->setFileType(FileType::CppSource);
     ui->editCFileTemplate->setFileType(FileType::CSource);
     ui->editGASFileTemplate->setFileType(FileType::ATTASM);
-    ui->editGASFileTemplate->setSyntaxer(syntaxerManager.getSyntaxer(QSynedit::ProgrammingLanguage::ATTAssembly));
+    //ui->editGASFileTemplate->setSyntaxer(syntaxerManager.getSyntaxer(QSynedit::ProgrammingLanguage::ATTAssembly));
 }
 
 EditorSnippetWidget::~EditorSnippetWidget()


### PR DESCRIPTION
来源于作者第3151的提交修复的尝试。
<img width="1127" alt="对比" src="https://github.com/user-attachments/assets/7c51eb2e-587b-4098-8647-a3258e962b09" />
