### PR TITLE
Set application window icon for RedPandaIDE

### DIFF
--- a/RedPandaIDE/src/main.cpp
+++ b/RedPandaIDE/src/main.cpp
@@ -16,6 +16,7 @@
  */
 #include "main.h"
 #include "utils/os.h"
+#include <QIcon>
 
 #ifdef Q_OS_WIN
 static_assert(WM_APP_OPEN_FILE < 0xc000);
@@ -263,6 +264,7 @@ int main(int argc, char *argv[])
 #if QT_VERSION_MAJOR < 6
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+    app.setWindowIcon(QIcon(":/icons/images/devcpp.ico"));
     QDir startupDir = QDir::current();
     ExternalResource resource;
 


### PR DESCRIPTION
修复 Windows 下无父窗口对话框标题栏图标显示为默认占位图标的问题，通过在 main.cpp 设置 QApplication 全局图标统一修复。
Fix the issue where dialogs without a parent window show the default placeholder icon in the title bar on Windows, by setting the global QApplication icon in main.cpp.

修复前
Before Fix
<img width="250" height="146" alt="redpanda图标异常" src="https://github.com/user-attachments/assets/c41d9045-1ddf-450e-a599-5dc20bcf9006" />

修复后
After Fix
<img width="234" height="131" alt="redpanda图标异常修复后" src="https://github.com/user-attachments/assets/65cc6e47-8c0d-4e41-bc47-e677da1e5883" />


