### PR TITLE
enhancement: stop parsing when switching file

### DIFF
--- a/RedPandaIDE/src/mainwindow.cpp
+++ b/RedPandaIDE/src/mainwindow.cpp
@@ -8383,13 +8383,32 @@ void MainWindow::invalidateProjectProxyModel()
     mProjectProxyModel->invalidate();
 }
 
+static void stopParserForEditor(Editor *editor)
+{
+    if (editor && editor->parser()) {
+        editor->parser()->stopParsing();
+    }
+}
+
 void MainWindow::on_EditorTabsLeft_currentChanged(int)
 {
+    for (int i = 0; i < mEditorManager->pageCount(); ++i) {
+        stopParserForEditor((*mEditorManager)[i]);
+    }
+    if (mProject && mProject->cppParser()) {
+        mProject->cppParser()->stopParsing();
+    }
 }
 
 
 void MainWindow::on_EditorTabsRight_currentChanged(int)
 {
+    for (int i = 0; i < mEditorManager->pageCount(); ++i) {
+        stopParserForEditor((*mEditorManager)[i]);
+    }
+    if (mProject && mProject->cppParser()) {
+        mProject->cppParser()->stopParsing();
+    }
 }
 
 void MainWindow::on_tableTODO_doubleClicked(const QModelIndex &index)

--- a/RedPandaIDE/src/parser/cppparser.cpp
+++ b/RedPandaIDE/src/parser/cppparser.cpp
@@ -55,6 +55,7 @@ CppParser::CppParser() : QObject{nullptr},
     updateSerialId();
     mUniqId = 0;
     mParsing = false;
+    mStopParse = false;
     //mStatementList ; // owns the objects
     //mFilesToScan;
     //mIncludePaths;
@@ -1058,6 +1059,7 @@ bool CppParser::parseFile(const QString &fileName, bool inProject,
         if (mLockCount>0)
             return false;
         mParsing = true;
+        mStopParse = false; // clear any previous stop request
         updateSerialId();
         if (updateView)
             emit onBusy();
@@ -1087,6 +1089,11 @@ bool CppParser::parseFile(const QString &fileName, bool inProject,
             foreach (const QString& file,files) {
                 mFilesScannedCount++;
                 emit progress(file,mFilesToScanCount,mFilesScannedCount);
+                {
+                    QMutexLocker locker(&mMutex);
+                    if (mStopParse)
+                        return false;
+                }
                 if (!mPreprocessor.fileScanned(file)) {
                     internalParse(file);
                 }
@@ -1099,8 +1106,16 @@ bool CppParser::parseFile(const QString &fileName, bool inProject,
 
             mFilesScannedCount++;
             emit progress(fileName,mFilesToScanCount,mFilesScannedCount);
+            {
+                QMutexLocker locker(&mMutex);
+                if (mStopParse)
+                    return false;
+            }
             internalParse(contextFilename);
             if (!mPreprocessor.fileScanned(fileName)) {
+                QMutexLocker locker(&mMutex);
+                if (mStopParse)
+                    return false;
                 internalParse(fileName);
             }
         }
@@ -1118,6 +1133,7 @@ void CppParser::parseFileList(bool updateView)
             return;
         updateSerialId();
         mParsing = true;
+        mStopParse = false; // clear previous stop request
         if (updateView)
             emit onBusy();
         emit parseStarted();
@@ -1139,6 +1155,11 @@ void CppParser::parseFileList(bool updateView)
         foreach (const QString& file, files) {
             mFilesScannedCount++;
             emit progress(mCurrentFile,mFilesToScanCount,mFilesScannedCount);
+            {
+                QMutexLocker locker(&mMutex);
+                if (mStopParse)
+                    break;
+            }
             if (!mPreprocessor.fileScanned(file)) {
                 internalParse(file);
             }
@@ -1237,6 +1258,12 @@ void CppParser::unFreeze()
 {
     QMutexLocker locker(&mMutex);
     mLockCount--;
+}
+
+void CppParser::stopParsing()
+{
+    QMutexLocker locker(&mMutex);
+    mStopParse = true;
 }
 
 bool CppParser::fileScanned(const QString &fileName) const
@@ -3573,6 +3600,8 @@ void CppParser::handleAccessibilitySpecifiers(KeywordType keywordType, int maxIn
 
 bool CppParser::handleStatement(int maxIndex)
 {
+    if (mStopParse)
+        return false;
 //    int idx=getCurrentBlockEndSkip();
 //    int idx2=getCurrentBlockBeginSkip();
     int idx3=getCurrentInlineNamespaceEndSkip(maxIndex);
@@ -4598,6 +4627,11 @@ void CppParser::internalParse(const QString &fileName)
 
     //timer.restart();
     // Tokenize the preprocessed buffer file
+    {
+        QMutexLocker locker(&mMutex);
+        if (mStopParse)
+            return;
+    }
     mTokenizer.tokenize(preprocessResult);
     //reduce memory usage
     preprocessResult.clear();
@@ -4614,6 +4648,8 @@ void CppParser::internalParse(const QString &fileName)
     // Process the token list
     int endIndex = mTokenizer.tokenCount();
     while(true) {
+        if (mStopParse)
+            break;
         if (!handleStatement(endIndex))
             break;
     }

--- a/RedPandaIDE/src/parser/cppparser.h
+++ b/RedPandaIDE/src/parser/cppparser.h
@@ -124,6 +124,11 @@ public:
     bool isSystemHeaderFile(const QString& fileName) const;
     void parseHardDefines();
     bool parsing() const;
+    /**
+     * Request the parser to stop as soon as possible.
+     * Parser threads will check the internal flag and abort early when observed.
+     */
+    void stopParsing();
     void resetParser();
     void unFreeze(); // UnFree/UnLock (reparse while searching)
     bool fileScanned(const QString& fileName) const;


### PR DESCRIPTION
Stop parsing when switching files to improve file switching speed and reduce unnecessary calculations.