### PR TITLE
Make filesystem layout configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,34 @@ set(CMAKE_AUTOUIC ON)
 
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(MACOS 1)
+endif()
+
 option(FORCE_QT5 "Force Qt 5 when building with system Qt" OFF)
 option(LUA_ADDON "Enable Lua add-ons" OFF)
 option(SDCC "Enable SDCC compiler support" ON)
 option(VCS "Enable Git integration" OFF)
 option(WINDOWS_PREFER_OPENCONSOLE "Prefer OpenConsole.exe as terminal emulator" OFF)
 
-set(LIBEXECDIR libexec CACHE STRING "Directory for auxiliary executables, RELATIVE TO prefix.")
+if (WIN32)
+    set(FILESYSTEM_LAYOUT_DEFAULT flat)
+    set(PORTABLE_CONFIG_DEFAULT registry)
+elseif (MACOS)
+    set(FILESYSTEM_LAYOUT_DEFAULT bundle)
+    set(PORTABLE_CONFIG_DEFAULT non)
+else()
+    set(FILESYSTEM_LAYOUT_DEFAULT hierarchy)
+    set(PORTABLE_CONFIG_DEFAULT non)
+endif()
+
 set(APP_NAME RedPandaCPP CACHE STRING "Subdirectory name to $prefix/share and $prefix/libexec.")
+set(FILESYSTEM_LAYOUT ${FILESYSTEM_LAYOUT_DEFAULT} CACHE STRING "Use 'hierarchy', 'flat', or 'bundle' filesystem layout.")
+set(LIBEXECDIR libexec CACHE STRING "Directory for auxiliary executables, RELATIVE TO prefix.")
 set(OVERRIDE_MALLOC "" CACHE STRING "Override malloc implementation, e.g. mimalloc")
+set(PORTABLE_CONFIG ${PORTABLE_CONFIG_DEFAULT} CACHE STRING
+    # avoid "yes" "no", they may be treated as boolean values
+    "Use portable configuration directory. 'oui' (for yes), 'non' (for no), or 'registry'.")
 
 set(QT_COMPONENTS
     Core
@@ -37,6 +56,10 @@ set(QT_COMPONENTS
     Test
     Widgets
     Xml)
+
+if (MACOS)
+    list(APPEND QT_COMPONENTS GuiPrivate)
+endif()
 
 if (FORCE_QT5)
     set(QT_VERSION_MAJOR 5)
@@ -255,25 +278,44 @@ if (XDG)
         DESTINATION share/${APP_NAME}
         FILES_MATCHING PATTERN "*")
 elseif(WIN32)
-    install(
-        DIRECTORY platform/windows/templates/
-        DESTINATION templates
-        FILES_MATCHING PATTERN "*")
-    install(
-        DIRECTORY platform/windows/templates-win64/
-        DESTINATION templates
-        FILES_MATCHING PATTERN "*")
+    if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
+        install(
+            DIRECTORY platform/windows/templates/
+            DESTINATION share/${APP_NAME}/templates
+            FILES_MATCHING PATTERN "*")
+        install(
+            DIRECTORY platform/windows/templates-win64/
+            DESTINATION share/${APP_NAME}/templates
+            FILES_MATCHING PATTERN "*")
+    elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
+        install(
+            DIRECTORY platform/windows/templates/
+            DESTINATION templates
+            FILES_MATCHING PATTERN "*")
+        install(
+            DIRECTORY platform/windows/templates-win64/
+            DESTINATION templates
+            FILES_MATCHING PATTERN "*")
+    else()
+        message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
+    endif()
 endif()
 
 # docs
-if (XDG)
+if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
     install(
         FILES README.md NEWS.md LICENSE
         DESTINATION share/doc/${APP_NAME})
-else()
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
     install(
         FILES README.md NEWS.md LICENSE
         DESTINATION .)
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "bundle")
+    install(
+        FILES README.md NEWS.md LICENSE
+        DESTINATION RedPandaIDE.app/Contents/Resources/doc)
+else()
+    message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
 endif()
 
 # icon
