### PR TITLE
Simplify UCRT packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Build
         run: |
-          ./packages/msys/build-mingw.sh --ucrt x64 --ucrt x86
-          ./packages/msys/build-mingw.sh --mingw --ucrt x64 --ucrt x86
+          ./packages/msys/build-mingw.sh --ucrt
+          ./packages/msys/build-mingw.sh --mingw --ucrt
 
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/BUILD.md
+++ b/BUILD.md
@@ -76,7 +76,7 @@ Extra arguments for `build-mingw.sh`:
 - `--mingw`: alias for `--mingw64` (x64 app).
 - `--gcc-linux-x86-64`: add `assets/gcc-linux-x86-64.7z` and `assets/alpine-minirootfs-x86_64.tar` to the package.
 - `--gcc-linux-aarch64`: add `assets/gcc-linux-aarch64.7z` and `assets/alpine-minirootfs-aarch64.tar` to the package.
-- `--ucrt <build>`: include UCRT installer (VC_redist) in the package. `<arch>` can be x86 or x64. This option can be specified multiple times.
+- `--ucrt`: include UCRT installer (VC_redist) in the package.
 
 ## Windows NT 5.x Qt Library with MinGW Lite Toolchain
 

--- a/BUILD_cn.md
+++ b/BUILD_cn.md
@@ -76,7 +76,7 @@
 - `--mingw`：`--mingw64`（x64 程序）的别名。
 - `--gcc-linux-x86-64`：把 `assets/gcc-linux-x86-64.7z` 和 `assets/alpine-minirootfs-x86_64.tar` 添加到包中。
 - `--gcc-linux-aarch64`：把 `assets/gcc-linux-aarch64.7z` 和 `assets/alpine-minirootfs-aarch64.tar` 添加到包中。
-- `--ucrt <arch>`：把 UCRT 安装程序添加到包中。`<arch>` 可选 `x86` 或 `x64`。此选项可以添加多次。
+- `--ucrt`：把 UCRT 安装程序添加到包中。
 
 ## 用于 Windows NT 5.x 的 Qt 库 + MinGW Lite 工具链
 

--- a/BUILD_ru.md
+++ b/BUILD_ru.md
@@ -79,7 +79,7 @@ Red Panda C++ должна работать с любым 64-битным наб
 - `--mingw`: псевдоним для  `--mingw64` (x64-приложение).
 - `--gcc-linux-x86-64`: добавить `assets/gcc-linux-x86-64.7z` и `assets/alpine-minirootfs-x86_64.tar` в пакет.
 - `--gcc-linux-aarch64`: добавить `assets/gcc-linux-aarch64.7z` и `assets/alpine-minirootfs-aarch64.tar` в пакет.
-- `--ucrt <build>`: include UCRT installer (VC_redist) in the package. `<arch>` can be x86 or x64. This option can be specified multiple times.
+- `--ucrt`: include UCRT installer (VC_redist) in the package.
 
 ## Windows NT 5.x с библиотекой Qt с набором инструментов MinGW Lite
 

--- a/packages/msys/build-mingw.sh
+++ b/packages/msys/build-mingw.sh
@@ -18,9 +18,7 @@ function fn_print_help() {
    --mingw64                Build mingw64 integrated compiler.
    --gcc-linux-x86-64       Build x86_64-linux-gnu integrated compiler.
    --gcc-linux-aarch64      Build aarch64-linux-gnu integrated compiler.
-   --ucrt <arch>            Include UCRT installer (VC_redist) in the package.
-                            <arch> can be x86 or x64.
-                            This option can be specified multiple times.
+   --ucrt                   Include UCRT installer (VC_redist) in the package.
    -nd, --no-deps           Skip dependency check.
    -t, --target-dir <dir>   Set target directory for the packages."
 }
@@ -82,8 +80,7 @@ COMPILER_GCC_LINUX_AARCH64=0
 REQUIRED_WINDOWS_BUILD=7600
 REQUIRED_WINDOWS_NAME="Windows 7"
 TARGET_DIR="$(pwd)/dist"
-UCRT_X86=0
-UCRT_X64=0
+UCRT=0
 while [[ $# -gt 0 ]]; do
   case $1 in
     -h|--help)
@@ -153,24 +150,8 @@ while [[ $# -gt 0 ]]; do
       esac
       ;;
     --ucrt)
-      case "$2" in
-        x86)
-          UCRT_X86=1
-          shift 2
-          ;;
-        x64)
-          UCRT_X64=1
-          shift 2
-          ;;
-        arm64)
-          echo "UCRT is always a system component on arm64."
-          exit 1
-          ;;
-        *)
-          echo "Invalid UCRT architecture: $2"
-          exit 1
-          ;;
-      esac
+      UCRT=1
+      shift
       ;;
     -nd|--no-deps)
       CHECK_DEPS=0
