### PR TITLE
fix: replace non-POD global static with Q_GLOBAL_STATIC

### DIFF
--- a/RedPandaIDE/src/todoparser.cpp
+++ b/RedPandaIDE/src/todoparser.cpp
@@ -22,8 +22,12 @@
 
 #include <QRegularExpression>
 
+Q_GLOBAL_STATIC_WITH_ARGS(
+    QRegularExpression,
+    todoReg,
+    (QStringLiteral("\\b(todo|fixme)\\b"), QRegularExpression::CaseInsensitiveOption)
+)
 
-static QRegularExpression todoReg("\\b(todo|fixme)\\b", QRegularExpression::CaseInsensitiveOption);
 TodoParser::TodoParser(QObject *parent) : QObject(parent),
     mMutex()
 {


### PR DESCRIPTION
Use Q_GLOBAL_STATIC_WITH_ARGS to initialize the global QRegularExpression 'todoReg' (and the related QString).

The previous file-scope static Qt objects could be constructed before QCoreApplication, leading to undefined behavior or crashes. Q_GLOBAL_STATIC ensures thread-safe, lazy initialization that is safe for Qt.

This fixes the following clazy warnings:
  - non-POD static (QRegularExpression todoReg) [-Wclazy-non-pod-global-static]
  - non-POD static (QString todoReg) [-Wclazy-non-pod-global-static]