### PR TITLE
fix: fix variable type error of 'oldValue'

### DIFF
--- a/libs/qsynedit/qsynedit/document.cpp
+++ b/libs/qsynedit/qsynedit/document.cpp
@@ -582,7 +582,7 @@ void Document::setTabSize(int newTabSize)
 
 void Document::setForceMonospace(bool newForceMonospace)
 {
-    int oldValue = forceMonospace();
+    bool oldValue = forceMonospace();    // (fix): forceMonospace() returns bool, not int
     mGlyphCalculator.setForceMonospace(newForceMonospace);
     if (oldValue != newForceMonospace)
         invalidateAllLineWidth();


### PR DESCRIPTION
## Fix: fix variable type error of 'oldValue'
### Problem
forceMonospace() returns bool not int.

### What did the PR patch
fix the problem