### PR TITLE
repair some problems in qt6

### DIFF
--- a/RedPandaIDE/settingsdialog/editorcolorschemewidget.cpp
+++ b/RedPandaIDE/settingsdialog/editorcolorschemewidget.cpp
@@ -142,41 +142,41 @@ PColorScheme EditorColorSchemeWidget::getCurrentScheme()
 
 void EditorColorSchemeWidget::connectModificationSlots()
 {
-    connect(ui->cbBackground,&QCheckBox::stateChanged,
+    connect(ui->cbBackground,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onBackgroundChanged);
     connect(ui->colorBackground,&ColorEdit::colorChanged,
             this, &EditorColorSchemeWidget::onBackgroundChanged);
-    connect(ui->cbForeground,&QCheckBox::stateChanged,
+    connect(ui->cbForeground,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onForegroundChanged);
     connect(ui->colorForeground,&ColorEdit::colorChanged,
             this, &EditorColorSchemeWidget::onForegroundChanged);
-    connect(ui->cbBold,&QCheckBox::stateChanged,
+    connect(ui->cbBold,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    connect(ui->cbItalic,&QCheckBox::stateChanged,
+    connect(ui->cbItalic,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    connect(ui->cbStrikeout,&QCheckBox::stateChanged,
+    connect(ui->cbStrikeout,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    connect(ui->cbUnderlined,&QCheckBox::stateChanged,
+    connect(ui->cbUnderlined,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
 }
 
 void EditorColorSchemeWidget::disconnectModificationSlots()
 {
-    disconnect(ui->cbBackground,&QCheckBox::stateChanged,
+    disconnect(ui->cbBackground,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onBackgroundChanged);
     disconnect(ui->colorBackground,&ColorEdit::colorChanged,
             this, &EditorColorSchemeWidget::onBackgroundChanged);
-    disconnect(ui->cbForeground,&QCheckBox::stateChanged,
+    disconnect(ui->cbForeground,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onForegroundChanged);
     disconnect(ui->colorForeground,&ColorEdit::colorChanged,
             this, &EditorColorSchemeWidget::onForegroundChanged);
-    disconnect(ui->cbBold,&QCheckBox::stateChanged,
+    disconnect(ui->cbBold,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    disconnect(ui->cbItalic,&QCheckBox::stateChanged,
+    disconnect(ui->cbItalic,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    disconnect(ui->cbStrikeout,&QCheckBox::stateChanged,
+    disconnect(ui->cbStrikeout,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
-    disconnect(ui->cbUnderlined,&QCheckBox::stateChanged,
+    disconnect(ui->cbUnderlined,STATE_CHANGED_SIGNAL,
             this, &EditorColorSchemeWidget::onFontStyleChanged);
 }
 

--- a/RedPandaIDE/settingsdialog/editorcolorschemewidget.h
+++ b/RedPandaIDE/settingsdialog/editorcolorschemewidget.h
@@ -23,6 +23,13 @@
 #include <QMenu>
 #include <QStandardItemModel>
 #include <QStyledItemDelegate>
+#include <QCheckBox>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#define STATE_CHANGED_SIGNAL &QCheckBox::checkStateChanged
+#else
+#define STATE_CHANGED_SIGNAL &QCheckBox::stateChanged
+#endif
 
 namespace Ui {
 class EditorColorSchemeWidget;

--- a/libs/qsynedit/qsynedit/qsynedit.h
+++ b/libs/qsynedit/qsynedit/qsynedit.h
@@ -24,6 +24,7 @@
 #include <QStringList>
 #include <QTimer>
 #include <QWidget>
+#include <QElapsedTimer>
 #include "gutter.h"
 #include "codefolding.h"
 #include "types.h"


### PR DESCRIPTION
1. 我这里使用了宏来处理Qt5和Qt6的接口兼容性
2. 加入#include <QElapsedTimer>是因为部分情况下编译器无法正确找到QElapsedTimer