### PR TITLE
chore(debian): relax compiler and debugger dependencies for better co…

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -12,7 +12,7 @@ Homepage: https://github.com/royqh1979/RedPanda-CPP
 Package: redpanda-cpp
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         gcc, g++, make, gdb, gdbserver, astyle
+         gcc | c-compiler, g++ | c++-compiler, make, gdb | lldb, gdbserver | lldb, astyle
 Recommends: qterminal | konsole | gnome-terminal | terminator | lxterminal | mate-terminal | terminology | xfce4-terminal | alacritty | cool-retro-term | kitty | sakura | termit | tilix
 Description: A lightweight but powerful C/C++ IDE
  Red Panda C++ (Old name Red Panda Dev-C++ 7) is a full featured C/C++ IDE.

--- a/packages/linux/control.in
+++ b/packages/linux/control.in
@@ -7,7 +7,7 @@ Package: redpanda-cpp-bin
 Version: __VERSION__
 Architecture: __ARCH__
 Architecture-Variant: __ARCH_VARIANT__
-Depends: gcc, g++, make, gdb, gdbserver
+Depends: gcc | c-compiler, g++ | c++-compiler, make, gdb | lldb, gdbserver | lldb
 Recommends: qterminal | konsole | gnome-terminal | terminator | lxterminal | mate-terminal | terminology | xfce4-terminal | alacritty | cool-retro-term | kitty | sakura | termit | tilix
 Suggests: clang
 Description: A lightweight but powerful C/C++ IDE, built upon static Qt


### PR DESCRIPTION
…mpatibility

- Replace strict `gcc` and `g++` dependencies with `gcc | c-compiler` and `g++ | c++-compiler` to support environments with specific compiler versions (e.g., `g++-14`) or pure Clang setups.
- Add `lldb` as a valid alternative to `gdb` and `gdbserver` to accommodate LLVM-based toolchains without forcing GNU debuggers.

This makes the package installation more robust across different user environments while keeping the GNU toolchain as the default for new users.