@@ -302,14 +344,26 @@ endif()
 
 # qt.conf
 if(WIN32)
-    install(
-        FILES platform/windows/qt.conf
-        DESTINATION .)
+    if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
+        # skip, bindir is shared
+    elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
+        install(
+            FILES platform/windows/qt.conf
+            DESTINATION .)
+    else()
+        message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
+    endif()
 endif()
 
 # devcpp.ico
 if(WIN32)
-    install(
-        FILES RedPandaIDE/images/devcpp.ico
-        DESTINATION .)
+    if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
+        # TODO: where to put it?
+    elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
+        install(
+            FILES RedPandaIDE/images/devcpp.ico
+            DESTINATION .)
+    else()
+        message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
+    endif()
 endif()

--- a/RedPandaIDE/CMakeLists.txt
+++ b/RedPandaIDE/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 # RedPandaIDE #
 
-add_executable(RedPandaIDE WIN32 MACOSX_BUNDLE)
+add_executable(RedPandaIDE WIN32)
 
 target_qt_plain_cpp(RedPandaIDE
     src/autolinkmanager
@@ -378,6 +378,18 @@ if(MACOS)
     target_link_libraries(RedPandaIDE PRIVATE Qt::GuiPrivate)
 endif()
 
+if(${FILESYSTEM_LAYOUT} STREQUAL "bundle")
+    set_target_properties(RedPandaIDE PROPERTIES
+        MACOSX_BUNDLE ON)
+    set(MACOSX_BUNDLE_ICON_FILE RedPandaIDE.icns)
+    set_source_files_properties(
+        ${CMAKE_SOURCE_DIR}/platform/macos/RedPandaIDE.icns
+        PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources)
+    target_sources(RedPandaIDE PRIVATE
+        ${CMAKE_SOURCE_DIR}/platform/macos/RedPandaIDE.icns)
+endif()
+
 if(LINUX AND QT_FEATURE_static)
     qt_import_plugins(RedPandaIDE
         INCLUDE
@@ -386,16 +398,38 @@ if(LINUX AND QT_FEATURE_static)
             Qt::QIbusPlatformInputContextPlugin)
 endif()
 
-if(XDG)
+if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
     install(
         TARGETS RedPandaIDE
         DESTINATION ${CMAKE_INSTALL_BINDIR})
-else()
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
     install(
         TARGETS RedPandaIDE
-        BUNDLE DESTINATION .
-        RUNTIME DESTINATION .)
+        DESTINATION .)
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "bundle")
+    install(
+        TARGETS RedPandaIDE
+        BUNDLE DESTINATION .)
+else()
+    message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
 endif()
+
+#########
+# Paths #
+#########
+
+set (MAIN_PROGRAM_PATH_DEFS
+    FILESYSTEM_LAYOUT=FILESYSTEM_LAYOUT_${FILESYSTEM_LAYOUT}
+    FILESYSTEM_LAYOUT_hierarchy=1
+    FILESYSTEM_LAYOUT_flat=2
+    FILESYSTEM_LAYOUT_bundle=2
+    PORTABLE_CONFIG=PORTABLE_CONFIG_${PORTABLE_CONFIG}
+    PORTABLE_CONFIG_oui=1
+    PORTABLE_CONFIG_non=2
+    PORTABLE_CONFIG_registry=3)
+
+target_compile_definitions(RedPandaIDE PRIVATE ${MAIN_PROGRAM_PATH_DEFS})
+target_compile_definitions(test-editor PRIVATE ${MAIN_PROGRAM_PATH_DEFS})
 
 ###################
 # Feature options #

