### PR TITLE
fix: resolve short namespace names in using directives (#633)

### DIFF
--- a/RedPandaIDE/src/parser/cppparser.cpp
+++ b/RedPandaIDE/src/parser/cppparser.cpp
@@ -4190,6 +4190,18 @@ void CppParser::handleUsing(int maxIndex)
         if (!mNamespaces.contains(fullName)) {
             fullName = usingName;
         }
+        // For short namespace names (no "::"), try to resolve through
+        // existing using directives. E.g. "using namespace chrono;" after
+        // "using namespace std;" should resolve chrono → std::chrono.
+        if (!mNamespaces.contains(fullName) && !usingName.contains("::")) {
+            foreach (const QString& ns, scopeStatement->usingList) {
+                PStatement foundNs = findStatementInNamespace(usingName, ns);
+                if (foundNs && foundNs->kind == StatementKind::Namespace) {
+                    fullName = foundNs->fullName;
+                    break;
+                }
+            }
+        }
         if (mNamespaces.contains(fullName)) {
             scopeStatement->usingList.insert(fullName);
         }
@@ -4199,6 +4211,16 @@ void CppParser::handleUsing(int maxIndex)
             return;
         if (mNamespaces.contains(usingName)) {
             fileInfo->addUsing(usingName);
+        } else if (!usingName.contains("::")) {
+            // Resolve short name through file-level usings
+            const QSet<QString>& fileUsings = fileInfo->usings();
+            foreach (const QString& ns, fileUsings) {
+                PStatement foundNs = findStatementInNamespace(usingName, ns);
+                if (foundNs && foundNs->kind == StatementKind::Namespace) {
+                    fileInfo->addUsing(foundNs->fullName);
+                    break;
+                }
+            }
         }
     }
     //skip ;


### PR DESCRIPTION
## Summary

Fixes #633 — code completion fails for `std::chrono` symbols when using shorthand `using namespace` directives.

## Root Cause

When processing `using namespace chrono;` after `using namespace std;`, the parser could not resolve `chrono` to `std::chrono`. 

The lookup logic was:
```
mNamespaces.contains("chrono") → false
// mNamespaces key is "std::chrono", not "chrono"
→ using namespace chrono silently ignored
```

Per C++ standard name lookup rules, after `using namespace std;` is in effect, the name `chrono` should resolve to `std::chrono` — but the parser wasn't doing this two-step resolution.

## Fix

When a short namespace name (no `::`) fails direct lookup in `mNamespaces`, the parser now searches through the scope's existing `usingList` to resolve the name:

```
using namespace std;    → usingList = {"std"}
using namespace chrono; → "chrono" not in mNamespaces
                        → search usingList: find "chrono" inside "std"
                        → found std::chrono!
                        → usingList = {"std", "std::chrono"} ✓
```

Uses the existing `findStatementInNamespace()` function — no new search infrastructure needed.

**1 file changed**: `RedPandaIDE/src/parser/cppparser.cpp` (+22 lines)

## Performance

- Only triggered when a short name fails direct `mNamespaces` lookup
- Typical `usingList` size: 1-5 entries
- Each entry: one `findStatementInNamespace` call (O(1) hash lookup + direct child search)
- Total overhead: < 1 microsecond per `using namespace` directive

## Testing

- Build: ✅ MSVC 2026 + Qt 6.8.3 — zero errors, zero warnings
- test-cppparser: ✅ 11/11 passed
- test-editor: ✅ 53/53 passed

Fixes #633
