### PR TITLE
Update C++ standard values

### DIFF
--- a/RedPandaIDE/src/compiler/compilerinfo.cpp
+++ b/RedPandaIDE/src/compiler/compilerinfo.cpp
@@ -108,14 +108,16 @@ void CompilerInfo::prepareCompilerOptions()
     sl.append(QPair<QString,QString>("ISO C++17","c++17"));
     sl.append(QPair<QString,QString>("ISO C++20","c++2a"));
     sl.append(QPair<QString,QString>("ISO C++23","c++2b"));
-    sl.append(QPair<QString,QString>("ISO C++26","c++2c"));
+    sl.append(QPair<QString,QString>("ISO C++26","c++26"));
+    sl.append(QPair<QString,QString>("ISO C++29","c++29"));
     sl.append(QPair<QString,QString>("GNU C++","gnu++98"));
     sl.append(QPair<QString,QString>("GNU C++11","gnu++11"));
     sl.append(QPair<QString,QString>("GNU C++14","gnu++14"));
     sl.append(QPair<QString,QString>("GNU C++17","gnu++17"));
     sl.append(QPair<QString,QString>("GNU C++20","gnu++2a"));
     sl.append(QPair<QString,QString>("GNU C++23","gnu++2b"));
-    sl.append(QPair<QString,QString>("GNU C++26","gnu++2c"));
+    sl.append(QPair<QString,QString>("GNU C++26","gnu++26"));
+    sl.append(QPair<QString,QString>("GNU C++29","gnu++29"));
     addOption(CC_CMD_OPT_STD, QObject::tr("C++ Language standard (-std)"), groupName, false, true, false, "-std=",CompilerOptionType::Choice, sl);
 
     sl.clear();


### PR DESCRIPTION
- Add "c++29": GCC 0c5c6249a2e9a75d2e7d1c6c434487c8dc077130
- A survey about previous standard values suggests "c++2c" is unnecessary -- it was added at the same time as "c++26".
  - GCC : commit 5388a43f6a3f348929292998bd6d0c1da6f006de (GCC has done this since "c++23" in commit 78739c2df788ee5c868d998a6333d453317d8711)
  - Clang: commit b763d6a4ed4650c74c6846d743156468563b0e31