### PR TITLE
Fix: Set window icon for progress dialog

### DIFF
--- a/RedPandaIDE/src/settings/compilersetsettings.cpp
+++ b/RedPandaIDE/src/settings/compilersetsettings.cpp
@@ -1887,6 +1887,7 @@ void CompilerSets::findSets(bool showProgress)
                 0,
                 1,
                 };
+    progressDlg.setWindowIcon(QIcon(":/icons/images/devcpp.ico"));
     if (showProgress) {
         progressDlg.setMinimumDuration(500);
         progressDlg.setWindowModality(Qt::WindowModal);


### PR DESCRIPTION
Fix the issue with the compiler window search icon.
修复搜寻编译器窗口图标问题 

Before fix
<img width="273" height="195" alt="Before" src="https://github.com/user-attachments/assets/fb888072-6a66-4e0c-b9fe-96edc1a1abbb" />

After fix
<img width="222" height="170" alt="After" src="https://github.com/user-attachments/assets/5ac457ad-067a-47cf-9177-c9bfe189b0c0" />

