### PR TITLE
Fix crash

### DIFF
--- a/RedPandaIDE/src/main.cpp
+++ b/RedPandaIDE/src/main.cpp
@@ -257,6 +257,9 @@ int main(int argc, char *argv[])
 #endif
 
     QApplication app(argc, argv);
+#if QT_VERSION_MAJOR >= 6
+    app.setAttribute(Qt::AA_DontUseNativeDialogs);
+#endif
 #if QT_VERSION_MAJOR < 6
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif

--- a/libs/qsynedit/qsynedit/formatter/cppformatter.cpp
+++ b/libs/qsynedit/qsynedit/formatter/cppformatter.cpp
@@ -222,7 +222,7 @@ namespace QSynedit {
                 if (pSyntaxer->getToken() == "(") {
                     posList.push_back(pSyntaxer->getTokenPos());
                 } else if (pSyntaxer->getToken() == ")") {
-                    posList.pop_back();
+                    if(!posList.empty())posList.pop_back();
                 }
             }
             pSyntaxer->next();


### PR DESCRIPTION
### commit 1: fix: cppformatter: prevent crash on unmatched closing parenthesis in pasted code

crash data:
```
1
4
)()(
)()(
```

### commit 2:fix: Switch to native dialog to avoid KIO socket leak on crash in KDE Plasma 6 & Qt 6

In KDE Plasma 6 with Qt 6, when using native file dialogs,
an unexpected program crash or abnormal exit may leave the
KIO process's socket connection uncleaned.

```
kf.kio.core: ConnectionServer::listenForRemote failed: "QLocalServer::listen：未知错误 17"
kf.kio.core: KIO Connection server not listening, could not connect
kf.kio.core: couldn't create worker: "无法创建用于为协议“tags”启动 KIO 工作程序的套接字。"
```