### PR TITLE
Allow build for glibc-hwcaps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,28 @@ jobs:
           name: Arch Linux
           path: dist/*.pkg.tar.zst
 
+  archlinux_hwcaps:
+    name: Arch Linux (glibc hwcaps)
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: docker.io/amd64/archlinux:latest
+      PLATFORM: linux/amd64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: |
+          ${{ env.CONTAINER_COMMAND }} ./packages/archlinux-hwcaps/01-in-docker.sh
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: Arch Linux (glibc hwcaps)
+          path: dist/*.pkg.tar.zst
+
   fedora:
     name: Fedora
     runs-on: ubuntu-latest

--- a/RedPandaIDE/main.cpp
+++ b/RedPandaIDE/main.cpp
@@ -225,7 +225,11 @@ void setTheme(const QString& theme) {
 
 }
 
+#ifdef ENABLE_GLIBC_HWCAPS
+extern "C" int Q_DECL_EXPORT RedPandaIDE_main(int argc, char *argv[])
+#else
 int main(int argc, char *argv[])
+#endif
 {
 //#ifdef Q_OS_WINDOWS
 //    // Make title bar and palette follow system-wide dark mode setting on recent Windows releases.

--- a/RedPandaIDE/main_glibc_hwcaps.c
+++ b/RedPandaIDE/main_glibc_hwcaps.c
@@ -1,0 +1,6 @@
+extern int RedPandaIDE_main(int argc, char *argv[]);
+
+int main(int argc, char *argv[])
+{
+    return RedPandaIDE_main(argc, argv);
+}

--- a/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_pt_BR.ts
@@ -55,7 +55,27 @@
         <translation>Versão:</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+5"/>
+        <source>, μarch level v4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, baseline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+40"/>
         <source>unknown compiler</source>
         <translation>compilador desconhecido</translation>
     </message>

--- a/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_ru_RU.ts
@@ -57,7 +57,27 @@
         <translation>Версия: </translation>
     </message>
     <message>
-        <location filename="../widgets/aboutdialog.cpp" line="68"/>
+        <location filename="../widgets/aboutdialog.cpp" line="35"/>
+        <source>, μarch level v4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="37"/>
+        <source>, μarch level v3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="39"/>
+        <source>, μarch level v2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="41"/>
+        <source>, baseline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../widgets/aboutdialog.cpp" line="81"/>
         <source>unknown compiler</source>
         <translation>неизвестный компилятор</translation>
     </message>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_CN.ts
@@ -129,7 +129,27 @@ p, li { white-space: pre-wrap; }
         <translation>版本：</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+5"/>
+        <source>, μarch level v4</source>
+        <translation>，微架构级别 v4</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v3</source>
+        <translation>，微架构级别 v3</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v2</source>
+        <translation>，微架构级别 v2</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, baseline</source>
+        <translation>，基线</translation>
+    </message>
+    <message>
+        <location line="+40"/>
         <source>unknown compiler</source>
         <translation>未知编译器</translation>
     </message>

--- a/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
+++ b/RedPandaIDE/translations/RedPandaIDE_zh_TW.ts
@@ -57,7 +57,27 @@
         <translation>版本：</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+5"/>
+        <source>, μarch level v4</source>
+        <translation>，微架構級別 v4</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v3</source>
+        <translation>，微架構級別 v3</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, μarch level v2</source>
+        <translation>，微架構級別 v2</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>, baseline</source>
+        <translation>，基線</translation>
+    </message>
+    <message>
+        <location line="+40"/>
         <source>unknown compiler</source>
         <translation>未知編譯器</translation>
     </message>

--- a/RedPandaIDE/widgets/aboutdialog.cpp
+++ b/RedPandaIDE/widgets/aboutdialog.cpp
@@ -29,6 +29,19 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->setupUi(this);
     ui->lblTitle->setText(ui->lblTitle->text() + tr("Version: ") + REDPANDA_CPP_VERSION);
 
+    QString buildArch = appArch();
+#if defined(__x86_64__) && defined(ENABLE_GLIBC_HWCAPS)
+# if defined(__AVX512__)
+    buildArch += tr(", μarch level v4");
+# elif defined(__AVX2__)
+    buildArch += tr(", μarch level v3");
+# elif defined(__SSE4_2__)
+    buildArch += tr(", μarch level v2");
+# else
+    buildArch += tr(", baseline");
+# endif
+#endif
+
 #if defined(__clang__) // Clang always pretends to be GCC/MSVC. Check it first.
 # if defined(_MSC_VER)
     QString templ = "Clang %1.%2.%3 %4 MSVC ABI";
@@ -43,7 +56,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
                             .arg(__clang_major__)
                             .arg(__clang_minor__)
                             .arg(__clang_patchlevel__)
-                            .arg(appArch()))
+                            .arg(buildArch))
                        .arg(osArch()));
 #elif defined(__GNUC__)
     ui->lblQt->setText(ui->lblQt->text()
@@ -52,7 +65,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
                  .arg(__GNUC__)
                  .arg(__GNUC_MINOR__)
                  .arg(__GNUC_PATCHLEVEL__)
-                 .arg(appArch()))
+                 .arg(buildArch))
             .arg(osArch()));
 #elif defined(_MSC_VER)
     ui->lblQt->setText(ui->lblQt->text()
@@ -60,7 +73,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
             .arg(QStringLiteral("MSVC %1.%2 %3")
                 .arg(_MSC_VER / 100)
                 .arg(_MSC_VER % 100)
-                .arg(appArch()))
+                .arg(buildArch))
             .arg(osArch()));
 #else
     ui->lblQt->setText(ui->lblQt->text()

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -1,15 +1,40 @@
 set_languages("cxx17")
 
+target("RedPandaIDE_main_glibc_hwcaps")
+    if has_config("glibc-hwcaps") then
+        set_enabled(true)
+    else
+        set_enabled(false)
+    end
+    set_kind("binary")
+    set_basename("RedPandaIDE")
+
+    add_deps('RedPandaIDE')
+
+    add_files("main_glibc_hwcaps.c")
+
 target("RedPandaIDE")
-    add_rules("qt.widgetapp", "qt.ts")
+    if has_config("glibc-hwcaps") then
+        add_rules("qt.shared")
+        set_symbols("hidden")
+    else
+        add_rules("qt.widgetapp")
+    end
+    add_rules("qt.ts")
 
     add_deps("redpanda_qt_utils", "qsynedit")
-    add_frameworks("QtNetwork", "QtPrintSupport", "QtSvg", "QtXml")
+    add_frameworks(
+        "QtGui",
+        "QtNetwork",
+        "QtPrintSupport",
+        "QtSvg",
+        "QtWidgets",
+        "QtXml")
     add_includedirs(".")
 
     -- defines
 
-    add_options("app-name", "prefix", "libexecdir")
+    add_options("app-name", "prefix", "libexecdir", "glibc-hwcaps")
     add_options("lua-addon", "sdcc", "vcs")
 
     if APP_VERSION_SUFFIX ~= "" then

--- a/packages/archlinux-hwcaps/01-in-docker.sh
+++ b/packages/archlinux-hwcaps/01-in-docker.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+if [[ -v MIRROR && -n $MIRROR ]]
+then
+  echo Server = "http://$MIRROR/archlinux/\$repo/os/\$arch" >/etc/pacman.d/mirrorlist
+fi
+
+pacman -Syu --noconfirm --needed base-devel git
+
+useradd -m builduser
+echo 'builduser ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builduser
+echo "MAKEFLAGS=-j$(($(nproc)+1))" >>/etc/makepkg.conf.d/jobs.conf
+
+su builduser -c "git config --global --add safe.directory $PWD"
+su builduser -c ./packages/archlinux-hwcaps/buildpkg.sh
+
+mkdir -p dist
+cp /tmp/redpanda-cpp-hwcaps/redpanda-cpp-hwcaps-*.pkg.tar.zst dist/

--- a/packages/archlinux-hwcaps/PKGBUILD.in
+++ b/packages/archlinux-hwcaps/PKGBUILD.in
@@ -1,0 +1,72 @@
+_pkgname=RedPanda-CPP
+pkgname=${_pkgname,,}-hwcaps
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc='A fast, lightweight, open source, and cross platform C++ IDE (with glibc-hwcaps)'
+arch=('x86_64')
+url="https://github.com/royqh1979/$_pkgname"
+license=('GPL3')
+depends=(qt6-base qt6-svg gcc gdb astyle)
+makedepends=(qt6-tools xmake imagemagick librsvg)
+optdepends=(
+    'clang: C/C++ compiler (alternative)'
+)
+conflicts=("${_pkgname,,}")
+provides=("${_pkgname,,}")
+source=(
+    "$_pkgname.tar.gz"
+    'compiler_hint.lua'
+)
+sha256sums=(
+    'SKIP'
+    'SKIP'
+)
+
+prepare() {
+    sed -i '/^TEST_VERSION = / s/^.*$/TEST_VERSION = ""/' $_pkgname/xmake.lua
+}
+
+build() {
+    cd $_pkgname
+
+    xmake_flags=(
+        '--mode=release'
+        '--policies=build.optimization.lto'
+        '--qt=/usr'
+        '--qt_sdkver=6'
+        '--glibc-hwcaps=y'
+        '--prefix=/usr'
+        '--libexecdir=lib'
+    )
+
+    xmake f --cxflags=-march=x86-64 "${xmake_flags[@]}"
+    xmake b
+    xmake i -o pkg-v1
+
+    for uarch in v2 v3 v4; do
+        xmake f --cxflags=-march=x86-64-$uarch "${xmake_flags[@]}"
+        xmake b RedPandaIDE
+        xmake i -o pkg-$uarch RedPandaIDE
+    done
+}
+
+package() {
+    install -Dm644 "compiler_hint.lua" "$pkgdir/usr/lib/RedPandaCPP/compiler_hint.lua"
+
+    cd $_pkgname
+    cp -r pkg-v1/* "$pkgdir/usr/"
+
+    local hwcaps_dir="$pkgdir/usr/lib/glibc-hwcaps"
+    for uarch in v2 v3 v4; do
+        install -D -t "$hwcaps_dir/x86-64-$uarch" "pkg-$uarch/lib/libRedPandaIDE.so"
+    done
+
+    for size in 16 22 24 32 36 48 64 72 96 128 192 256 512; do
+        mkdir -p "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps"
+        magick convert \
+            -background none \
+            "$pkgdir/usr/share/icons/hicolor/scalable/apps/redpandaide.svg" \
+            -resize ${size}x${size} \
+            "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/redpandaide.png"
+    done
+}

--- a/packages/archlinux-hwcaps/buildpkg.sh
+++ b/packages/archlinux-hwcaps/buildpkg.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+TMP_FOLDER=/tmp/redpanda-cpp-hwcaps
+[[ -d $TMP_FOLDER ]] && rm -rf $TMP_FOLDER
+mkdir -p "$TMP_FOLDER"
+
+VERSION=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g') || VERSION="0.0.r$(git rev-list HEAD --count).g$(git rev-parse --short HEAD)"
+sed "s/__VERSION__/$VERSION/g" packages/archlinux-hwcaps/PKGBUILD.in >"$TMP_FOLDER/PKGBUILD"
+
+git archive --prefix="RedPanda-CPP/" -o "$TMP_FOLDER/RedPanda-CPP.tar.gz" HEAD
+cp packages/archlinux-hwcaps/compiler_hint.lua "$TMP_FOLDER/"
+
+cd "$TMP_FOLDER"
+makepkg -s --noconfirm

--- a/packages/archlinux-hwcaps/compiler_hint.lua
+++ b/packages/archlinux-hwcaps/compiler_hint.lua
@@ -1,0 +1,308 @@
+function apiVersion()
+   return {
+      kind = "compiler_hint",
+      major = 0,
+      minor = 2,
+   }
+end
+
+
+
+
+
+
+
+
+local compilerNameTemplate = {
+   system = {
+      en_US = "System %1, %2",
+      pt_BR = "%1 sistema, %2",
+      zh_CN = "系统 %1，%2",
+      zh_TW = "系統 %1，%2",
+   },
+   multilib = {
+      en_US = "Multilib %1, %2",
+      pt_BR = "%1 multilib, %2",
+      zh_CN = "Multilib %1，%2",
+      zh_TW = "Multilib %1，%2",
+   },
+   cross = {
+      en_US = "Cross %1 %3, %2",
+      pt_BR = "%1 cruzado %3, %2",
+      zh_CN = "交叉编译 %1 %3，%2",
+      zh_TW = "交叉編譯 %1 %3，%2",
+   },
+   mingw = {
+      en_US = "MinGW %1 %3, %2",
+      pt_BR = "MinGW %1 %3, %2",
+      zh_CN = "MinGW %1 %3，%2",
+      zh_TW = "MinGW %1 %3，%2",
+   },
+}
+
+
+
+
+
+
+
+local profileNameMap = {
+   release = {
+      en_US = "release",
+      pt_BR = "lançamento",
+      zh_CN = "发布",
+      zh_TW = "發佈",
+   },
+   debug = {
+      en_US = "debug",
+      pt_BR = "depuração",
+      zh_CN = "调试",
+      zh_TW = "偵錯",
+   },
+   debugWithAsan = {
+      en_US = "debug with ASan",
+      pt_BR = "depuração com ASan",
+      zh_CN = "ASan 调试",
+      zh_TW = "ASan 偵錯",
+   },
+}
+
+local function nameGenerator(lang, name, kind, profile, arch)
+   local template = compilerNameTemplate[kind][lang] or compilerNameTemplate[kind].en_US
+   local profileName = profileNameMap[profile][lang] or profileNameMap[profile].en_US
+   return C_Util.format(template, name, profileName, arch)
+end
+
+local function mergeCompilerSet(compilerSet, other)
+   local c = compilerSet
+   local o = other
+   for k, v in pairs(o) do
+      c[k] = v
+   end
+end
+
+
+
+
+
+
+
+
+local function generateConfig(
+   lang, name, kind,
+   cCompiler, cxxCompiler,
+   config)
+
+   local commonOptions = {
+      cCompiler = cCompiler,
+      cxxCompiler = cxxCompiler,
+      debugger = "/usr/bin/gdb",
+      debugServer = "/usr/bin/gdbserver",
+      make = "/usr/bin/make",
+      compilerType = name:sub(1, 5) == "Clang" and "Clang" or "GCC_UTF8",
+      preprocessingSuffix = ".i",
+      compilationProperSuffix = ".s",
+      assemblingSuffix = ".o",
+      executableSuffix = kind == "mingw" and ".exe" or "",
+      compilationStage = 3,
+      ccCmdOptUsePipe = "on",
+      ccCmdOptWarningAll = "on",
+      ccCmdOptWarningExtra = "on",
+      ccCmdOptCheckIsoConformance = "on",
+      binDirs = { "/usr/bin" },
+   }
+   if kind == "multilib" then
+      commonOptions.ccCmdOptPointerSize = "32"
+   end
+   if kind == "mingw" then
+      commonOptions.resourceCompiler = "/usr/bin/" .. config.triplet .. "-windres"
+   end
+   if config.customCompileParams then
+      commonOptions.customCompileParams = config.customCompileParams
+   end
+   if config.customLinkParams then
+      commonOptions.customLinkParams = config.customLinkParams
+   end
+   local release = {
+      name = nameGenerator(lang, name, kind, "release", config.arch),
+      staticLink = true,
+      linkCmdOptStripExe = "on",
+      ccCmdOptOptimize = "2",
+   }
+   local debug_ = {
+      name = nameGenerator(lang, name, kind, "debug", config.arch),
+      ccCmdOptDebugInfo = "on",
+   }
+   local debugWithAsan = {
+      name = nameGenerator(lang, name, kind, "debugWithAsan", config.arch),
+      ccCmdOptDebugInfo = "on",
+      ccCmdOptAddressSanitizer = "address",
+   }
+   mergeCompilerSet(release, commonOptions)
+   mergeCompilerSet(debug_, commonOptions)
+   mergeCompilerSet(debugWithAsan, commonOptions)
+   return release, debug_, debugWithAsan
+end
+
+function main()
+   local arch = C_System.osArch()
+   local lang = C_Desktop.language()
+
+   local compilerList = {}
+
+   do
+      local release, debug_, debugWithAsan = generateConfig(
+      lang, "GCC", "system", "/usr/bin/gcc", "/usr/bin/g++",
+      {})
+
+      table.insert(compilerList, release)
+      table.insert(compilerList, debug_)
+      table.insert(compilerList, debugWithAsan)
+   end
+
+   local versionedGccs = C_FileSystem.matchFiles("/usr/bin", "^gcc-[0-9]+$")
+   for _, gcc in ipairs(versionedGccs) do
+      local version = gcc:sub(5)
+      local name = "GCC " .. version
+      local release, debug_, debugWithAsan = generateConfig(
+      lang, name, "system", "/usr/bin/" .. gcc, "/usr/bin/g++-" .. version,
+      {})
+
+      table.insert(compilerList, release)
+      table.insert(compilerList, debug_)
+      table.insert(compilerList, debugWithAsan)
+   end
+
+   if C_FileSystem.isExecutable("/usr/bin/clang") then
+      local release, debug_, debugWithAsan = generateConfig(
+      lang, "Clang", "system", "/usr/bin/clang", "/usr/bin/clang++",
+      {})
+
+      table.insert(compilerList, release)
+      table.insert(compilerList, debug_)
+      table.insert(compilerList, debugWithAsan)
+   end
+
+
+   if arch == "x86_64" and C_FileSystem.isExecutable("/usr/lib32/libstdc++.so") then
+      do
+         local release, debug_, debugWithAsan = generateConfig(
+         lang, "GCC", "multilib", "/usr/bin/gcc", "/usr/bin/g++",
+         {})
+
+         table.insert(compilerList, release)
+         table.insert(compilerList, debug_)
+         table.insert(compilerList, debugWithAsan)
+      end
+
+      if C_FileSystem.isExecutable("/usr/bin/clang") then
+         local release, debug_, debugWithAsan = generateConfig(
+         lang, "Clang", "multilib", "/usr/bin/clang", "/usr/bin/clang++",
+         {})
+
+         table.insert(compilerList, release)
+         table.insert(compilerList, debug_)
+         table.insert(compilerList, debugWithAsan)
+      end
+   end
+
+
+   if (
+      arch == "x86_64" and
+      C_FileSystem.exists("/proc/sys/fs/binfmt_misc/qemu-aarch64") and
+      C_FileSystem.isExecutable("/usr/bin/aarch64-linux-gnu-gcc")) then
+
+      local release, _, _ = generateConfig(
+      lang, "GCC", "cross",
+      "/usr/bin/aarch64-linux-gnu-gcc", "/usr/bin/aarch64-linux-gnu-g++",
+      { arch = "aarch64" })
+
+      table.insert(compilerList, release)
+   end
+
+
+   if (
+      arch == "x86_64" and (
+      C_FileSystem.exists("/proc/sys/fs/binfmt_misc/DOSWin") or
+      C_FileSystem.exists("/proc/sys/fs/binfmt_misc/WSLInterop"))) then
+
+
+      if C_FileSystem.isExecutable("/usr/bin/x86_64-w64-mingw32-gcc") then
+         do
+            local release, _, _ = generateConfig(
+            lang, "GCC", "mingw",
+            "/usr/bin/x86_64-w64-mingw32-gcc", "/usr/bin/x86_64-w64-mingw32-g++",
+            {
+               arch = "x86_64",
+               triplet = "x86_64-w64-mingw32",
+               customLinkParams = {},
+            })
+
+            table.insert(compilerList, release)
+         end
+
+
+         if C_FileSystem.isExecutable("/usr/bin/clang") then
+            local release, _, _ = generateConfig(
+            lang, "Clang", "mingw", "/usr/bin/clang", "/usr/bin/clang++",
+            {
+               arch = "x86_64",
+               triplet = "x86_64-w64-mingw32",
+               customCompileParams = { "-target", "x86_64-w64-mingw32" },
+               customLinkParams = {
+                  "-target", "x86_64-w64-mingw32",
+                  "-lstdc++", "-lwinpthread",
+               },
+            })
+
+            table.insert(compilerList, release)
+         end
+      end
+
+      if C_FileSystem.isExecutable("/usr/bin/i686-w64-mingw32-gcc") then
+         do
+            local release, _, _ = generateConfig(
+            lang, "GCC", "mingw",
+            "/usr/bin/i686-w64-mingw32-gcc", "/usr/bin/i686-w64-mingw32-g++",
+            {
+               arch = "i686",
+               triplet = "i686-w64-mingw32",
+               customLinkParams = {},
+            })
+
+            table.insert(compilerList, release)
+         end
+
+
+         if C_FileSystem.isExecutable("/usr/bin/clang") then
+            local release, _, _ = generateConfig(
+            lang, "Clang", "mingw",
+            "/usr/bin/clang", "/usr/bin/clang++",
+            {
+               arch = "i686",
+               triplet = "i686-w64-mingw32",
+               customCompileParams = { "-target", "i686-w64-mingw32" },
+               customLinkParams = {
+                  "-target", "i686-w64-mingw32",
+                  "-lstdc++", "-lwinpthread",
+               },
+            })
+
+            table.insert(compilerList, release)
+         end
+      end
+   end
+
+   local result = {
+      compilerList = compilerList,
+      noSearch = {
+         "/usr/bin",
+         "/opt/cuda/bin",
+         "/usr/lib/ccache/bin",
+      },
+      preferCompiler = 3,
+   }
+
+   return result
+
+end

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,6 +40,15 @@ option("libexecdir")
     end
     add_defines('LIBEXECDIR="$(libexecdir)"')
 
+option("glibc-hwcaps")
+    if is_os("linux") then
+        set_showmenu(true)
+    else
+        set_showmenu(false)
+    end
+    set_default(false)
+    add_defines('ENABLE_GLIBC_HWCAPS')
+
 -- feature flags
 
 option("lua-addon")


### PR DESCRIPTION
When building for glibc-hwcaps, the target `RedPandaIDE` is built as a share object `libRedPandaIDE.so`, with `main` renamed to `RedPandaIDE_main`. A thunk executable `RedPandaIDE` is introduced:

```c
int main(int argc, char *argv[])
{
    return RedPandaIDE_main(argc, argv);
}
```

After the normal build process, the shared object `libRedPandaIDE.so` is built 3 more times, with `-march=x86-64-v2`, `-march=x86-64-v3`, `-march=x86-64-v4`, respectively, and installed to `$prefix/lib/x86-64-{v2,v3,v4}`.

```
usr
+- bin
|  +- RedPandaIDE
+- lib
   +- libRedPandaIDE.so
   +- glibc-hwcaps
      +- x86-64-v2
      |  +- libRedPandaIDE.so
      +- x86-64-v3
      |  +- libRedPandaIDE.so
      +- x86-64-v4
         +- libRedPandaIDE.so
```

When executing `RedPandaIDE`, the glibc dynamic linker is asked to load `libRedPandaIDE.so`, and it will search `glibc-hwcaps` subdirectories, loading the optimal one for current CPU.