### PR TITLE
Update Build System

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,12 +158,16 @@ jobs:
 
   windows_msvc_x64:
     name: Windows MSVC x64
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install MSVC 2019
+        run: |
+          choco install visualstudio2019enterprise --package-parameters "--add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended" -y
 
       - name: Setup
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -40,7 +40,7 @@ jobs:
           path: pkg/*.tar
 
   windows_msvc_x64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +50,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install MSVC 2019
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.2
+          arch: x64
 
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1


### PR DESCRIPTION
In GitHub Action, windows-2019 has been out of support.
This Pull updates Action File, using windows-2022 to install Visual Studio 2019 and build.
