### PR TITLE
fix: add error dialog when file creation fails

### DIFF
--- a/RedPandaIDE/src/mainwindow.cpp
+++ b/RedPandaIDE/src/mainwindow.cpp
@@ -4766,7 +4766,10 @@ void MainWindow::onFilesViewCreateFile()
         fileName = QString("untitled%1").arg(count)+suffix;
     }
     QFile file(dir.filePath(fileName));
-    file.open(QFile::NewOnly);
+    if (!file.open(QFile::NewOnly)) {
+        QMessageBox::critical(this, tr("Create File"), tr("Failed to create file %1").arg(file.fileName()));
+        return;
+    }
     file.close();
     QModelIndex newIndex = mFileSystemModel->index(dir.filePath(fileName));
     connect(mFileSystemModel,&QFileSystemModel::directoryLoaded,


### PR DESCRIPTION
## Fix: add error dialog when file creation fails
### Problem
When creating a new file, the program may not be able to create the file due to insufficient permissions for that directory. The original code did not prompt any issues when it failed to create. 

### What was the patch do
This submission has added a message window to prompt the user that the file cannot be created.