### PR TITLE
- bug fix: The appearance of EditorTabBar is incorrect in Qt6

### DIFF
--- a/RedPandaIDE/mainwindow.cpp
+++ b/RedPandaIDE/mainwindow.cpp
@@ -1095,6 +1095,8 @@ void MainWindow::applySettings()
     mFileEncodingStatus->setPalette(appTheme->palette());
     mFileModeStatus->setPalette(appTheme->palette());
     mFileInfoStatus->setPalette(appTheme->palette());
+    ui->EditorTabsLeft->tabBar()->setPalette(appTheme->palette());
+    ui->EditorTabsRight->tabBar()->setPalette(appTheme->palette());
 
     updateEditorColorSchemes();
 


### PR DESCRIPTION
Due to not updating the appearance of the Editor Tab Bar during the appearance update, its appearance is incorrect in Qt6. 
The original code can run very miraculously in Qt5.