### PR TITLE
chore:Fix macOS bundle on Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist
 # Visual Studio Code
 .vscode
 .cache
+
+# macOS Things
+.DS_Store

--- a/packages/macos/build.sh
+++ b/packages/macos/build.sh
@@ -58,11 +58,13 @@ function fn_prepare_dirs() {
 }
 
 function fn_build() {
+  arch_info=$(uname -m)
+  echo "Building for $arch_info architecture..."
   cmake -S . -B "$_BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH="$_QT_DIR" \
     -DCMAKE_INSTALL_PREFIX="$_PKG_DIR" \
-    -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+    -DCMAKE_OSX_ARCHITECTURES="$arch_info"
 
   cmake --build "$_BUILD_DIR" --parallel $(sysctl -n hw.logicalcpu)
 }
@@ -72,6 +74,7 @@ function fn_package() {
 
   macdeployqt "$_PKG_DIR/RedPandaIDE.app"
   tar -C "$_PKG_DIR" -cJf dist/RedPandaIDE-$APP_VERSION.tar.xz RedPandaIDE.app
+  codesign --force --deep --sign "-" "$_PKG_DIR/RedPandaIDE.app"
 }
 
 fn_check_qt_install


### PR DESCRIPTION
此Pull Request更改了以下内容：

chore:修正在Apple Silicon平台上的构建

注：需要最后codesign是因为会出现EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))导致崩溃问题