### PR TITLE
fix: simplify the expression for judging AT&T

### DIFF
--- a/libs/qsynedit/qsynedit/syntaxer/gas.cpp
+++ b/libs/qsynedit/qsynedit/syntaxer/gas.cpp
@@ -106,8 +106,9 @@ bool GASSyntaxer::isCommentStartChar(QChar ch)
 
 void GASSyntaxer::procNull()
 {
-    if ( (mLineNumber == mThisLineHasSyntaxDirective)
-            && !mThisLineHasSyntaxDirective) {
+    // if ( (mLineNumber == mThisLineHasSyntaxDirective)
+    //         && !mThisLineHasSyntaxDirective) {
+    if (mLineNumber == 0 && !mThisLineHasSyntaxDirective) {
         mSyntaxMode = SyntaxMode::ATT;
         setPrefixRegisterNames(true);
         mDirectiveSyntaxLine = -1;


### PR DESCRIPTION
## Fix: simplify the expression for judging AT&T
### Problems
1. The original expression is too complex。
2. The original expression compares the int type with the boolean type.

### What did the PR patch
This submission simplifies the relevant expressions, ensuring semantic clarity while maintaining code quality.