@@ -196,9 +177,8 @@ SOURCE_DIR="$(pwd)"
 ASSETS_DIR="${SOURCE_DIR}/assets"
 
 # Visual C++ Redistributable for Visual Studio 2019, version 16.7 (14.27)
-# This is the last version that supports all Windows versions (on which UCRT is supported).
-UCRT_X86_URL="https://download.visualstudio.microsoft.com/download/pr/c168313d-1754-40d4-8928-18632c2e2a71/D305BAA965C9CD1B44EBCD53635EE9ECC6D85B54210E2764C8836F4E9DEFA345/VC_redist.x86.exe"
-UCRT_X64_URL="https://download.visualstudio.microsoft.com/download/pr/722d59e4-0671-477e-b9b1-b8da7d4bd60b/591CBE3A269AFBCC025681B968A29CD191DF3C6204712CBDC9BA1CB632BA6068/VC_redist.x64.exe"
+# This is the last version that supports Windows XP.
+UCRT_URL="https://download.visualstudio.microsoft.com/download/pr/c168313d-1754-40d4-8928-18632c2e2a71/D305BAA965C9CD1B44EBCD53635EE9ECC6D85B54210E2764C8836F4E9DEFA345/VC_redist.x86.exe"
 
 case "${MSYSTEM}" in
   MINGW32)
@@ -285,14 +265,9 @@ if [[ ${COMPILER_GCC_LINUX_AARCH64} -eq 1 ]]; then
   fi
 fi
 
-if [[ ${UCRT_X86} -eq 1 ]] ; then
+if [[ ${UCRT} -eq 1 ]] ; then
   if [[ ! -f "${SOURCE_DIR}/assets/VC_redist.x86.exe" ]]; then
-    curl -L -o "${SOURCE_DIR}/assets/VC_redist.x86.exe" "${UCRT_X86_URL}"
-  fi
-fi
-if [[ ${UCRT_X64} -eq 1 ]] ; then
-  if [[ ! -f "${SOURCE_DIR}/assets/VC_redist.x64.exe" ]]; then
-    curl -L -o "${SOURCE_DIR}/assets/VC_redist.x64.exe" "${UCRT_X64_URL}"
+    curl -L -o "${SOURCE_DIR}/assets/VC_redist.x86.exe" "${UCRT_URL}"
   fi
 fi
 
@@ -402,13 +377,9 @@ if [[ ${COMPILER_GCC_LINUX_AARCH64} -eq 1 ]]; then
     cp "${SOURCE_DIR}/assets/${ALPINE_AARCH64_ARCHIVE}" alpine-minirootfs.tar
   fi
 fi
-if [[ ${UCRT_X86} -eq 1 ]]; then
-  nsis_flags+=(-DHAVE_UCRT_X86)
+if [[ ${UCRT} -eq 1 ]]; then
+  nsis_flags+=(-DHAVE_UCRT)
   cp "${SOURCE_DIR}/assets/VC_redist.x86.exe" VC_redist.x86.exe
-fi
-if [[ ${UCRT_X64} -eq 1 ]]; then
-  nsis_flags+=(-DHAVE_UCRT_X64)
-  cp "${SOURCE_DIR}/assets/VC_redist.x64.exe" VC_redist.x64.exe
 fi
 "${NSIS}" "${nsis_flags[@]}" redpanda.nsi
 

--- a/platform/windows/installer-scripts/redpanda.nsi
+++ b/platform/windows/installer-scripts/redpanda.nsi
@@ -134,19 +134,11 @@ Section "$(SectionMainName)" SectionMain
   !endif
 
   # UCRT installers are for target platform. host switches does not apply.
-  # to avoid too many switches, we just install all versions (if applicable).
-  !ifdef HAVE_UCRT_X86
+  # to avoid too many switches, we just install it.
+  !ifdef HAVE_UCRT
     File "VC_redist.x86.exe"
     ${IfNot} ${AtLeastWin10}
       ExecWait '"$INSTDIR\VC_redist.x86.exe" /quiet /norestart'
-    ${EndIf}
-  !endif
-  !ifdef HAVE_UCRT_X64
-    File "VC_redist.x64.exe"
-    ${IfNot} ${AtLeastWin10}
-      ${IfNot} $osArch == "x86"
-        ExecWait '"$INSTDIR\VC_redist.x64.exe" /quiet /norestart'
-      ${EndIf}
     ${EndIf}
   !endif
 


### PR DESCRIPTION
On NT 6.x, the VC_redist installer deploys the UCRT via the MSU package (KB2999226). The MSU package used is always in native architecture. This means that even VC_redist.x86.exe installs both x86 and x64 versions of UCRT on x64 editions of Windows -- making VC_redist.x64.exe unnecessary for NT 6.x platforms.

The only exception is Windows Server 2003 x64, where VC_redist.x86.exe does not install the x64 UCRT. I think it's definitely okay to ignore such an OS, which was killed by Microsoft not after 2010 (Office 2010 doesn't support it).