### PR TITLE
fix: empty pointer in editor manager

### DIFF
--- a/RedPandaIDE/src/editormanager.cpp
+++ b/RedPandaIDE/src/editormanager.cpp
@@ -181,14 +181,22 @@ QTabWidget* EditorManager::getFocusedPageControl() const {
     case LayoutShowType::lstRight:
         return mRightPageWidget;
     case LayoutShowType::lstBoth: {
-        Editor* rightEditor = dynamic_cast<Editor*>(mRightPageWidget->currentWidget());
-        if (!rightEditor)
+        if (!mRightPageWidget || !mLeftPageWidget)
+            return mLeftPageWidget ? mLeftPageWidget : mRightPageWidget;
+
+        QWidget *rw = mRightPageWidget->currentWidget();
+        Editor* rightEditor = rw ? dynamic_cast<Editor*>(rw) : nullptr;
+        if (!rightEditor) {
             return mLeftPageWidget;
+        }
         if (rightEditor->hasFocus())
             return mRightPageWidget;
-        Editor *leftEditor = dynamic_cast<Editor*>(mLeftPageWidget->currentWidget());
-        if (!leftEditor)
+
+        QWidget *lw = mLeftPageWidget->currentWidget();
+        Editor *leftEditor = lw ? dynamic_cast<Editor*>(lw) : nullptr;
+        if (!leftEditor) {
             return mRightPageWidget;
+        }
         if (leftEditor->hasFocus())
             return mLeftPageWidget;
         if (rightEditor->lastFocusOutTime() > leftEditor->lastFocusOutTime())


### PR DESCRIPTION
editormanager.cpp:877:5: Control jumps to 'case lstBoth:'  at line 886
editormanager.cpp:888:17: Calling 'EditorManager::getEditor'
editormanager.cpp:511:9: Assuming pointer value is null
editormanager.cpp:511:5: Taking true branch
editormanager.cpp:512:26: Calling 'EditorManager::getFocusedPageControl'
editormanager.cpp:178:5: Control jumps to 'case lstBoth:'  at line 183
editormanager.cpp:184:53: Called C++ object pointer is null
editormanager.cpp:877:5: Control jumps to 'case lstBoth:'  at line 886
editormanager.cpp:887:16: Calling 'EditorManager::getEditor'
editormanager.cpp:511:9: Assuming pointer value is null
editormanager.cpp:511:5: Taking true branch
editormanager.cpp:512:26: Calling 'EditorManager::getFocusedPageControl'
editormanager.cpp:178:5: Control jumps to 'case lstBoth:'  at line 183
editormanager.cpp:185:13: Assuming 'rightEditor' is non-null
editormanager.cpp:185:9: Taking false branch
editormanager.cpp:187:13: Assuming the condition is false
editormanager.cpp:187:9: Taking false branch
editormanager.cpp:189:52: Called C++ object pointer is null
editormanager.cpp:184:53: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
 1: Control jumps to 'case lstBoth:'  at line 886 in editormanager.cpp:877
 2: Calling 'EditorManager::getEditor' in editormanager.cpp:888
 3: Assuming pointer value is null in editormanager.cpp:511
 4: Taking true branch in editormanager.cpp:511
 5: Calling 'EditorManager::getFocusedPageControl' in editormanager.cpp:512
 6: Control jumps to 'case lstBoth:'  at line 183 in editormanager.cpp:178
 7: Called C++ object pointer is null in editormanager.cpp:184
editormanager.cpp:189:52: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
 1: Control jumps to 'case lstBoth:'  at line 886 in editormanager.cpp:877
 2: Calling 'EditorManager::getEditor' in editormanager.cpp:887
 3: Assuming pointer value is null in editormanager.cpp:511
 4: Taking true branch in editormanager.cpp:511
 5: Calling 'EditorManager::getFocusedPageControl' in editormanager.cpp:512
 6: Control jumps to 'case lstBoth:'  at line 183 in editormanager.cpp:178
 7: Assuming 'rightEditor' is non-null in editormanager.cpp:185
 8: Taking false branch in editormanager.cpp:185
 9: Assuming the condition is false in editormanager.cpp:187
10: Taking false branch in editormanager.cpp:187
11: Called C++ object pointer is null in editormanager.cpp:189
