### PR TITLE
Simplify ege.h link parameters

### DIFF
--- a/RedPandaIDE/resources/autolink.json
+++ b/RedPandaIDE/resources/autolink.json
@@ -25,14 +25,14 @@
     },
     {
         "header": "ege.h",
-        "links": "-lgraphics -luuid -lmsimg32 -lgdi32 -limm32 -lole32 -loleaut32 -lwinmm -lgdiplus"
+        "links": "-lgraphics -lgdi32 -lgdiplus"
     },
     {
         "header": "easyx.h",
         "links": "-leasyx"
     },    
     {
-		"execUseUTF8": true,
+        "execUseUTF8": true,
         "header": "fmt/core.h",
         "links": "-lfmt"
     },

--- a/platform/windows/templates/Graphics/info.template
+++ b/platform/windows/templates/Graphics/info.template
@@ -19,6 +19,4 @@ Cpp=CL_Graphics_cpp.txt
 UnitCount=1
 Type=0
 IsCpp=1
-linker=-lgraphics -luuid -lmsimg32 -lgdi32 -limm32 -lole32 -loleaut32 -lwinmm -lgdiplus_@@__@@_
-
-
+linker=-lgraphics -lgdi32 -lgdiplus


### PR DESCRIPTION
简化ege.h链接参数
24.04版大幅减少依赖，链接参数由9个缩减至3个，生成程序不变，提高编译效率

另提：ege近期在大改，使用master主分支风险较高，短期内如果发布正式版建议使用此分支：https://github.com/Ltabsyy/xege/tree/se

测试：个人程序均编译通过并正常运行，yixy音乐播放器编译通过并正常运行