### PR TITLE
- bug fix: Passing an l-value causes a mismatch

### DIFF
--- a/libs/qsynedit/qsynedit/syntaxer/cpp.cpp
+++ b/libs/qsynedit/qsynedit/syntaxer/cpp.cpp
@@ -619,7 +619,7 @@ void CppSyntaxer::procIdentifier()
                             mRange.extraData.remove(DATA_KEY_PARENT_OF_POPED_IFS);
                         } else {
                             mRange.extraData.insert(DATA_KEY_LAST_FINISHED_IFS,lastPopedIfs);
-                            var.setValue<QList<int>>(ifParents);
+                            var = QVariant::fromValue(ifParents);
                             mRange.extraData.insert(DATA_KEY_PARENT_OF_POPED_IFS,var);
                         }
                     }
@@ -1499,7 +1499,7 @@ void CppSyntaxer::popStatementIndents()
     if (lastPopedIfs!=0) {
         mRange.extraData.insert(DATA_KEY_LAST_FINISHED_IFS,lastPopedIfs);
         QVariant var;
-        var.setValue<QList<int>>(ifParents);
+        var = QVariant::fromValue(ifParents);
         mRange.extraData.insert(DATA_KEY_PARENT_OF_POPED_IFS, var);
     }
 }


### PR DESCRIPTION
The ifParents here is an l-value (a variable with a specific name), while the template parameter of setValue requires passing an r-value reference (T&&). Directly passing an l-value will result in a type mismatch.