### PR TITLE
Fix: The icon displays incorrectly in the Help → About dialog box.

### DIFF
--- a/RedPandaIDE/src/widgets/aboutdialog.ui
+++ b/RedPandaIDE/src/widgets/aboutdialog.ui
@@ -13,6 +13,11 @@
   <property name="windowTitle">
    <string>About</string>
   </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>:/icons/images/devcpp.ico</normaloff>:/icons/images/devcpp.ico
+   </iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="lblTitle">


### PR DESCRIPTION
Fix: The icon displays incorrectly in the Help → About dialog box.
修正：帮助→关于弹出的关于窗口的图标错误的问题

fix
修正后
<img width="329" height="292" alt="correct" src="https://github.com/user-attachments/assets/128a7f5d-39d3-4e8f-87d0-67fea030f893" />
incorrect
错误
<img width="329" height="292" alt="incorrect" src="https://github.com/user-attachments/assets/15f8623c-897f-4803-bb59-72a65e4599fc" />
