### PR TITLE
fix: file creation in subdirs (#615) and auto-update check (#704)

### DIFF
--- a/RedPandaIDE/CMakeLists.txt
+++ b/RedPandaIDE/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(RedPandaIDE WIN32)
 
 target_qt_plain_cpp(RedPandaIDE
     src/autolinkmanager
+    src/autoupdater
     src/colorscheme
     src/customfileiconprovider
     src/projectoptions

--- a/RedPandaIDE/src/autoupdater.cpp
+++ b/RedPandaIDE/src/autoupdater.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020-2026 Roy Qu (royqh1979@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "autoupdater.h"
+#include <QJsonDocument>
+#include <QJsonObject>
+
+static const QString GITHUB_API_URL =
+    QStringLiteral("https://api.github.com/repos/royqh1979/RedPanda-CPP/releases/latest");
+static const QString GITEE_API_URL =
+    QStringLiteral("https://gitee.com/api/v5/repos/royqh1979/RedPanda-CPP/releases/latest");
+
+static QString sCurrentVersion;
+
+void setAutoUpdaterCurrentVersion(const QString &version)
+{
+    sCurrentVersion = version;
+}
+
+AutoUpdater::AutoUpdater(QObject *parent)
+    : QObject(parent)
+    , mNetworkManager(new QNetworkAccessManager(this))
+{
+}
+
+void AutoUpdater::checkForUpdates(bool silent, UpdateCallback callback)
+{
+    if (!callback) return;
+
+    QNetworkRequest request(GITHUB_API_URL);
+    request.setTransferTimeout(8000);
+
+    QNetworkReply *reply = mNetworkManager->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, silent, callback]() {
+        doReply(reply, silent, callback);
+    });
+}
+
+void AutoUpdater::doReply(QNetworkReply *reply, bool silent, UpdateCallback callback)
+{
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        QNetworkRequest request(GITEE_API_URL);
+        request.setTransferTimeout(8000);
+        QNetworkReply *r2 = mNetworkManager->get(request);
+        connect(r2, &QNetworkReply::finished, this, [this, r2, silent, callback]() {
+            r2->deleteLater();
+            QString tag, url;
+            if (r2->error() == QNetworkReply::NoError) {
+                QJsonDocument doc = QJsonDocument::fromJson(r2->readAll());
+                tag = doc.object()["tag_name"].toString();
+                url = doc.object()["html_url"].toString();
+            }
+            if (isNewerThan(tag, sCurrentVersion))
+                callback(tag, url);
+            else if (!silent)
+                callback(QString(), QString());
+        });
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+    QString tag = doc.object()["tag_name"].toString();
+    QString url = doc.object()["html_url"].toString();
+
+    if (isNewerThan(tag, sCurrentVersion))
+        callback(tag, url);
+    else if (!silent)
+        callback(QString(), QString());
+}
+
+bool AutoUpdater::isNewerThan(const QString &latest, const QString &current)
+{
+    if (latest.isEmpty() || current.isEmpty()) return false;
+    QString lv = latest.startsWith('v', Qt::CaseInsensitive) ? latest.mid(1) : latest;
+    QVersionNumber lvn = QVersionNumber::fromString(lv);
+    QVersionNumber cvn = QVersionNumber::fromString(current);
+    if (!lvn.isNull() && !cvn.isNull()) return lvn > cvn;
+    return lv != current;
+}

--- a/RedPandaIDE/src/autoupdater.h
+++ b/RedPandaIDE/src/autoupdater.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020-2026 Roy Qu (royqh1979@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef AUTOUPDATER_H
+#define AUTOUPDATER_H
+
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QVersionNumber>
+#include <functional>
+
+using UpdateCallback = std::function<void(const QString &version, const QString &downloadUrl)>;
+
+class AutoUpdater : public QObject
+{
+public:
+    explicit AutoUpdater(QObject *parent = nullptr);
+
+    void checkForUpdates(bool silent, UpdateCallback callback);
+
+private:
+    void doReply(QNetworkReply *reply, bool silent, UpdateCallback callback);
+    static bool isNewerThan(const QString &latest, const QString &current);
+
+    QNetworkAccessManager *mNetworkManager;
+};
+
+extern void setAutoUpdaterCurrentVersion(const QString &version);
+
+#endif // AUTOUPDATER_H

--- a/RedPandaIDE/src/main.cpp
+++ b/RedPandaIDE/src/main.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "main.h"
+#include "autoupdater.h"
 #include "utils/os.h"
 
 #ifdef Q_OS_WIN
@@ -257,6 +258,7 @@ int main(int argc, char *argv[])
 #endif
 
     QApplication app(argc, argv);
+    setAutoUpdaterCurrentVersion(REDPANDA_CPP_VERSION);
 #if QT_VERSION_MAJOR >= 6
     app.setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif

--- a/RedPandaIDE/src/mainwindow.cpp
+++ b/RedPandaIDE/src/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <QMimeData>
 #include <QScreen>
 #include <QStyleFactory>
+#include <QTimer>
 #include <QTcpSocket>
 #include <QTemporaryFile>
 #include <QTextBlock>
@@ -90,6 +91,7 @@
 #include "vcs/gitremotedialog.h"
 #include "vcs/gituserconfigdialog.h"
 #endif
+#include "autoupdater.h"
 #include "widgets/infomessagebox.h"
 #include "widgets/newtemplatedialog.h"
 #include "visithistorymanager.h"
@@ -537,6 +539,24 @@ MainWindow::MainWindow(QWidget *parent)
     updateShortcuts();
     updateEditorSettings();
     //updateEditorBookmarks();
+
+    // Delayed auto-update check (runs 3 seconds after startup)
+    AutoUpdater *updater = new AutoUpdater(this);
+    QTimer::singleShot(3000, this, [this, updater]() {
+        updater->checkForUpdates(true, [this](const QString &version, const QString &url) {
+            if (version.isEmpty()) return;
+            QMessageBox msgBox(this);
+            msgBox.setIcon(QMessageBox::Information);
+            msgBox.setWindowTitle(tr("Update Available"));
+            msgBox.setText(tr("A new version of Red Panda C++ is available: %1").arg(version));
+            msgBox.setInformativeText(tr("Would you like to go to the download page?"));
+            QPushButton *downloadBtn = msgBox.addButton(tr("Download"), QMessageBox::AcceptRole);
+            msgBox.addButton(tr("Later"), QMessageBox::RejectRole);
+            msgBox.exec();
+            if (msgBox.clickedButton() == downloadBtn)
+                QDesktopServices::openUrl(QUrl(url));
+        });
+    });
 }
 
 MainWindow::~MainWindow()
@@ -4250,6 +4270,10 @@ void MainWindow::onFileEncodingContextMenu(const QPoint &pos)
 
 void MainWindow::onFilesViewContextMenu(const QPoint &pos)
 {
+    // Remember the clicked index so that create/rename actions use the
+    // correct target directory instead of falling back to root.
+    mFilesViewClickedIndex = ui->treeFiles->indexAt(pos);
+
     QMenu menu(this);
 #ifdef ENABLE_VCS
     GitManager vcsManager;
@@ -4703,19 +4727,21 @@ void MainWindow::onFilesViewCreateFolderFolderLoaded(const QString& path)
 
 void MainWindow::onFilesViewCreateFolder()
 {
-    QModelIndex index = ui->treeFiles->currentIndex();
+    // Prefer the index from the last context menu click, falling back
+    // to currentIndex() for keyboard-activated operations.
+    QModelIndex index = mFilesViewClickedIndex.isValid()
+        ? QModelIndex(mFilesViewClickedIndex)
+        : ui->treeFiles->currentIndex();
     QModelIndex parentIndex;
     QDir dir;
     if (index.isValid()
-            && ui->treeFiles->selectionModel()->isSelected(index)) {
-        if (mFileSystemModel->isDir(index)) {
-            dir = QDir(mFileSystemModel->fileInfo(index).absoluteFilePath());
-            parentIndex = index;
-        } else {
-            dir = mFileSystemModel->fileInfo(index).absoluteDir();
-            parentIndex = mFileSystemModel->index(dir.absolutePath());
-        }
-        //ui->treeFiles->expand(index);
+            && mFileSystemModel->fileInfo(index).isDir()) {
+        dir = QDir(mFileSystemModel->fileInfo(index).absoluteFilePath());
+        parentIndex = index;
+        ui->treeFiles->selectionModel()->select(index, QItemSelectionModel::Select);
+    } else if (index.isValid()) {
+        dir = mFileSystemModel->fileInfo(index).absoluteDir();
+        parentIndex = mFileSystemModel->index(dir.absolutePath());
     } else {
         dir = mFileSystemModel->rootDirectory();
         parentIndex=mFileSystemModel->index(dir.absolutePath());
@@ -4743,14 +4769,18 @@ void MainWindow::onFilesViewCreateFolder()
 
 void MainWindow::onFilesViewCreateFile()
 {
-    QModelIndex index = ui->treeFiles->currentIndex();
+    // Prefer the index from the last context menu click, falling back
+    // to currentIndex() for keyboard-activated operations.
+    QModelIndex index = mFilesViewClickedIndex.isValid()
+        ? QModelIndex(mFilesViewClickedIndex)
+        : ui->treeFiles->currentIndex();
     QDir dir;
     if (index.isValid()
-            && ui->treeFiles->selectionModel()->isSelected(index)) {
-        if (mFileSystemModel->isDir(index))
-            dir = QDir(mFileSystemModel->fileInfo(index).absoluteFilePath());
-        else
-            dir = mFileSystemModel->fileInfo(index).absoluteDir();
+            && mFileSystemModel->fileInfo(index).isDir()) {
+        dir = QDir(mFileSystemModel->fileInfo(index).absoluteFilePath());
+        ui->treeFiles->selectionModel()->select(index, QItemSelectionModel::Select);
+    } else if (index.isValid()) {
+        dir = mFileSystemModel->fileInfo(index).absoluteDir();
     } else {
         dir = mFileSystemModel->rootDirectory();
     }

--- a/RedPandaIDE/src/mainwindow.h
+++ b/RedPandaIDE/src/mainwindow.h
@@ -958,6 +958,7 @@ private:
     QString mClassBrowserCurrentStatement;
     QString mFilesViewNewCreatedFolder;
     QString mFilesViewNewCreatedFile;
+    QPersistentModelIndex mFilesViewClickedIndex;
 
     bool mCheckSyntaxInBack;
     bool mShouldRemoveAllSettings;

--- a/RedPandaIDE/xmake.lua
+++ b/RedPandaIDE/xmake.lua
@@ -74,6 +74,7 @@ target("RedPandaIDE")
 
     add_files(
         "src/autolinkmanager.cpp",
+        "src/autoupdater.cpp",
         "src/colorscheme.cpp",
         "src/customfileiconprovider.cpp",
         "src/projectoptions.cpp",


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Fix #615 — File creation path in subdirectories

When right-clicking a subdirectory in the file browser and selecting "New File" or "New Folder", the new item would appear in the root directory instead of the clicked subdirectory.

**Root cause**: `onFilesViewCreateFolder()` and `onFilesViewCreateFile()` used `ui->treeFiles->currentIndex()` which may not be updated on right-click. When the clicked item wasn't the current selection, the code fell back to `rootDirectory()`.

**Fix**: Capture `ui->treeFiles->indexAt(pos)` from the context menu event and use it as the preferred target directory. Falls back to `currentIndex()` for keyboard-triggered operations.

### 2. Implement #704 — Auto-update check

Added `AutoUpdater` class that checks for newer versions on startup:

- Queries GitHub Releases API (`api.github.com/repos/royqh1979/RedPanda-CPP/releases/latest`)
- Falls back to Gitee API if GitHub is unreachable
- Compares semantic versions using `QVersionNumber`
- Shows a notification dialog 3 seconds after startup if an update is available
- Silent mode: no popup when already on the latest version
- 8-second network timeout to avoid blocking

## Changes

| File | Change |
|------|--------|
| `autoupdater.h` (new) | AutoUpdater class declaration |
| `autoupdater.cpp` (new) | Implementation with GitHub/Gitee API fallback |
| `mainwindow.h/cpp` | Context menu index capture + AutoUpdater wiring |
| `main.cpp` | Pass version string to AutoUpdater |
| `CMakeLists.txt`, `xmake.lua` | Add new source file |

## Testing

- Build: ✅ MSVC 2026 + Qt 6.8.3 — zero errors, zero warnings
- test-cppparser: ✅ 11/11 passed
- test-editor: ✅ 53/53 passed

Fixes #615, fixes #704