--- a/RedPandaIDE/resources/terminal-windows.json
+++ b/RedPandaIDE/resources/terminal-windows.json
@@ -1,11 +1,11 @@
 [
     {
         "group": "Bundled",
-        "comment": "Use `%*APP_DIR*%` in path for application directory.",
+        "comment": "Use `%*APP_DIR*%` in path for application directory; `%*APP_LIBEXEC_DIR*%` for application libexec directory.",
         "terminals": [
             {
                 "name": "UTF-8 compatible Console Host",
-                "path": "OpenConsole.exe",
+                "path": "%*APP_LIBEXEC_DIR*%/OpenConsole.exe",
                 "argsPattern": "$term -- $argv"
             }
         ]

--- a/RedPandaIDE/src/main.cpp
+++ b/RedPandaIDE/src/main.cpp
@@ -182,7 +182,7 @@ bool BlockWheelEventFiler::eventFilter(QObject *watched, QEvent *event)
 QString getSettingFilename(const QString& filepath, bool& firstRun) {
     QString filename;
     if (filepath.isEmpty()) {
-        if (isGreenEdition()) {
+        if (usePortableConfigPath()) {
             filename = includeTrailingPathDelimiter(QApplication::applicationDirPath()) +
                     "config/"  + APP_SETTSINGS_FILENAME;
         } else {
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
     QTranslator trans,transQt,transUtils;
     bool firstRun;
     QString settingFilename = getSettingFilename(QString(), firstRun);
-    if (!isGreenEdition()) {
+    if (!usePortableConfigPath()) {
         QStringList documentLocations = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
         QDir::setCurrent(documentLocations.first());
     }

--- a/RedPandaIDE/src/settings/compilersetsettings.cpp
+++ b/RedPandaIDE/src/settings/compilersetsettings.cpp
@@ -1793,14 +1793,14 @@ void CompilerSets::findSets()
     QStringList pathList = path.split(PATH_SEPARATOR);
 #ifdef Q_OS_WIN
     pathList = QStringList{
-        mDirSettings->appDir() + "/clang64/bin",
-        mDirSettings->appDir() + "/mingw64/bin",
-        mDirSettings->appDir() + "/mingw32/bin",
+        mDirSettings->appLibexecDir() + "/clang64/bin",
+        mDirSettings->appLibexecDir() + "/mingw64/bin",
+        mDirSettings->appLibexecDir() + "/mingw32/bin",
 
         // cross toolchain targeting Linux
         // directory names follow dynamic linker (ld-linux-x86-64.so -> gcc-linux-x86-64)
-        mDirSettings->appDir() + "/gcc-linux-x86-64/bin",
-        mDirSettings->appDir() + "/gcc-linux-aarch64/bin",
+        mDirSettings->appLibexecDir() + "/gcc-linux-x86-64/bin",
+        mDirSettings->appLibexecDir() + "/gcc-linux-aarch64/bin",
     } + pathList;
 #endif
     QString folder, canonicalFolder;
@@ -2000,41 +2000,31 @@ PCompilerSet CompilerSets::getSet(int index)
 }
 
 void CompilerSets::savePath(const QString& name, const QString& path) {
-    if (!isGreenEdition()) {
-        mPersistor->saveValue(name, path);
-        return;
-    }
-
     QString s;
-    QString prefix1 = excludeTrailingPathDelimiter(mDirSettings->appDir()) + "/";
-    QString prefix2 = excludeTrailingPathDelimiter(mDirSettings->appDir()) + QDir::separator();
+    QString prefix1 = excludeTrailingPathDelimiter(mDirSettings->appLibexecDir()) + "/";
+    QString prefix2 = excludeTrailingPathDelimiter(mDirSettings->appLibexecDir()) + QDir::separator();
     if (path.startsWith(prefix1, PATH_SENSITIVITY)) {
-        s = "%AppPath%/"+ path.mid(prefix1.length());
+        s = "%*APP_LIBEXEC_DIR*%/" + path.mid(prefix1.length());
     } else if (path.startsWith(prefix2, PATH_SENSITIVITY)) {
-        s = "%AppPath%/"+ path.mid(prefix2.length());
+        s = "%*APP_LIBEXEC_DIR*%/" + path.mid(prefix2.length());
     } else {
-        s= path;
+        s = path;
     }
     mPersistor->saveValue(name,s);
 }
 
 void CompilerSets::savePathList(const QString& name, const QStringList& pathList) {
-    if (!isGreenEdition()) {
-        mPersistor->saveValue(name, pathList);
-        return;
-    }
-
     QStringList sl;
     for (const QString& path: pathList) {
         QString s;
-        QString prefix1 = excludeTrailingPathDelimiter(mDirSettings->appDir()) + "/";
-        QString prefix2 = excludeTrailingPathDelimiter(mDirSettings->appDir()) + QDir::separator();
+        QString prefix1 = excludeTrailingPathDelimiter(mDirSettings->appLibexecDir()) + "/";
+        QString prefix2 = excludeTrailingPathDelimiter(mDirSettings->appLibexecDir()) + QDir::separator();
         if (path.startsWith(prefix1, PATH_SENSITIVITY)) {
-            s = "%AppPath%/"+ path.mid(prefix1.length());
+            s = "%*APP_LIBEXEC_DIR*%/" + path.mid(prefix1.length());
         } else if (path.startsWith(prefix2, PATH_SENSITIVITY)) {
-            s = "%AppPath%/" + path.mid(prefix2.length());
+            s = "%*APP_LIBEXEC_DIR*%/" + path.mid(prefix2.length());
         } else {
-            s= path;
+            s = path;
         }
         sl.append(s);
     }

--- a/RedPandaIDE/src/settings/dirsettings.cpp
+++ b/RedPandaIDE/src/settings/dirsettings.cpp
@@ -31,34 +31,48 @@ DirSettings::DirSettings(SettingsPersistor *persistor):
 
 QString DirSettings::appDir()
 {
+#if defined(Q_OS_MACOS) && (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_hierarchy)
+    // Qt on macOS does not resolve symlink,
+    // while brew installs the package to celler and creates symlink.
+    static QString cachedAppDir;
+    if (cachedAppDir.isEmpty()) {
+        const QString appFile = QCoreApplication::applicationFilePath();
+        const QString realAppFile = QFileInfo(appFile).canonicalFilePath();
+        cachedAppDir = QFileInfo(realAppFile).path();
+    }
+    return cachedAppDir;
+#else
     return QApplication::instance()->applicationDirPath();
+#endif
 }
 
 QString DirSettings::appResourceDir()
 {
-#ifdef Q_OS_WIN
-    return appDir();
-#elif defined(Q_OS_MACOS)
-//    return QApplication::instance()->applicationDirPath();
-    return "";
-#else // XDG desktop
-    // in AppImage or tarball PREFIX is not true, resolve from relative path
-    const static QString absoluteResourceDir(QDir(appDir()).absoluteFilePath("../share/" APP_NAME));
-    return absoluteResourceDir;
-#endif
+    if constexpr (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_hierarchy) {
+        const static QString absoluteResourceDir{QDir{appDir()}.absoluteFilePath("../share/" APP_NAME)};
+        return absoluteResourceDir;
+    } else if constexpr (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_flat) {
+        return appDir();
+    } else if constexpr (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_bundle) {
+        const static QString absoluteResourceDir{QDir{appDir()}.absoluteFilePath("../Resources/")};
+        return absoluteResourceDir;
+    } else {
+        __builtin_unreachable();
+    }
 }
 
 
 QString DirSettings::appLibexecDir()
 {
-#ifdef Q_OS_WIN
-    return appDir();
-#elif defined(Q_OS_MACOS)
-    return QApplication::instance()->applicationDirPath();
-#else // XDG desktop
-    const static QString libExecDir(QDir(appDir()).absoluteFilePath("../" LIBEXECDIR "/" APP_NAME));
-    return libExecDir;
-#endif
+    if constexpr (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_hierarchy) {
+        const static QString absoluteResourceDir{QDir{appDir()}.absoluteFilePath("../" LIBEXECDIR "/" APP_NAME)};
+        return absoluteResourceDir;
+    } else if constexpr (FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_flat ||
+                         FILESYSTEM_LAYOUT == FILESYSTEM_LAYOUT_bundle) {
+        return appDir();
+    } else {
+        __builtin_unreachable();
+    }
 }
 
 QString DirSettings::projectDir() const
@@ -119,7 +133,7 @@ void DirSettings::doSave()
 void DirSettings::doLoad()
 {
     QString defaultProjectDir;
-    if (isGreenEdition()) {
+    if (usePortableConfigPath()) {
         defaultProjectDir = getFilePath(appDir(), "projects");
     } else {
         QStringList docLocations = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);

--- a/RedPandaIDE/src/settings/environmentsettings.cpp
+++ b/RedPandaIDE/src/settings/environmentsettings.cpp
@@ -71,8 +71,8 @@ void EnvironmentSettings::doLoad()
 
     // check saved terminal path
     mTerminalPath = stringValue("terminal_path", "");
-    // replace libexec dir for forward compatibility
     mTerminalPath = replacePrefix(mTerminalPath, "%*APP_LIBEXEC_DIR*%", mDirSettings->appLibexecDir());
+    // replace app dir for backward compatibility
     mTerminalPath = replacePrefix(mTerminalPath, "%*APP_DIR*%", mDirSettings->appDir());
     mTerminalArgumentsPattern = stringValue("terminal_arguments_pattern", "");
 
@@ -87,7 +87,6 @@ void EnvironmentSettings::doLoad()
         QString path = env.value("PATH");
         QStringList pathList = path.split(PATH_SEPARATOR);
         pathList = QStringList{
-            mDirSettings->appDir(),
             mDirSettings->appLibexecDir(),
         } + pathList;
 
@@ -99,7 +98,10 @@ void EnvironmentSettings::doLoad()
                 break;
             }
         }
-        mAStylePath = replacePrefix(mAStylePath, mDirSettings->appDir() , "%*APP_DIR*%");
+    } else {
+        mAStylePath = replacePrefix(mAStylePath, "%*APP_LIBEXEC_DIR*%", mDirSettings->appLibexecDir());
+        // replace app dir for backward compatibility
+        mAStylePath = replacePrefix(mAStylePath, "%*APP_DIR*%", mDirSettings->appDir());
     }
 
     mHideNonSupportFilesInFileView=boolValue("hide_non_support_files_file_view",true);
@@ -171,18 +173,12 @@ QString EnvironmentSettings::AStylePath() const
     QString path = mAStylePath;
     if (path.isEmpty())
         path = getFilePath(mDirSettings->appLibexecDir(),ASTYLE_PROGRAM);
-    else {
-        // replace libexec dir for forward compatibility
-        path = replacePrefix(path, "%*APP_LIBEXEC_DIR*%", mDirSettings->appLibexecDir());
-        path = replacePrefix(path, "%*APP_DIR*%", mDirSettings->appDir());
-    }
     return path;
 }
 
 void EnvironmentSettings::setAStylePath(const QString &aStylePath)
 {
     mAStylePath = aStylePath;
-    mAStylePath = replacePrefix(mAStylePath, mDirSettings->appDir() , "%*APP_DIR*%");
 }
 
 QString EnvironmentSettings::terminalArgumentsPattern() const
@@ -263,6 +259,7 @@ void EnvironmentSettings::checkAndSetTerminal()
     QList<TerminalItem> terminalList = loadTerminalList();
     for (const TerminalItem& termItem:terminalList) {
         QString term=termItem.terminal;
+        term = replacePrefix(term, "%*APP_LIBEXEC_DIR*%", mDirSettings->appLibexecDir());
         term = replacePrefix(term, "%*APP_DIR*%", mDirSettings->appDir());
         QFileInfo info{term};
         QString absoluteTerminalPath;
@@ -331,6 +328,7 @@ QList<EnvironmentSettings::TerminalItem> EnvironmentSettings::loadTerminalList()
             QString termExecutable = QFileInfo(path).fileName();
             QString pattern = terminal["argsPattern"].toString();
             EnvironmentSettings::TerminalItem terminalItem;
+            path = replacePrefix(path, "%*APP_LIBEXEC_DIR*%", mDirSettings->appDir());
             path = replacePrefix(path, "%*APP_DIR*%", mDirSettings->appDir());
             terminalItem.terminal = path;
             terminalItem.param = pattern;
@@ -372,6 +370,9 @@ bool EnvironmentSettings::isTerminalValid()
 
 void EnvironmentSettings::doSave()
 {
+    QString terminalPath = replacePrefix(mTerminalPath, mDirSettings->appLibexecDir(), "%*APP_LIBEXEC_DIR*%/");
+    QString astylePath = replacePrefix(mAStylePath, mDirSettings->appLibexecDir(), "%*APP_LIBEXEC_DIR*%/");
+
     //Appearance
     saveValue("theme", mTheme);
     saveValue("interface_font", mInterfaceFont);
@@ -385,21 +386,13 @@ void EnvironmentSettings::doSave()
 
     saveValue("current_folder",mCurrentFolder);
     saveValue("default_open_folder",mDefaultOpenFolder);
-    QString terminalPath = mTerminalPath;
-    if (isGreenEdition())
-    {
-        // APP_DIR trick for windows portable app
-        // For non-portable app (other platform or Windows installer), multiple instances
-        // share the same configuration and thus the trick may break terminal path
-        terminalPath = replacePrefix(terminalPath, mDirSettings->appDir(), "%*APP_DIR*%");
-    }
 
     saveValue("terminal_path",terminalPath);
     saveValue("terminal_arguments_pattern",mTerminalArgumentsPattern);
 #ifdef Q_OS_WINDOWS
     saveValue("use_custom_terminal",mUseCustomTerminal);
 #endif
-    saveValue("astyle_path",mAStylePath);
+    saveValue("astyle_path",astylePath);
 
     saveValue("hide_non_support_files_file_view",mHideNonSupportFilesInFileView);
     saveValue("open_files_in_single_instance",mOpenFilesInSingleInstance);

--- a/RedPandaIDE/src/utils/os.cpp
+++ b/RedPandaIDE/src/utils/os.cpp
@@ -16,6 +16,7 @@
  */
 #include "os.h"
 #include "pe.h"
+#include "../utils.h"
 #include <qt_utils/utils.h>
 #include <QApplication>
 #include <QDomDocument>
@@ -59,6 +60,19 @@ bool isGreenEdition()
         gIsGreenEditionInited = true;
     }
     return gIsGreenEdition;
+}
+
+bool usePortableConfigPath()
+{
+    if constexpr (PORTABLE_CONFIG == PORTABLE_CONFIG_oui) {
+        return true;
+    } else if constexpr (PORTABLE_CONFIG == PORTABLE_CONFIG_non) {
+        return false;
+    } else if constexpr (PORTABLE_CONFIG == PORTABLE_CONFIG_registry) {
+        return isGreenEdition();
+    } else {
+        __builtin_unreachable();
+    }
 }
 #endif
 

--- a/RedPandaIDE/src/utils/os.h
+++ b/RedPandaIDE/src/utils/os.h
@@ -23,8 +23,9 @@
 
 #ifdef Q_OS_WIN
 bool isGreenEdition();
+bool usePortableConfigPath();
 #else
-constexpr bool isGreenEdition() { return false; }
+constexpr bool usePortableConfigPath() { return PORTABLE_CONFIG == PORTABLE_CONFIG_oui; }
 #endif
 
 #ifdef Q_OS_WIN

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -55,8 +55,17 @@ target("RedPandaIDE")
 
     -- defines
 
-    add_options("app-name", "prefix", "libexecdir", "glibc-hwcaps")
-    add_options("lua-addon", "sdcc", "vcs")
+    add_options(
+        "app-name",
+        "filesystem-layout",
+        "libexecdir",
+        "portable-config",
+        "prefix")
+    add_options(
+        "glibc-hwcaps",
+        "lua-addon",
+        "sdcc",
+        "vcs")
 
     add_defines("ARCH_X86_64=1")
     add_defines("ARCH_X86=1")
@@ -295,9 +304,15 @@ target("RedPandaIDE")
         add_links("dbghelp", "psapi", "shlwapi")
     end
 
+    -- install
+
+    set_install_bin()
+
 target("test-makefile-escape")
     set_kind("binary")
     add_rules("qt.console")
+
+    set_default(false)
 
     add_tests("default")
 

--- a/tools/consolepauser/CMakeLists.txt
+++ b/tools/consolepauser/CMakeLists.txt
@@ -16,12 +16,18 @@ if(UNIX)
     target_sources(consolepauser PRIVATE main.unix.cpp)
 endif()
 
-if(XDG)
+if(${FILESYSTEM_LAYOUT} STREQUAL "hierarchy")
     install(
         TARGETS consolepauser
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${APP_NAME})
-else()
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "flat")
     install(
         TARGETS consolepauser
         DESTINATION .)
+elseif(${FILESYSTEM_LAYOUT} STREQUAL "bundle")
+    install(
+        TARGETS consolepauser
+        DESTINATION RedPandaIDE.app/Contents/MacOS)
+else()
+    message(FATAL_ERROR "Unknown FILESYSTEM_LAYOUT: ${FILESYSTEM_LAYOUT}")
 endif()

--- a/tools/consolepauser/xmake.lua
+++ b/tools/consolepauser/xmake.lua
@@ -18,6 +18,4 @@ target("consolepauser")
         add_syslinks("rt")
     end
 
-    if is_xdg() then
-        on_install(install_libexec)
-    end
+    set_install_libexec()

--- a/tools/redpanda-git-askpass/xmake.lua
+++ b/tools/redpanda-git-askpass/xmake.lua
@@ -4,6 +4,4 @@ target("redpanda-git-askpass")
     add_files("main.cpp")
     add_ui_classes("dialog")
 
-    if is_xdg() then
-        on_install(install_libexec)
-    end
+    set_install_libexec()

--- a/tools/redpanda-win-git-askpass/xmake.lua
+++ b/tools/redpanda-win-git-askpass/xmake.lua
@@ -8,3 +8,5 @@ target("redpanda-win-git-askpass")
         "resource.rc")
 
     add_links("user32")
+
+    set_install_libexec()

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,10 +12,50 @@ if is_os("windows") then
     add_defines("_WIN32_WINNT=0x0501")
 end
 
+-- paths
+
 option("app-name")
     set_default("RedPandaCPP")
     set_showmenu(true)
     add_defines("APP_NAME=\"$(app-name)\"")
+
+option("filesystem-layout")
+    if is_os("windows") then
+        set_default("flat")
+        set_values("hierarchy", "flat")
+    else
+        set_default("hierarchy")
+        set_values("hierarchy")
+    end
+    set_showmenu(true)
+
+    add_defines(
+        "FILESYSTEM_LAYOUT=FILESYSTEM_LAYOUT_$(filesystem-layout)",
+        "FILESYSTEM_LAYOUT_hierarchy=1",
+        "FILESYSTEM_LAYOUT_flat=2",
+        "FILESYSTEM_LAYOUT_bundle=3")
+
+option("libexecdir")
+    set_default("libexec")
+    set_showmenu(true)
+    add_defines('LIBEXECDIR="$(libexecdir)"')
+
+option("portable-config")
+    if is_os("windows") then
+        set_default("registry")
+        -- avoid "yes" "no", they may be treated as boolean values
+        set_values("oui", "non", "registry")
+    else
+        set_default("non")
+        set_values("non")
+    end
+    set_showmenu(true)
+
+    add_defines(
+        "PORTABLE_CONFIG=PORTABLE_CONFIG_$(portable-config)",
+        "PORTABLE_CONFIG_oui=1",
+        "PORTABLE_CONFIG_non=2",
+        "PORTABLE_CONFIG_registry=3")
 
 option("prefix")
     if is_xdg() then
@@ -26,15 +66,7 @@ option("prefix")
         set_default("")
     end
 
-option("libexecdir")
-    if is_xdg() then
-        set_default("libexec")
-        set_showmenu(true)
-    else
-        set_default("")
-        set_showmenu(false)
-    end
-    add_defines('LIBEXECDIR="$(libexecdir)"')
+-- feature flags
 
 option("glibc-hwcaps")
     if is_os("linux") then
@@ -44,8 +76,6 @@ option("glibc-hwcaps")
     end
     set_default(false)
     add_defines('ENABLE_GLIBC_HWCAPS')
-
--- feature flags
 
 option("lua-addon")
     set_default(true)
@@ -182,10 +212,26 @@ function add_ui_classes(...)
     end
 end
 
-function install_libexec(target)
-    local installdir = target:installdir() .. "/$(libexecdir)/$(app-name)"
-    print("installing", target:name(), "to", installdir, "..")
-    os.cp(target:targetfile(), installdir .. "/" .. target:filename())
+function set_install_bin()
+    local fs_layout = get_config("filesystem-layout")
+    if fs_layout == "hierarchy" then
+        set_prefixdir("/", {bindir = "bin"})
+    elseif fs_layout == "flat" then
+        set_prefixdir("/", {bindir = "/"})
+    elseif fs_layout ~= nil then
+        trap_unreachable()
+    end
+end
+
+function set_install_libexec()
+    local fs_layout = get_config("filesystem-layout")
+    if fs_layout == "hierarchy" then
+        set_prefixdir("/", {bindir = "$(libexecdir)/$(app-name)"})
+    elseif fs_layout == "flat" then
+        set_prefixdir("/", {bindir = "/"})
+    elseif fs_layout ~= nil then
+        trap_unreachable()
+    end
 end
 
 includes("RedPandaIDE")
@@ -211,16 +257,25 @@ target("resources")
     if is_xdg() then
         add_installfiles("platform/linux/templates/(**.*)", {prefixdir = "share/$(app-name)/templates"})
     elseif is_os("windows") then
-        add_installfiles("platform/windows/templates/(**.*)", {prefixdir = "bin/templates"})
-        add_installfiles("platform/windows/templates-win64/(**.*)", {prefixdir = "bin/templates"})
+        if get_config("filesystem-layout") == "hierarchy" then
+            add_installfiles("platform/windows/templates/(**.*)", {prefixdir = "share/$(app-name)/templates"})
+            add_installfiles("platform/windows/templates-win64/(**.*)", {prefixdir = "share/$(app-name)/templates"})
+        elseif get_config("filesystem-layout") == "flat" then
+            add_installfiles("platform/windows/templates/(**.*)", {prefixdir = "templates"})
+            add_installfiles("platform/windows/templates-win64/(**.*)", {prefixdir = "templates"})
+        elseif get_config("filesystem-layout") ~= nil then
+            trap_unreachable()
+        end
     end
 
     -- docs
 
-    if is_xdg() then
+    if get_config("filesystem-layout") == "hierarchy" then
         add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "share/doc/$(app-name)"})
-    else
-        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = "bin"})
+    elseif get_config("filesystem-layout") == "flat" then
+        add_installfiles("README.md", "NEWS.md", "LICENSE", {prefixdir = ""})
+    elseif get_config("filesystem-layout") ~= nil then
+        trap_unreachable()
     end
 
     -- icon
@@ -249,5 +304,11 @@ target("resources")
     -- qt.conf
 
     if is_os("windows") then
-        add_installfiles("platform/windows/qt.conf", {prefixdir = "bin"})
+        if get_config("filesystem-layout") == "hierarchy" then
+            -- skip, bindir is shared
+        elseif get_config("filesystem-layout") == "flat" then
+            add_installfiles("platform/windows/qt.conf", {prefixdir = ""})
+        elseif get_config("filesystem-layout") ~= nil then
+            trap_unreachable()
+        end
     end


### PR DESCRIPTION
Paths for config, aux executables, resources is now determined by config options “use hierarchy, flat, or bundle filesystem layout” and “whether to use portable config”, instead of OS.